### PR TITLE
perf(start): initialize built-in modules with snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ name = "rsvim"
 version = "0.1.1-alpha.6"
 dependencies = [
  "clap",
+ "once_cell",
  "parking_lot",
  "rsvim_core",
  "tokio",

--- a/rsvim_cli/Cargo.toml
+++ b/rsvim_cli/Cargo.toml
@@ -25,6 +25,7 @@ tracing-appender = { workspace = true, features = ["parking_lot"] }
 tokio = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive", "unicode"] }
 toml = { workspace = true }
+once_cell = { workspace = true, features = ["parking_lot"] }
 
 [build-dependencies]
 rsvim_core = { workspace = true }

--- a/rsvim_cli/src/bin/rsvim.rs
+++ b/rsvim_cli/src/bin/rsvim.rs
@@ -5,13 +5,20 @@
 use rsvim_core::cli::CliOpt;
 use rsvim_core::error::IoResult;
 use rsvim_core::evloop::EventLoop;
+use rsvim_core::js::SnapshotData;
 use rsvim_core::log;
 
 use clap::Parser;
+use once_cell::sync::Lazy;
 // use heed::types as heed_types;
 // use heed::{byteorder, Database, EnvOpenOptions};
 // use toml::Table;
 use tracing::debug;
+
+static RSVIM_SNAPSHOT: Lazy<Box<[u8]>> = Lazy::new(|| {
+  static BYTES: &[u8] = include_bytes!("../../RSVIM_SNAPSHOT.BIN");
+  Box::from(BYTES)
+});
 
 fn main() -> IoResult<()> {
   log::init();
@@ -52,7 +59,7 @@ fn main() -> IoResult<()> {
   let evloop_tokio_runtime = tokio::runtime::Runtime::new()?;
   evloop_tokio_runtime.block_on(async {
     // Create event loop.
-    let mut event_loop = EventLoop::new(cli_opt)?;
+    let mut event_loop = EventLoop::new(cli_opt, SnapshotData::new(&RSVIM_SNAPSHOT))?;
 
     // Initialize user config.
     event_loop.init_config()?;

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -8,7 +8,7 @@ use crate::evloop::msg::WorkerToMasterMessage;
 use crate::evloop::task::TaskableDataAccess;
 use crate::glovar;
 use crate::js::msg::{self as jsmsg, EventLoopToJsRuntimeMessage, JsRuntimeToEventLoopMessage};
-use crate::js::{JsRuntime, JsRuntimeOptions};
+use crate::js::{JsRuntime, JsRuntimeOptions, SnapshotData};
 use crate::state::fsm::StatefulValue;
 use crate::state::{State, StateArc};
 use crate::ui::canvas::{Canvas, CanvasArc, Shader, ShaderCommand};
@@ -117,7 +117,7 @@ pub struct EventLoop {
 
 impl EventLoop {
   /// Make new event loop.
-  pub fn new(cli_opt: CliOpt) -> IoResult<Self> {
+  pub fn new(cli_opt: CliOpt, snapshot: SnapshotData) -> IoResult<Self> {
     // Canvas
     let (cols, rows) = crossterm::terminal::size()?;
     let canvas_size = U16Size::new(cols, rows);
@@ -188,6 +188,7 @@ impl EventLoop {
     // Js Runtime
     let js_runtime = JsRuntime::new(
       JsRuntimeOptions::default(),
+      snapshot,
       startup_moment,
       startup_unix_epoch,
       js_runtime_send_to_master,

--- a/rsvim_core/src/js/hook.rs
+++ b/rsvim_core/src/js/hook.rs
@@ -49,7 +49,7 @@ pub extern "C" fn host_initialize_import_meta_object_cb(
   let module = v8::Global::new(scope, module);
 
   let url = state.module_map.get_path(module).unwrap();
-  let is_main = state.module_map.main() == Some(url.to_owned());
+  // let is_main = state.module_map.main() == Some(url.to_owned());
 
   // Setup import.url property.
   let key = v8::String::new(scope, "url").unwrap();
@@ -58,7 +58,8 @@ pub extern "C" fn host_initialize_import_meta_object_cb(
 
   // Setup import.main property.
   let key = v8::String::new(scope, "main").unwrap();
-  let value = v8::Boolean::new(scope, is_main);
+  // let value = v8::Boolean::new(scope, is_main);
+  let value = v8::Boolean::new(scope, false);
   meta.create_data_property(scope, key.into(), value.into());
 
   let url = v8::String::new(scope, &url).unwrap();

--- a/rsvim_core/src/js/module.rs
+++ b/rsvim_core/src/js/module.rs
@@ -209,7 +209,7 @@ impl ModuleGraph {
 /// It maintains all the modules inside js runtime, including already resolved and pending
 /// fetching.
 pub struct ModuleMap {
-  pub main: Option<ModulePath>,
+  // pub main: Option<ModulePath>,
   pub index: HashMap<ModulePath, v8::Global<v8::Module>>,
   pub seen: HashMap<ModulePath, ModuleStatus>,
   pub pending: Vec<Rc<RefCell<ModuleGraph>>>,
@@ -219,7 +219,7 @@ impl ModuleMap {
   // Creates a new module-map instance.
   pub fn new() -> ModuleMap {
     Self {
-      main: None,
+      // main: None,
       index: HashMap::new(),
       seen: HashMap::new(),
       pending: vec![],
@@ -228,10 +228,10 @@ impl ModuleMap {
 
   // Inserts a compiled ES module to the map.
   pub fn insert(&mut self, path: &str, module: v8::Global<v8::Module>) {
-    // No main module has been set, so let's update the value.
-    if self.main.is_none() && std::fs::metadata(path).is_ok() {
-      self.main = Some(path.into());
-    }
+    // // No main module has been set, so let's update the value.
+    // if self.main.is_none() && std::fs::metadata(path).is_ok() {
+    //   self.main = Some(path.into());
+    // }
     self.index.insert(path.into(), module);
   }
 
@@ -254,10 +254,10 @@ impl ModuleMap {
       .map(|(p, _)| p.clone())
   }
 
-  // Returns the main entry point.
-  pub fn main(&self) -> Option<ModulePath> {
-    self.main.clone()
-  }
+  // // Returns the main entry point.
+  // pub fn main(&self) -> Option<ModulePath> {
+  //   self.main.clone()
+  // }
 }
 
 impl Default for ModuleMap {


### PR DESCRIPTION
Follow up #199 , #202, #201 , this PR initialize js runtime with the snapshot to improve startup time.

Related links:

- [cli/build.rs - create_cli_snapshot()](https://github.com/denoland/deno/blob/b9d9cd17c96e19e80932caaed017745e74b44f8b/cli/build.rs?plain=1#L367)