### PR TITLE
feat(ui): maps every char index to its display boundary columns in viewport

### DIFF
--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -27,14 +27,14 @@ impl LineViewportRow {
   pub fn new(
     dcolumn_range: Range<usize>,
     char_idx_range: Range<usize>,
-    char2dcolumns: BTreeMap<usize, (usize, usize)>,
+    char2dcolumns: &BTreeMap<usize, (usize, usize)>,
   ) -> Self {
     Self {
       start_dcolumn: dcolumn_range.start,
       end_dcolumn: dcolumn_range.end,
       start_char_idx: char_idx_range.start,
       end_char_idx: char_idx_range.end,
-      char2dcolumns,
+      char2dcolumns: char2dcolumns.clone(),
     }
   }
 

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -691,6 +691,23 @@ mod tests {
         assert_eq!(payload, expect[*r as usize]);
         let total_width = payload.chars().map(|c| buffer.char_width(c)).sum::<usize>();
         assert_eq!(total_width, row.end_dcolumn() - row.start_dcolumn());
+        assert_eq!(row.chars_length(), row.char2dcolumns().len());
+        assert_eq!(
+          row.start_char_idx(),
+          *row.char2dcolumns().first_key_value().unwrap().0
+        );
+        assert_eq!(
+          row.end_char_idx(),
+          *row.char2dcolumns().last_key_value().unwrap().0 + 1
+        );
+        assert_eq!(
+          row.start_dcolumn(),
+          row.char2dcolumns().first_key_value().unwrap().1 .0
+        );
+        assert_eq!(
+          row.end_dcolumn(),
+          row.char2dcolumns().last_key_value().unwrap().1 .1
+        );
 
         if r > rows.first_key_value().unwrap().0 {
           let prev_r = r - 1;

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -670,18 +670,18 @@ mod tests {
         l, line_viewport, actual_line_idx, expect_start_fills, expect_end_fills
       );
       assert_eq!(
-        line_viewport.start_filled_columns,
+        line_viewport.start_filled_columns(),
         *expect_start_fills.get(&actual_line_idx).unwrap()
       );
       assert_eq!(
-        line_viewport.end_filled_columns,
+        line_viewport.end_filled_columns(),
         *expect_end_fills.get(&actual_line_idx).unwrap()
       );
 
-      let rows = &line_viewport.rows;
+      let rows = &line_viewport.rows();
       for (r, row) in rows.iter() {
         let mut payload = String::new();
-        for c_idx in row.start_char_idx..row.end_char_idx {
+        for c_idx in row.start_char_idx()..row.end_char_idx() {
           payload.push(line.get_char(c_idx).unwrap());
         }
         info!(
@@ -690,7 +690,7 @@ mod tests {
         );
         assert_eq!(payload, expect[*r as usize]);
         let total_width = payload.chars().map(|c| buffer.char_width(c)).sum::<usize>();
-        assert_eq!(total_width, row.end_dcolumn - row.start_dcolumn);
+        assert_eq!(total_width, row.end_dcolumn() - row.start_dcolumn());
 
         if r > rows.first_key_value().unwrap().0 {
           let prev_r = r - 1;
@@ -699,7 +699,7 @@ mod tests {
             "row-{:?}, current row[{}]:{:?}, previous row[{}]:{:?}",
             r, r, row, prev_r, prev_row
           );
-          assert_eq!(prev_row.end_dcolumn, row.start_dcolumn);
+          assert_eq!(prev_row.end_dcolumn(), row.start_dcolumn());
         }
         if r < rows.last_key_value().unwrap().0 {
           let next_r = r + 1;
@@ -708,7 +708,7 @@ mod tests {
             "row-{:?}, current row[{}]:{:?}, next row[{}]:{:?}",
             r, r, row, next_r, next_row
           );
-          assert_eq!(next_row.start_dcolumn, row.end_dcolumn);
+          assert_eq!(next_row.start_dcolumn(), row.end_dcolumn());
         }
       }
     }

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -62,12 +62,6 @@ impl LineViewportRow {
     self.end_dcolumn
   }
 
-  /// Maps from each char index to its (start and end) display column indexes in current row,
-  /// starts from 0. The value's 0 slot is `start_dcolumn`, 1 slot is `end_dcolumn`.
-  pub fn char2dcolumns(&self) -> &BTreeMap<usize, (usize, usize)> {
-    &self.char2dcolumns
-  }
-
   /// First (fully displayed) char index in current row.
   ///
   /// NOTE: The start and end indexes are left-inclusive and right-exclusive.
@@ -82,6 +76,12 @@ impl LineViewportRow {
   /// The start and end indexes are left-inclusive and right-exclusive.
   pub fn end_char_idx(&self) -> usize {
     self.end_char_idx
+  }
+
+  /// Maps from each char index to its (start and end) display column indexes in current row,
+  /// starts from 0. The value's 0 slot is `start_dcolumn`, 1 slot is `end_dcolumn`.
+  pub fn char2dcolumns(&self) -> &BTreeMap<usize, (usize, usize)> {
+    &self.char2dcolumns
   }
 }
 

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -680,6 +680,7 @@ mod tests {
 
       let rows = &line_viewport.rows();
       for (r, row) in rows.iter() {
+        info!("r-{:?}, row:{:?}", r, row);
         assert_eq!(row.chars_length(), row.char2dcolumns().len());
         assert_eq!(
           row.start_char_idx(),

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1017,10 +1017,10 @@ fn _sync_from_top_left_wrap_linebreak(
               }
             }
           } else {
+            // Enough space to place this word in current row
             let saved_c_idx = bchars;
             let saved_start_dcol = dcol;
 
-            // Enough space to place this word in current row
             dcol += wd_width;
             bchars += wd_chars;
             end_dcol = dcol;

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1017,6 +1017,9 @@ fn _sync_from_top_left_wrap_linebreak(
               }
             }
           } else {
+            let saved_c_idx = bchars;
+            let saved_start_dcol = dcol;
+
             // Enough space to place this word in current row
             dcol += wd_width;
             bchars += wd_chars;
@@ -1024,11 +1027,11 @@ fn _sync_from_top_left_wrap_linebreak(
             end_c_idx = bchars;
             wcol += wd_width as u16;
 
-            let mut tmp_start_dcol = start_dcol;
+            let mut tmp_start_dcol = saved_start_dcol;
             for (k, c) in wd.chars().enumerate() {
               let c_width = buffer.char_width(c);
               let tmp_end_dcol = tmp_start_dcol + c_width;
-              ch2dcols.insert(start_c_idx + k, (tmp_start_dcol, tmp_end_dcol));
+              ch2dcols.insert(saved_c_idx + k, (tmp_start_dcol, tmp_end_dcol));
               tmp_start_dcol = tmp_end_dcol;
             }
           }

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -153,6 +153,8 @@ fn _sync_from_top_left_nowrap(
         let mut start_c_idx_init = false;
         let mut _end_c_idx_init = false;
 
+        let mut ch2dcols: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
+
         let mut start_fills = 0_usize;
         let mut end_fills = 0_usize;
 
@@ -202,11 +204,7 @@ fn _sync_from_top_left_nowrap(
             // );
             rows.insert(
               wrow,
-              LineViewportRow::new(
-                start_dcol..end_dcol,
-                start_c_idx..end_c_idx,
-                BTreeMap::new(),
-              ),
+              LineViewportRow::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
             );
             break;
           }
@@ -215,6 +213,7 @@ fn _sync_from_top_left_nowrap(
           end_dcol = dcol;
           end_c_idx = i + 1;
           wcol += c_width as u16;
+          ch2dcols.insert(start_c_idx, (start_dcol, end_dcol));
           // trace!(
           //   "5-wrow/wcol:{}/{}, c:{:?}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
           //   wrow,
@@ -248,11 +247,7 @@ fn _sync_from_top_left_nowrap(
             // );
             rows.insert(
               wrow,
-              LineViewportRow::new(
-                start_dcol..end_dcol,
-                start_c_idx..end_c_idx,
-                BTreeMap::new(),
-              ),
+              LineViewportRow::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
             );
             break;
           }
@@ -275,11 +270,7 @@ fn _sync_from_top_left_nowrap(
             // );
             rows.insert(
               wrow,
-              LineViewportRow::new(
-                start_dcol..end_dcol,
-                start_c_idx..end_c_idx,
-                BTreeMap::new(),
-              ),
+              LineViewportRow::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
             );
             break;
           }
@@ -390,6 +381,8 @@ fn _sync_from_top_left_wrap_nolinebreak(
         let mut start_c_idx_init = false;
         let mut _end_c_idx_init = false;
 
+        let mut ch2dcols: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
+
         let mut start_fills = 0_usize;
         let mut end_fills = 0_usize;
 
@@ -448,17 +441,14 @@ fn _sync_from_top_left_wrap_nolinebreak(
             // );
             rows.insert(
               wrow,
-              LineViewportRow::new(
-                start_dcol..end_dcol,
-                start_c_idx..end_c_idx,
-                BTreeMap::new(),
-              ),
+              LineViewportRow::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
             );
             let saved_end_fills = width as usize - wcol as usize;
             wrow += 1;
             wcol = 0_u16;
             start_dcol = end_dcol;
             start_c_idx = end_c_idx;
+            ch2dcols.clear();
             if wrow >= height {
               end_fills = saved_end_fills;
               // trace!(
@@ -484,6 +474,7 @@ fn _sync_from_top_left_wrap_nolinebreak(
           end_dcol = dcol;
           end_c_idx = i + 1;
           wcol += c_width as u16;
+          ch2dcols.insert(start_c_idx, (start_dcol, end_dcol));
 
           // trace!(
           //   "5-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
@@ -518,11 +509,7 @@ fn _sync_from_top_left_wrap_nolinebreak(
             // );
             rows.insert(
               wrow,
-              LineViewportRow::new(
-                start_dcol..end_dcol,
-                start_c_idx..end_c_idx,
-                BTreeMap::new(),
-              ),
+              LineViewportRow::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
             );
             break;
           }
@@ -546,17 +533,14 @@ fn _sync_from_top_left_wrap_nolinebreak(
             // );
             rows.insert(
               wrow,
-              LineViewportRow::new(
-                start_dcol..end_dcol,
-                start_c_idx..end_c_idx,
-                BTreeMap::new(),
-              ),
+              LineViewportRow::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
             );
             debug_assert_eq!(wcol, width);
             wrow += 1;
             wcol = 0_u16;
             start_dcol = end_dcol;
             start_c_idx = end_c_idx;
+            ch2dcols.clear();
             if wrow >= height {
               // trace!(
               //   "8-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, height:{}",
@@ -661,7 +645,6 @@ fn _sync_from_top_left_wrap_linebreak(
   // );
 
   let mut line_viewports: BTreeMap<usize, LineViewport> = BTreeMap::new();
-  // let mut max_column = start_dcolumn;
 
   match buffer.get_lines_at(start_line) {
     Some(buflines) => {

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -209,11 +209,15 @@ fn _sync_from_top_left_nowrap(
             break;
           }
 
+          let saved_start_dcol = dcol;
+          let saved_c_idx = i;
+
           dcol += c_width;
           end_dcol = dcol;
           end_c_idx = i + 1;
           wcol += c_width as u16;
-          ch2dcols.insert(start_c_idx, (start_dcol, end_dcol));
+
+          ch2dcols.insert(saved_c_idx, (saved_start_dcol, dcol));
           // trace!(
           //   "5-wrow/wcol:{}/{}, c:{:?}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
           //   wrow,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -792,7 +792,7 @@ fn _sync_from_top_left_wrap_linebreak(
             //   width
             // );
 
-            // If if happens this word starts from the beginning of the row, then we don't need to
+            // If it happens this word starts from the beginning of the row, then we don't need to
             // start from the next row. Because this is an empty of entire row.
             // If this word starts in the middle of the row, then we will have to start a new row.
             if wcol > 0 {

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -933,12 +933,16 @@ fn _sync_from_top_left_wrap_linebreak(
                 }
               }
 
+              let saved_c_idx = bchars;
+              let saved_start_dcol = dcol;
+
               dcol += c_width;
               bchars += 1;
               end_dcol = dcol;
               end_c_idx = bchars;
               wcol += c_width as u16;
-              ch2dcols.insert(start_c_idx, (start_dcol, end_dcol));
+
+              ch2dcols.insert(saved_c_idx, (saved_start_dcol, end_dcol));
 
               // trace!(
               //   "8-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -217,7 +217,8 @@ fn _sync_from_top_left_nowrap(
           end_c_idx = i + 1;
           wcol += c_width as u16;
 
-          ch2dcols.insert(saved_c_idx, (saved_start_dcol, dcol));
+          ch2dcols.insert(saved_c_idx, (saved_start_dcol, end_dcol));
+
           // trace!(
           //   "5-wrow/wcol:{}/{}, c:{:?}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
           //   wrow,
@@ -474,11 +475,15 @@ fn _sync_from_top_left_wrap_nolinebreak(
             }
           }
 
+          let saved_c_idx = i;
+          let saved_start_dcol = dcol;
+
           dcol += c_width;
           end_dcol = dcol;
           end_c_idx = i + 1;
           wcol += c_width as u16;
-          ch2dcols.insert(start_c_idx, (start_dcol, end_dcol));
+
+          ch2dcols.insert(saved_c_idx, (saved_start_dcol, end_dcol));
 
           // trace!(
           //   "5-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -54,7 +54,7 @@ pub fn from_top_left(
   buffer: BufferWk,
   actual_shape: &U16Rect,
   start_line: usize,
-  start_bcolumn: usize,
+  start_dcolumn: usize,
 ) -> (ViewportLineRange, BTreeMap<usize, LineViewport>) {
   // If window is zero-sized.
   let height = actual_shape.height();
@@ -65,13 +65,13 @@ pub fn from_top_left(
 
   match (options.wrap, options.line_break) {
     (false, _) => {
-      _sync_from_top_left_nowrap(options, buffer, actual_shape, start_line, start_bcolumn)
+      _sync_from_top_left_nowrap(options, buffer, actual_shape, start_line, start_dcolumn)
     }
     (true, false) => {
-      _sync_from_top_left_wrap_nolinebreak(options, buffer, actual_shape, start_line, start_bcolumn)
+      _sync_from_top_left_wrap_nolinebreak(options, buffer, actual_shape, start_line, start_dcolumn)
     }
     (true, true) => {
-      _sync_from_top_left_wrap_linebreak(options, buffer, actual_shape, start_line, start_bcolumn)
+      _sync_from_top_left_wrap_linebreak(options, buffer, actual_shape, start_line, start_dcolumn)
     }
   }
 }
@@ -92,7 +92,7 @@ fn _sync_from_top_left_nowrap(
   buffer: BufferWk,
   actual_shape: &U16Rect,
   start_line: usize,
-  start_bcolumn: usize,
+  start_dcolumn: usize,
 ) -> (ViewportLineRange, BTreeMap<usize, LineViewport>) {
   let height = actual_shape.height();
   let width = actual_shape.width();
@@ -120,7 +120,6 @@ fn _sync_from_top_left_nowrap(
   // );
 
   let mut line_viewports: BTreeMap<usize, LineViewport> = BTreeMap::new();
-  // let mut max_bcolumn = start_bcolumn;
 
   match buffer.get_lines_at(start_line) {
     // The `start_line` is in the buffer.
@@ -145,9 +144,9 @@ fn _sync_from_top_left_nowrap(
         let mut rows: BTreeMap<u16, LineViewportRow> = BTreeMap::new();
         let mut wcol = 0_u16;
 
-        let mut bcol = 0_usize;
-        let mut start_bcol = 0_usize;
-        let mut end_bcol = 0_usize;
+        let mut dcol = 0_usize;
+        let mut start_dcol = 0_usize;
+        let mut end_dcol = 0_usize;
 
         let mut start_c_idx = 0_usize;
         let mut end_c_idx = 0_usize;
@@ -161,26 +160,26 @@ fn _sync_from_top_left_nowrap(
         for (i, c) in line.chars().enumerate() {
           let c_width = buffer.char_width(c);
 
-          // Prefix width is still before `start_bcolumn`.
-          if bcol + c_width < start_bcolumn {
-            bcol += c_width;
-            end_bcol = bcol;
+          // Prefix width is still before `start_dcolumn`.
+          if dcol + c_width < start_dcolumn {
+            dcol += c_width;
+            end_dcol = dcol;
             end_c_idx = i;
             // trace!(
-            //   "1-wrow/wcol:{}/{}, c:{:?}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, start_bcolumn:{}",
-            //   wrow, wcol, c, c_width, bcol, start_bcol, end_bcol, start_c_idx, end_c_idx, start_fills, end_fills, start_bcolumn
+            //   "1-wrow/wcol:{}/{}, c:{:?}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, start_dcolumn:{}",
+            //   wrow, wcol, c, c_width, dcol, start_dcol, end_dcol, start_c_idx, end_c_idx, start_fills, end_fills, start_dcolumn
             // );
             continue;
           }
 
           if !start_c_idx_init {
             start_c_idx_init = true;
-            start_bcol = bcol;
+            start_dcol = dcol;
             start_c_idx = i;
-            start_fills = bcol - start_bcolumn;
+            start_fills = dcol - start_dcolumn;
             // trace!(
-            //   "2-wrow/wcol:{}/{}, c:{:?}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, start_bcolumn:{}",
-            //   wrow, wcol, c, c_width, bcol, start_bcol, end_bcol, start_c_idx, end_c_idx, start_fills, end_fills, start_bcolumn
+            //   "2-wrow/wcol:{}/{}, c:{:?}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, start_dcolumn:{}",
+            //   wrow, wcol, c, c_width, dcol, start_dcol, end_dcol, start_c_idx, end_c_idx, start_fills, end_fills, start_dcolumn
             // );
           }
 
@@ -188,14 +187,14 @@ fn _sync_from_top_left_nowrap(
           if wcol as usize + c_width > width as usize {
             end_fills = width as usize - wcol as usize;
             // trace!(
-            //   "4-wrow/wcol:{}/{}, c:{:?}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+            //   "4-wrow/wcol:{}/{}, c:{:?}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
             //   wrow,
             //   wcol,
             //   c,
             //   c_width,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   start_c_idx,
             //   end_c_idx,
             //   start_fills,
@@ -204,7 +203,7 @@ fn _sync_from_top_left_nowrap(
             rows.insert(
               wrow,
               LineViewportRow::new(
-                start_bcol..end_bcol,
+                start_dcol..end_dcol,
                 start_c_idx..end_c_idx,
                 BTreeMap::new(),
               ),
@@ -212,19 +211,19 @@ fn _sync_from_top_left_nowrap(
             break;
           }
 
-          bcol += c_width;
-          end_bcol = bcol;
+          dcol += c_width;
+          end_dcol = dcol;
           end_c_idx = i + 1;
           wcol += c_width as u16;
           // trace!(
-          //   "5-wrow/wcol:{}/{}, c:{:?}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+          //   "5-wrow/wcol:{}/{}, c:{:?}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
           //   wrow,
           //   wcol,
           //   c,
           //   c_width,
-          //   bcol,
-          //   start_bcol,
-          //   end_bcol,
+          //   dcol,
+          //   start_dcol,
+          //   end_dcol,
           //   start_c_idx,
           //   end_c_idx,
           //   start_fills,
@@ -234,14 +233,14 @@ fn _sync_from_top_left_nowrap(
           // End of the line.
           if i + 1 == line.len_chars() {
             // trace!(
-            //   "6-wrow/wcol:{}/{}, c:{:?}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+            //   "6-wrow/wcol:{}/{}, c:{:?}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
             //   wrow,
             //   wcol,
             //   c,
             //   c_width,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   start_c_idx,
             //   end_c_idx,
             //   start_fills,
@@ -250,7 +249,7 @@ fn _sync_from_top_left_nowrap(
             rows.insert(
               wrow,
               LineViewportRow::new(
-                start_bcol..end_bcol,
+                start_dcol..end_dcol,
                 start_c_idx..end_c_idx,
                 BTreeMap::new(),
               ),
@@ -261,14 +260,14 @@ fn _sync_from_top_left_nowrap(
           // Row column goes out of the row.
           if wcol >= width {
             // trace!(
-            //   "7-wrow/wcol:{}/{}, c:{:?}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+            //   "7-wrow/wcol:{}/{}, c:{:?}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
             //   wrow,
             //   wcol,
             //   c,
             //   c_width,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   start_c_idx,
             //   end_c_idx,
             //   start_fills,
@@ -277,7 +276,7 @@ fn _sync_from_top_left_nowrap(
             rows.insert(
               wrow,
               LineViewportRow::new(
-                start_bcol..end_bcol,
+                start_dcol..end_dcol,
                 start_c_idx..end_c_idx,
                 BTreeMap::new(),
               ),
@@ -291,13 +290,13 @@ fn _sync_from_top_left_nowrap(
           LineViewport::new(rows, start_fills, end_fills),
         );
         // trace!(
-        //   "8-current_line:{}, wrow/wcol:{}/{}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+        //   "8-current_line:{}, wrow/wcol:{}/{}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
         //   current_line,
         //   wrow,
         //   wcol,
-        //   bcol,
-        //   start_bcol,
-        //   end_bcol,
+        //   dcol,
+        //   start_dcol,
+        //   end_dcol,
         //   start_c_idx,
         //   end_c_idx,
         //   start_fills,
@@ -329,7 +328,7 @@ fn _sync_from_top_left_wrap_nolinebreak(
   buffer: BufferWk,
   actual_shape: &U16Rect,
   start_line: usize,
-  start_bcolumn: usize,
+  start_dcolumn: usize,
 ) -> (ViewportLineRange, BTreeMap<usize, LineViewport>) {
   let height = actual_shape.height();
   let width = actual_shape.width();
@@ -382,9 +381,9 @@ fn _sync_from_top_left_wrap_nolinebreak(
         let mut rows: BTreeMap<u16, LineViewportRow> = BTreeMap::new();
         let mut wcol = 0_u16;
 
-        let mut bcol = 0_usize;
-        let mut start_bcol = 0_usize;
-        let mut end_bcol = 0_usize;
+        let mut dcol = 0_usize;
+        let mut start_dcol = 0_usize;
+        let mut end_dcol = 0_usize;
 
         let mut start_c_idx = 0_usize;
         let mut end_c_idx = 0_usize;
@@ -397,32 +396,32 @@ fn _sync_from_top_left_wrap_nolinebreak(
         for (i, c) in line.chars().enumerate() {
           let c_width = buffer.char_width(c);
 
-          // Prefix width is still before `start_bcolumn`.
-          if bcol + c_width < start_bcolumn {
-            bcol += c_width;
-            end_bcol = bcol;
+          // Prefix width is still before `start_dcolumn`.
+          if dcol + c_width < start_dcolumn {
+            dcol += c_width;
+            end_dcol = dcol;
             end_c_idx = i;
             // trace!(
-            //   "1-wrow/wcol:{}/{}, c:{}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, start_bcolumn:{}",
-            //   wrow, wcol, c, c_width, bcol, start_bcol, end_bcol, start_c_idx, end_c_idx, start_fills, end_fills, start_bcolumn
+            //   "1-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, start_dcolumn:{}",
+            //   wrow, wcol, c, c_width, dcol, start_dcol, end_dcol, start_c_idx, end_c_idx, start_fills, end_fills, start_dcolumn
             // );
             continue;
           }
 
           if !start_c_idx_init {
             start_c_idx_init = true;
-            start_bcol = bcol;
+            start_dcol = dcol;
             start_c_idx = i;
-            start_fills = bcol - start_bcolumn;
+            start_fills = dcol - start_dcolumn;
             // trace!(
-            //   "2-wrow/wcol:{}/{}, c:{}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+            //   "2-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
             //   wrow,
             //   wcol,
             //   c,
             //   c_width,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   start_c_idx,
             //   end_c_idx,
             //   start_fills,
@@ -433,14 +432,14 @@ fn _sync_from_top_left_wrap_nolinebreak(
           // Column with next char will goes out of the row.
           if wcol as usize + c_width > width as usize {
             // trace!(
-            //   "3-wrow/wcol:{}/{}, c:{}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, width:{}",
+            //   "3-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, width:{}",
             //   wrow,
             //   wcol,
             //   c,
             //   c_width,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   start_c_idx,
             //   end_c_idx,
             //   start_fills,
@@ -450,7 +449,7 @@ fn _sync_from_top_left_wrap_nolinebreak(
             rows.insert(
               wrow,
               LineViewportRow::new(
-                start_bcol..end_bcol,
+                start_dcol..end_dcol,
                 start_c_idx..end_c_idx,
                 BTreeMap::new(),
               ),
@@ -458,19 +457,19 @@ fn _sync_from_top_left_wrap_nolinebreak(
             let saved_end_fills = width as usize - wcol as usize;
             wrow += 1;
             wcol = 0_u16;
-            start_bcol = end_bcol;
+            start_dcol = end_dcol;
             start_c_idx = end_c_idx;
             if wrow >= height {
               end_fills = saved_end_fills;
               // trace!(
-              //   "4-wrow/wcol:{}/{}, c:{}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, height:{}",
+              //   "4-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, height:{}",
               //   wrow,
               //   wcol,
               //   c,
               //   c_width,
-              //   bcol,
-              //   start_bcol,
-              //   end_bcol,
+              //   dcol,
+              //   start_dcol,
+              //   end_dcol,
               //   start_c_idx,
               //   end_c_idx,
               //   start_fills,
@@ -481,20 +480,20 @@ fn _sync_from_top_left_wrap_nolinebreak(
             }
           }
 
-          bcol += c_width;
-          end_bcol = bcol;
+          dcol += c_width;
+          end_dcol = dcol;
           end_c_idx = i + 1;
           wcol += c_width as u16;
 
           // trace!(
-          //   "5-wrow/wcol:{}/{}, c:{}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+          //   "5-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
           //   wrow,
           //   wcol,
           //   c,
           //   c_width,
-          //   bcol,
-          //   start_bcol,
-          //   end_bcol,
+          //   dcol,
+          //   start_dcol,
+          //   end_dcol,
           //   start_c_idx,
           //   end_c_idx,
           //   start_fills,
@@ -504,14 +503,14 @@ fn _sync_from_top_left_wrap_nolinebreak(
           // End of the line.
           if i + 1 == line.len_chars() {
             // trace!(
-            //   "6-wrow/wcol:{}/{}, c:{}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+            //   "6-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
             //   wrow,
             //   wcol,
             //   c,
             //   c_width,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   start_c_idx,
             //   end_c_idx,
             //   start_fills,
@@ -520,7 +519,7 @@ fn _sync_from_top_left_wrap_nolinebreak(
             rows.insert(
               wrow,
               LineViewportRow::new(
-                start_bcol..end_bcol,
+                start_dcol..end_dcol,
                 start_c_idx..end_c_idx,
                 BTreeMap::new(),
               ),
@@ -531,14 +530,14 @@ fn _sync_from_top_left_wrap_nolinebreak(
           // Column goes out of current row.
           if wcol >= width {
             // trace!(
-            //   "7-wrow/wcol:{}/{}, c:{}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, width:{}",
+            //   "7-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, width:{}",
             //   wrow,
             //   wcol,
             //   c,
             //   c_width,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   start_c_idx,
             //   end_c_idx,
             //   start_fills,
@@ -548,7 +547,7 @@ fn _sync_from_top_left_wrap_nolinebreak(
             rows.insert(
               wrow,
               LineViewportRow::new(
-                start_bcol..end_bcol,
+                start_dcol..end_dcol,
                 start_c_idx..end_c_idx,
                 BTreeMap::new(),
               ),
@@ -556,18 +555,18 @@ fn _sync_from_top_left_wrap_nolinebreak(
             debug_assert_eq!(wcol, width);
             wrow += 1;
             wcol = 0_u16;
-            start_bcol = end_bcol;
+            start_dcol = end_dcol;
             start_c_idx = end_c_idx;
             if wrow >= height {
               // trace!(
-              //   "8-wrow/wcol:{}/{}, c:{}/{:?}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, height:{}",
+              //   "8-wrow/wcol:{}/{}, c:{}/{:?}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}, height:{}",
               //   wrow,
               //   wcol,
               //   c,
               //   c_width,
-              //   bcol,
-              //   start_bcol,
-              //   end_bcol,
+              //   dcol,
+              //   start_dcol,
+              //   end_dcol,
               //   start_c_idx,
               //   end_c_idx,
               //   start_fills,
@@ -584,13 +583,13 @@ fn _sync_from_top_left_wrap_nolinebreak(
           LineViewport::new(rows, start_fills, end_fills),
         );
         // trace!(
-        //   "9-current_line:{}, wrow/wcol:{}/{}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+        //   "9-current_line:{}, wrow/wcol:{}/{}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
         //   current_line,
         //   wrow,
         //   wcol,
-        //   bcol,
-        //   start_bcol,
-        //   end_bcol,
+        //   dcol,
+        //   start_dcol,
+        //   end_dcol,
         //   start_c_idx,
         //   end_c_idx,
         //   start_fills,
@@ -636,7 +635,7 @@ fn _sync_from_top_left_wrap_linebreak(
   buffer: BufferWk,
   actual_shape: &U16Rect,
   start_line: usize,
-  start_bcolumn: usize,
+  start_dcolumn: usize,
 ) -> (ViewportLineRange, BTreeMap<usize, LineViewport>) {
   let height = actual_shape.height();
   let width = actual_shape.width();
@@ -662,7 +661,7 @@ fn _sync_from_top_left_wrap_linebreak(
   // );
 
   let mut line_viewports: BTreeMap<usize, LineViewport> = BTreeMap::new();
-  // let mut max_column = start_bcolumn;
+  // let mut max_column = start_dcolumn;
 
   match buffer.get_lines_at(start_line) {
     Some(buflines) => {
@@ -682,9 +681,9 @@ fn _sync_from_top_left_wrap_linebreak(
         let mut wcol = 0_u16;
 
         let mut bchars = 0_usize;
-        let mut bcol = 0_usize;
-        let mut start_bcol = 0_usize;
-        let mut end_bcol = 0_usize;
+        let mut dcol = 0_usize;
+        let mut start_dcol = 0_usize;
+        let mut end_dcol = 0_usize;
 
         let mut start_c_idx = 0_usize;
         let mut end_c_idx = 0_usize;
@@ -700,13 +699,13 @@ fn _sync_from_top_left_wrap_linebreak(
         // a viewport.
         let truncated_line = truncate_line(
           &line,
-          start_bcolumn,
+          start_dcolumn,
           height as usize * width as usize * 2 + height as usize * 2 + 16,
         );
         let word_boundaries: Vec<&str> = truncated_line.split_word_bounds().collect();
         // trace!(
-        //   "0-truncated_line: {:?}, word_boundaries: {:?}, wrow/wcol:{}/{}, bcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
-        //   truncated_line, word_boundaries, wrow, wcol, bcol, start_bcol, end_bcol, start_c_idx, end_c_idx, start_fills, end_fills
+        //   "0-truncated_line: {:?}, word_boundaries: {:?}, wrow/wcol:{}/{}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+        //   truncated_line, word_boundaries, wrow, wcol, dcol, start_dcol, end_dcol, start_c_idx, end_c_idx, start_fills, end_fills
         // );
 
         for (i, wd) in word_boundaries.iter().enumerate() {
@@ -724,19 +723,19 @@ fn _sync_from_top_left_wrap_linebreak(
           //   wd
           // );
 
-          // Prefix width is still before `start_bcolumn`.
-          if bcol + wd_width < start_bcolumn {
-            bcol += wd_width;
+          // Prefix width is still before `start_dcolumn`.
+          if dcol + wd_width < start_dcolumn {
+            dcol += wd_width;
             bchars += wd_chars;
-            end_bcol = bcol;
+            end_dcol = dcol;
             end_c_idx = bchars;
             // trace!(
-            //   "2-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, start_bcolumn:{}",
+            //   "2-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, start_dcolumn:{}",
             //   wrow,
             //   wcol,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   bchars,
             //   start_c_idx,
             //   end_c_idx,
@@ -744,23 +743,23 @@ fn _sync_from_top_left_wrap_linebreak(
             //   end_fills,
             //   wd_chars,
             //   wd_width,
-            //   start_bcolumn
+            //   start_dcolumn
             // );
             continue;
           }
 
           if !start_c_idx_init {
             start_c_idx_init = true;
-            start_bcol = bcol;
+            start_dcol = dcol;
             start_c_idx = bchars;
-            start_fills = bcol - start_bcolumn;
+            start_fills = dcol - start_dcolumn;
             // trace!(
-            //   "3-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
+            //   "3-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
             //   wrow,
             //   wcol,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   bchars,
             //   start_c_idx,
             //   end_c_idx,
@@ -783,12 +782,12 @@ fn _sync_from_top_left_wrap_linebreak(
           // 'line-break' option is `false`.
           if wcol as usize + wd_width > width as usize {
             // trace!(
-            //   "4.1-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+            //   "4.1-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
             //   wrow,
             //   wcol,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   bchars,
             //   start_c_idx,
             //   end_c_idx,
@@ -806,7 +805,7 @@ fn _sync_from_top_left_wrap_linebreak(
               rows.insert(
                 wrow,
                 LineViewportRow::new(
-                  start_bcol..end_bcol,
+                  start_dcol..end_dcol,
                   start_c_idx..end_c_idx,
                   BTreeMap::new(),
                 ),
@@ -836,13 +835,13 @@ fn _sync_from_top_left_wrap_linebreak(
                   }
                 }
                 //   trace!(
-                //   "4.2-wrow/wcol/tmp_wcol:{}/{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+                //   "4.2-wrow/wcol/tmp_wcol:{}/{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
                 //   wrow,
                 //   wcol,
                 //   tmp_wcol,
-                //   bcol,
-                //   start_bcol,
-                //   end_bcol,
+                //   dcol,
+                //   start_dcol,
+                //   end_dcol,
                 //   bchars,
                 //   start_c_idx,
                 //   end_c_idx,
@@ -857,18 +856,18 @@ fn _sync_from_top_left_wrap_linebreak(
 
               wrow += 1;
               wcol = 0_u16;
-              start_bcol = end_bcol;
+              start_dcol = end_dcol;
               start_c_idx = bchars;
 
               if wrow >= height {
                 end_fills = saved_end_fills as usize;
                 //   trace!(
-                //   "5-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
+                //   "5-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
                 //   wrow,
                 //   wcol,
-                //   bcol,
-                //   start_bcol,
-                //   end_bcol,
+                //   dcol,
+                //   start_dcol,
+                //   end_dcol,
                 //   bchars,
                 //   start_c_idx,
                 //   end_c_idx,
@@ -888,12 +887,12 @@ fn _sync_from_top_left_wrap_linebreak(
               // Column with next char will goes out of the row.
               if wcol as usize + c_width > width as usize {
                 // trace!(
-                //   "6-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+                //   "6-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
                 //   wrow,
                 //   wcol,
-                //   bcol,
-                //   start_bcol,
-                //   end_bcol,
+                //   dcol,
+                //   start_dcol,
+                //   end_dcol,
                 //   bchars,
                 //   j,
                 //   c,
@@ -908,7 +907,7 @@ fn _sync_from_top_left_wrap_linebreak(
                 rows.insert(
                   wrow,
                   LineViewportRow::new(
-                    start_bcol..end_bcol,
+                    start_dcol..end_dcol,
                     start_c_idx..end_c_idx,
                     BTreeMap::new(),
                   ),
@@ -919,18 +918,18 @@ fn _sync_from_top_left_wrap_linebreak(
                   wrow += 1;
                 }
                 wcol = 0_u16;
-                start_bcol = end_bcol;
+                start_dcol = end_dcol;
                 start_c_idx = bchars;
 
                 if wrow >= height {
                   end_fills = saved_end_fills;
                   // trace!(
-                  //   "7-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
+                  //   "7-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
                   //   wrow,
                   //   wcol,
-                  //   bcol,
-                  //   start_bcol,
-                  //   end_bcol,
+                  //   dcol,
+                  //   start_dcol,
+                  //   end_dcol,
                   //   bchars,
                   //   j,
                   //   c,
@@ -946,19 +945,19 @@ fn _sync_from_top_left_wrap_linebreak(
                 }
               }
 
-              bcol += c_width;
+              dcol += c_width;
               bchars += 1;
-              end_bcol = bcol;
+              end_dcol = dcol;
               end_c_idx = bchars;
               wcol += c_width as u16;
 
               // trace!(
-              //   "8-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
+              //   "8-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
               //   wrow,
               //   wcol,
-              //   bcol,
-              //   start_bcol,
-              //   end_bcol,
+              //   dcol,
+              //   start_dcol,
+              //   end_dcol,
               //   bchars,
               //   j,
               //   c,
@@ -973,12 +972,12 @@ fn _sync_from_top_left_wrap_linebreak(
               // Column goes out of current row.
               if wcol >= width {
                 // trace!(
-                //   "9-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+                //   "9-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
                 //   wrow,
                 //   wcol,
-                //   bcol,
-                //   start_bcol,
-                //   end_bcol,
+                //   dcol,
+                //   start_dcol,
+                //   end_dcol,
                 //   bchars,
                 //   j,
                 //   c,
@@ -993,7 +992,7 @@ fn _sync_from_top_left_wrap_linebreak(
                 rows.insert(
                   wrow,
                   LineViewportRow::new(
-                    start_bcol..end_bcol,
+                    start_dcol..end_dcol,
                     start_c_idx..end_c_idx,
                     BTreeMap::new(),
                   ),
@@ -1001,17 +1000,17 @@ fn _sync_from_top_left_wrap_linebreak(
                 debug_assert_eq!(wcol, width);
                 wrow += 1;
                 wcol = 0_u16;
-                start_bcol = end_bcol;
+                start_dcol = end_dcol;
                 start_c_idx = end_c_idx;
 
                 if wrow >= height {
                   // trace!(
-                  //   "10-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
+                  //   "10-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
                   //   wrow,
                   //   wcol,
-                  //   bcol,
-                  //   start_bcol,
-                  //   end_bcol,
+                  //   dcol,
+                  //   start_dcol,
+                  //   end_dcol,
                   //   bchars,
                   //   j,
                   //   c,
@@ -1031,20 +1030,20 @@ fn _sync_from_top_left_wrap_linebreak(
           // Row column with next char will goes out of the row.
           else {
             // Enough space to place this word in current row
-            bcol += wd_width;
+            dcol += wd_width;
             bchars += wd_chars;
-            end_bcol = bcol;
+            end_dcol = dcol;
             end_c_idx = bchars;
             wcol += wd_width as u16;
           }
 
           // trace!(
-          //   "9-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
+          //   "9-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
           //   wrow,
           //   wcol,
-          //   bcol,
-          //   start_bcol,
-          //   end_bcol,
+          //   dcol,
+          //   start_dcol,
+          //   end_dcol,
           //   bchars,
           //   start_c_idx,
           //   end_c_idx,
@@ -1057,12 +1056,12 @@ fn _sync_from_top_left_wrap_linebreak(
           // End of the line.
           if i + 1 == word_boundaries.len() {
             // trace!(
-            //   "10-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
+            //   "10-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
             //   wrow,
             //   wcol,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   bchars,
             //   start_c_idx,
             //   end_c_idx,
@@ -1074,7 +1073,7 @@ fn _sync_from_top_left_wrap_linebreak(
             rows.insert(
               wrow,
               LineViewportRow::new(
-                start_bcol..end_bcol,
+                start_dcol..end_dcol,
                 start_c_idx..end_c_idx,
                 BTreeMap::new(),
               ),
@@ -1085,12 +1084,12 @@ fn _sync_from_top_left_wrap_linebreak(
           // Column goes out of current row.
           if wcol >= width {
             // trace!(
-            //   "11-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+            //   "11-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
             //   wrow,
             //   wcol,
-            //   bcol,
-            //   start_bcol,
-            //   end_bcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
             //   bchars,
             //   start_c_idx,
             //   end_c_idx,
@@ -1103,7 +1102,7 @@ fn _sync_from_top_left_wrap_linebreak(
             rows.insert(
               wrow,
               LineViewportRow::new(
-                start_bcol..end_bcol,
+                start_dcol..end_dcol,
                 start_c_idx..end_c_idx,
                 BTreeMap::new(),
               ),
@@ -1111,17 +1110,17 @@ fn _sync_from_top_left_wrap_linebreak(
             debug_assert_eq!(wcol, width);
             wrow += 1;
             wcol = 0_u16;
-            start_bcol = end_bcol;
+            start_dcol = end_dcol;
             start_c_idx = end_c_idx;
 
             if wrow >= height {
               // trace!(
-              //   "12-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
+              //   "12-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
               //   wrow,
               //   wcol,
-              //   bcol,
-              //   start_bcol,
-              //   end_bcol,
+              //   dcol,
+              //   start_dcol,
+              //   end_dcol,
               //   bchars,
               //   start_c_idx,
               //   end_c_idx,
@@ -1141,12 +1140,12 @@ fn _sync_from_top_left_wrap_linebreak(
           LineViewport::new(rows, start_fills, end_fills),
         );
         // trace!(
-        //   "13-wrow/wcol:{}/{}, bcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}",
+        //   "13-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}",
         //   wrow,
         //   wcol,
-        //   bcol,
-        //   start_bcol,
-        //   end_bcol,
+        //   dcol,
+        //   start_dcol,
+        //   end_dcol,
         //   bchars,
         //   start_c_idx,
         //   end_c_idx,


### PR DESCRIPTION
This adds a more detailed index mapping in viewport, from each unicode char index to its start/end display columns.

It would help a lot when we implement the cursor movement on a viewport (in following work), because the cursor movement needs to know its adjacent char's position on both unicode char index and terminal displayed cells.

In previous work, the viewport only contains the start/end char index and start/end display column on each row in the window, but not the detailed each unicode chars inside the row.