### PR TITLE
feat(win): impl line-break/word-wrap rendering (again)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,6 @@ opt-level = 3
 opt-level = 3
 [profile.release.package.zstd-sys]
 opt-level = 3
-
 # Release }
 
 # Nightly

--- a/rsvim_core/src/buf.rs
+++ b/rsvim_core/src/buf.rs
@@ -67,7 +67,7 @@ pub type BufferWriteGuard<'a> = RwLockWriteGuard<'a, Buffer>;
 
 #[inline]
 fn get_cached_size(canvas_height: u16) -> std::num::NonZeroUsize {
-  std::num::NonZeroUsize::new(canvas_height as usize + 3_usize).unwrap()
+  std::num::NonZeroUsize::new(canvas_height as usize * 2 + 3).unwrap()
 }
 
 impl Buffer {

--- a/rsvim_core/src/buf.rs
+++ b/rsvim_core/src/buf.rs
@@ -179,33 +179,34 @@ impl Buffer {
     &mut self.rope
   }
 
-  // /// Similar with [`Buffer::get_line`], but collect and clone a normal string with start index
-  // /// (`start_char_idx`) and max chars length (`max_chars`).
-  // /// NOTE: This is for performance reason that this API limits the max chars instead of the whole
-  // /// line, this is useful for super long lines.
-  // pub fn clone_line(
-  //   &self,
-  //   line_idx: usize,
-  //   start_char_idx: usize,
-  //   max_chars: usize,
-  // ) -> Option<String> {
-  //   match self.rope.get_line(line_idx) {
-  //     Some(line) => match line.get_chars_at(start_char_idx) {
-  //       Some(chars_iter) => {
-  //         let mut builder = String::with_capacity(max_chars);
-  //         for (i, c) in chars_iter.enumerate() {
-  //           if i >= max_chars {
-  //             return Some(builder);
-  //           }
-  //           builder.push(c);
-  //         }
-  //         Some(builder)
-  //       }
-  //       None => None,
-  //     },
-  //     None => None,
-  //   }
-  // }
+  /// Similar with [`Rope::get_line`], but collect and clone a normal string with start index
+  /// (`start_char_idx`) and max chars length (`max_chars`).
+  ///
+  /// NOTE: It is for performance reason that limits maximized chars count instead of the whole
+  /// line, which is useful for super long lines.
+  pub fn clone_line(
+    &self,
+    line_idx: usize,
+    start_char_idx: usize,
+    max_chars: usize,
+  ) -> Option<String> {
+    match self.rope.get_line(line_idx) {
+      Some(line) => match line.get_chars_at(start_char_idx) {
+        Some(chars_iter) => {
+          let mut builder = String::with_capacity(max_chars);
+          for (i, c) in chars_iter.enumerate() {
+            if i >= max_chars {
+              return Some(builder);
+            }
+            builder.push(c);
+          }
+          Some(builder)
+        }
+        None => None,
+      },
+      None => None,
+    }
+  }
 }
 // Rope }
 

--- a/rsvim_core/src/buf.rs
+++ b/rsvim_core/src/buf.rs
@@ -317,12 +317,12 @@ impl Buffer {
       .truncate_since_width(width)
   }
 
-  /// Remove one specified line.
+  /// Remove one cached line.
   pub fn remove_cached_line(&mut self, line_idx: usize) {
     self.cached_lines_width.pop(&line_idx);
   }
 
-  /// Retain multiple lines by lambda function `f`.
+  /// Retain multiple cached lines by lambda function `f`.
   pub fn retain_cached_lines<F>(&mut self, f: F)
   where
     F: Fn(&usize, &ColumnIndex) -> bool,
@@ -338,7 +338,7 @@ impl Buffer {
     }
   }
 
-  /// Clear.
+  /// Clear cache.
   pub fn clear_cached_lines(&mut self) {
     self.cached_lines_width.clear()
   }

--- a/rsvim_core/src/buf.rs
+++ b/rsvim_core/src/buf.rs
@@ -346,9 +346,9 @@ impl Buffer {
 
   /// Resize cache.
   pub fn resize_cached_lines(&mut self, canvas_height: u16) {
-    let new_cached_size = get_cached_size(canvas_height);
-    if new_cached_size > self.cached_lines_width.cap() {
-      self.cached_lines_width.resize(new_cached_size);
+    let new_cache_size = get_cached_size(canvas_height);
+    if new_cache_size > self.cached_lines_width.cap() {
+      self.cached_lines_width.resize(new_cache_size);
     }
   }
 }

--- a/rsvim_core/src/buf.rs
+++ b/rsvim_core/src/buf.rs
@@ -67,7 +67,7 @@ pub type BufferWriteGuard<'a> = RwLockWriteGuard<'a, Buffer>;
 
 #[inline]
 fn get_cached_size(canvas_height: u16) -> std::num::NonZeroUsize {
-  std::num::NonZeroUsize::new((canvas_height as usize) * 2 + 1).unwrap()
+  std::num::NonZeroUsize::new(canvas_height as usize + 3_usize).unwrap()
 }
 
 impl Buffer {

--- a/rsvim_core/src/ui/widget/window/content.rs
+++ b/rsvim_core/src/ui/widget/window/content.rs
@@ -4,8 +4,8 @@ use crate::buf::{Buffer, BufferWk};
 use crate::prelude::*;
 use crate::ui::canvas::{Canvas, Cell};
 use crate::ui::tree::*;
-use crate::ui::widget::window::ViewportWk;
 use crate::ui::widget::Widgetable;
+use crate::ui::widget::window::ViewportWk;
 use crate::{inode_impl, rlock, wlock};
 
 use geo::point;

--- a/rsvim_core/src/ui/widget/window/content.rs
+++ b/rsvim_core/src/ui/widget/window/content.rs
@@ -4,8 +4,8 @@ use crate::buf::{Buffer, BufferWk};
 use crate::prelude::*;
 use crate::ui::canvas::{Canvas, Cell};
 use crate::ui::tree::*;
-use crate::ui::widget::Widgetable;
 use crate::ui::widget::window::ViewportWk;
+use crate::ui::widget::Widgetable;
 use crate::{inode_impl, rlock, wlock};
 
 use geo::point;
@@ -911,7 +911,7 @@ mod tests {
       " row of the  ",
       "window       ",
       "content      ",
-      "widget, 那么<",
+      "widget, 那么 ",
     ];
 
     let window_options = WindowLocalOptionsBuilder::default()
@@ -952,7 +952,7 @@ mod tests {
       "test lines",
       ".         ",
       "But still ",
-      "it contai<",
+      "it contai ",
     ];
 
     let window_options = WindowLocalOptionsBuilder::default()

--- a/rsvim_core/src/ui/widget/window/content.rs
+++ b/rsvim_core/src/ui/widget/window/content.rs
@@ -747,195 +747,221 @@ mod tests {
     do_test_draw_from_top_left(&actual, &expect);
   }
 
-  //#[test]
-  //fn draw_from_top_left_wrap_linebreak1() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello,    ",
-  //    "RSVIM!    ",
-  //    "This is a ",
-  //    "quite     ",
-  //    "simple and",
-  //    " small    ",
-  //    "test lines",
-  //    ".         ",
-  //    "But still ",
-  //    "it        ",
-  //  ];
-  //
-  //  let terminal_size = U16Size::new(10, 10);
-  //  let window_options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
-  //  do_test_draw_from_top_left(&actual, &expect);
-  //}
-  //
-  //#[test]
-  //fn draw_from_top_left_wrap_linebreak2() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, RSVIM!              ",
-  //    "This is a quite simple and ",
-  //    "small test lines.          ",
-  //    "But still it contains      ",
-  //    "several things we want to  ",
-  //    "test:                      ",
-  //    "  1. When the line is small",
-  //    " enough to completely put  ",
-  //    "inside a row of the window ",
-  //    "content widget, then the   ",
-  //    "line-wrap and word-wrap    ",
-  //    "doesn't affect the         ",
-  //    "rendering.                 ",
-  //    "  2. When the line is too  ",
-  //    "long to be completely put  ",
-  //  ];
-  //
-  //  let terminal_size = U16Size::new(27, 15);
-  //  let window_options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
-  //  do_test_draw_from_top_left(&actual, &expect);
-  //}
-  //
-  //#[test]
-  //fn draw_from_top_left_wrap_linebreak3() {
-  //  test_log_init();
-  //
-  //  let buffer = make_empty_buffer();
-  //  let expect = vec![
-  //    "                    ",
-  //    "                    ",
-  //    "                    ",
-  //    "                    ",
-  //    "                    ",
-  //    "                    ",
-  //    "                    ",
-  //    "                    ",
-  //  ];
-  //
-  //  let terminal_size = U16Size::new(20, 8);
-  //  let window_options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
-  //  do_test_draw_from_top_left(&actual, &expect);
-  //}
-  //
-  //#[test]
-  //fn draw_from_top_left_wrap_linebreak4() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, 那么行换行和单词换行选项都不会影响最终的渲染效果。\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, RSVIM!",
-  //    "             ",
-  //    "This is a    ",
-  //    "quite simple ",
-  //    "andsmalltestl",
-  //    "ineswithoutev",
-  //    "enanewlinebre",
-  //    "akbecausewewa",
-  //    "nttotesthowit",
-  //    "willhappensif",
-  //    "thereisaveryl",
-  //    "ongwordthatca",
-  //    "nnotbeenpplac",
-  //    "einsidearowof",
-  //    "thewindowcont",
-  //    "ent.         ",
-  //    "But still it ",
-  //    "contains     ",
-  //    "several      ",
-  //    "things we    ",
-  //    "want to test:",
-  //    "             ",
-  //    "  1. When the",
-  //    " line is     ",
-  //    "small enough ",
-  //    "to completely",
-  //    " put inside a",
-  //    " row of the  ",
-  //    "window       ",
-  //    "content      ",
-  //    "widget, 那么<",
-  //  ];
-  //
-  //  let terminal_size = U16Size::new(13, 31);
-  //  let window_options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
-  //  do_test_draw_from_top_left(&actual, &expect);
-  //}
-  //
-  //#[test]
-  //fn draw_from_top_left_wrap_linebreak5() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contai\tseveral things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello,    ",
-  //    "RSVIM!    ",
-  //    "This is a ",
-  //    "quite     ",
-  //    "simple and",
-  //    " small    ",
-  //    "test lines",
-  //    ".         ",
-  //    "But still ",
-  //    "it contai<",
-  //  ];
-  //
-  //  let terminal_size = U16Size::new(10, 10);
-  //  let window_options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
-  //  do_test_draw_from_top_left(&actual, &expect);
-  //}
+  #[test]
+  fn draw_from_top_left_wrap_linebreak1() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(10, 10);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+    let expect = vec![
+      "Hello,    ",
+      "RSVIM!    ",
+      "This is a ",
+      "quite     ",
+      "simple and",
+      " small    ",
+      "test lines",
+      ".         ",
+      "But still ",
+      "it        ",
+    ];
+
+    let window_options = WindowLocalOptionsBuilder::default()
+      .wrap(true)
+      .line_break(true)
+      .build()
+      .unwrap();
+    let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
+    do_test_draw_from_top_left(&actual, &expect);
+  }
+
+  #[test]
+  fn draw_from_top_left_wrap_linebreak2() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(27, 15);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+    let expect = vec![
+      "Hello, RSVIM!              ",
+      "This is a quite simple and ",
+      "small test lines.          ",
+      "But still it contains      ",
+      "several things we want to  ",
+      "test:                      ",
+      "  1. When the line is small",
+      " enough to completely put  ",
+      "inside a row of the window ",
+      "content widget, then the   ",
+      "line-wrap and word-wrap    ",
+      "doesn't affect the         ",
+      "rendering.                 ",
+      "  2. When the line is too  ",
+      "long to be completely put  ",
+    ];
+
+    let window_options = WindowLocalOptionsBuilder::default()
+      .wrap(true)
+      .line_break(true)
+      .build()
+      .unwrap();
+    let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
+    do_test_draw_from_top_left(&actual, &expect);
+  }
+
+  #[test]
+  fn draw_from_top_left_wrap_linebreak3() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(20, 8);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_empty_buffer(terminal_size.height(), buf_opts);
+    let expect = vec![
+      "                    ",
+      "                    ",
+      "                    ",
+      "                    ",
+      "                    ",
+      "                    ",
+      "                    ",
+      "                    ",
+    ];
+
+    let window_options = WindowLocalOptionsBuilder::default()
+      .wrap(true)
+      .line_break(true)
+      .build()
+      .unwrap();
+    let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
+    do_test_draw_from_top_left(&actual, &expect);
+  }
+
+  #[test]
+  fn draw_from_top_left_wrap_linebreak4() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(13, 31);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, 那么行换行和单词换行选项都不会影响最终的渲染效果。\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+    let expect = vec![
+      "Hello, RSVIM!",
+      "             ",
+      "This is a    ",
+      "quite simple ",
+      "andsmalltestl",
+      "ineswithoutev",
+      "enanewlinebre",
+      "akbecausewewa",
+      "nttotesthowit",
+      "willhappensif",
+      "thereisaveryl",
+      "ongwordthatca",
+      "nnotbeenpplac",
+      "einsidearowof",
+      "thewindowcont",
+      "ent.         ",
+      "But still it ",
+      "contains     ",
+      "several      ",
+      "things we    ",
+      "want to test:",
+      "             ",
+      "  1. When the",
+      " line is     ",
+      "small enough ",
+      "to completely",
+      " put inside a",
+      " row of the  ",
+      "window       ",
+      "content      ",
+      "widget, 那么<",
+    ];
+
+    let window_options = WindowLocalOptionsBuilder::default()
+      .wrap(true)
+      .line_break(true)
+      .build()
+      .unwrap();
+    let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
+    do_test_draw_from_top_left(&actual, &expect);
+  }
+
+  #[test]
+  fn draw_from_top_left_wrap_linebreak5() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(10, 10);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contai\tseveral things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+    let expect = vec![
+      "Hello,    ",
+      "RSVIM!    ",
+      "This is a ",
+      "quite     ",
+      "simple and",
+      " small    ",
+      "test lines",
+      ".         ",
+      "But still ",
+      "it contai<",
+    ];
+
+    let window_options = WindowLocalOptionsBuilder::default()
+      .wrap(true)
+      .line_break(true)
+      .build()
+      .unwrap();
+    let actual = make_window_content_drawn_canvas(terminal_size, window_options, buffer.clone());
+    do_test_draw_from_top_left(&actual, &expect);
+  }
 }
 // spellchecker:on

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1456,521 +1456,526 @@ mod tests {
     );
   }
 
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak1() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, ",
-  //    "RSVIM!\n",
-  //    "This is a ",
-  //    "quite ",
-  //    "simple and",
-  //    " small ",
-  //    "test lines",
-  //    ".\n",
-  //    "But still ",
-  //    "it ",
-  //  ];
-  //
-  //  let size = U16Size::new(10, 10);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    3,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak2() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-  //    "  2. When the line is to\to long to be completely p\tut in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and ",
-  //    "small test lines.\n",
-  //    "But still it contains ",
-  //    "several things we want to ",
-  //    "test:\n",
-  //    "  1. When the line is small",
-  //    " enough to completely put ",
-  //    "inside a row of the window ",
-  //    "content widget, then the ",
-  //    "line-wrap and word-wrap ",
-  //    "doesn't affect the ",
-  //    "rendering.\n",
-  //    "  2. When the line is to",
-  //    "\to long to be ",
-  //  ];
-  //
-  //  let size = U16Size::new(27, 15);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-  //    .into_iter()
-  //    .collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-  //    .into_iter()
-  //    .collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    5,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak3() {
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and ",
-  //    "small test lines.\n",
-  //    "But still it contains several ",
-  //    "things we want to test:\n",
-  //    "  1. When the line is small ",
-  //    "enough to completely put inside",
-  //    " a row of the window content ",
-  //    "widget, then the line-wrap and ",
-  //    "word-wrap doesn't affect the ",
-  //    "rendering.\n",
-  //    "",
-  //  ];
-  //
-  //  let size = U16Size::new(31, 11);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    4,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak4() {
-  //  test_log_init();
-  //
-  //  let buffer = make_empty_buffer();
-  //  let expect = vec![""];
-  //
-  //  let size = U16Size::new(10, 10);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_fills: BTreeMap<usize, usize> = vec![(0, 0)].into_iter().collect();
-  //  ensure_sync_from_top_left(buffer, &actual, &expect, 0, 1, &expect_fills, &expect_fills);
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak5() {
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and ",
-  //    "small test lines.\n",
-  //    "But still it contains several ",
-  //    "things we want to test:\n",
-  //    "  1. When the line is small ",
-  //    "enough to completely put inside",
-  //    " a row of the window content ",
-  //    "widget, then the line-wrap and ",
-  //    "word-wrap doesn't affect the ",
-  //  ];
-  //
-  //  let size = U16Size::new(31, 10);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    4,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak6() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
-  //    "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and ",
-  //    "small test lines.\n",
-  //    "But still it contains several ",
-  //    "things we want to test:\n",
-  //    "\t\t第一，当一行文",
-  //    "本内容的长度足够短，短到可以完",
-  //    "整的放入一个窗口（的一行）之中",
-  //    "，那么基于行的换行和基于单词的",
-  //    "换行两个选项都不会影响渲染的最",
-  //  ];
-  //
-  //  let size = U16Size::new(31, 10);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    4,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak7() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
-  //    "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and ",
-  //    "small test lines.\n",
-  //    "But still it contains several ",
-  //    "things we want to test:\n",
-  //    "\t\t第一，当一行文",
-  //    "本内容的长度足够短，短到可以完",
-  //    "整的放入一个窗口（的一行）之中",
-  //    "，那么基于行的换行和基于单词的",
-  //    "换行两个选项都不会影响渲染的最",
-  //    "终效果。\n",
-  //  ];
-  //
-  //  let size = U16Size::new(31, 11);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    4,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak8() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
-  //    "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple ",
-  //    "andsmalltestlineswithoutevenane",
-  //    "wlinebreakbecausewewanttotestho",
-  //    "witwillhappensifthereisaverylon",
-  //    "gwordthatcannotbeenpplaceinside",
-  //    "arowofthewindowcontent.\n",
-  //    "But still it contains several ",
-  //    "things we want to test:\n",
-  //    "\t\t第一，当一行文",
-  //    "本内容的长度足够短，短到可以完",
-  //  ];
-  //
-  //  let size = U16Size::new(31, 11);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    4,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak9() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, ",
-  //    "RSVIM!\n",
-  //    "This is a ",
-  //    "quite ",
-  //    "simple and",
-  //    " small ",
-  //    "test lines",
-  //    ".\n",
-  //    "But still ",
-  //    "it ",
-  //  ];
-  //
-  //  let size = U16Size::new(10, 10);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    3,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak10() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple and small test lines.\n",
-  //    "But still it contai\tseveral things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, ",
-  //    "RSVIM!\n",
-  //    "This is a ",
-  //    "quite ",
-  //    "simple and",
-  //    " small ",
-  //    "test lines",
-  //    ".\n",
-  //    "But still ",
-  //    "it contai",
-  //  ];
-  //
-  //  let size = U16Size::new(10, 10);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 1)].into_iter().collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    3,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
-  //
-  //#[test]
-  //fn sync_from_top_left_wrap_linebreak11() {
-  //  test_log_init();
-  //
-  //  let buffer = make_buffer_from_lines(vec![
-  //    "Hello, RSVIM!\n",
-  //    "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
-  //    "But still it contains several things we want to test:\n",
-  //    "  1. When the line is small enough to completely put inside a row of the window content widget, 那么行换行和单词换行选项都不会影响最终的渲染效果。\n",
-  //    "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-  //    "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-  //    "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-  //  ]);
-  //  let expect = vec![
-  //    "Hello, RSVIM!",
-  //    "\n",
-  //    "This is a ",
-  //    "quite simple ",
-  //    "andsmalltestl",
-  //    "ineswithoutev",
-  //    "enanewlinebre",
-  //    "akbecausewewa",
-  //    "nttotesthowit",
-  //    "willhappensif",
-  //    "thereisaveryl",
-  //    "ongwordthatca",
-  //    "nnotbeenpplac",
-  //    "einsidearowof",
-  //    "thewindowcont",
-  //    "ent.\n",
-  //    "But still it ",
-  //    "contains ",
-  //    "several ",
-  //    "things we ",
-  //    "want to test:",
-  //    "\n",
-  //    "  1. When the",
-  //    " line is ",
-  //    "small enough ",
-  //    "to completely",
-  //    " put inside a",
-  //    " row of the ",
-  //    "window ",
-  //    "content ",
-  //    "widget, 那么",
-  //    "行换行和单词",
-  //    "换行选项都不",
-  //  ];
-  //
-  //  let size = U16Size::new(13, 31);
-  //  let options = WindowLocalOptions::builder()
-  //    .wrap(true)
-  //    .line_break(true)
-  //    .build();
-  //  let actual = make_viewport_from_size(size, buffer.clone(), &options);
-  //  let expect_start_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-  //  let expect_end_fills: BTreeMap<usize, usize> =
-  //    vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
-  //  ensure_sync_from_top_left(
-  //    buffer,
-  //    &actual,
-  //    &expect,
-  //    0,
-  //    4,
-  //    &expect_start_fills,
-  //    &expect_end_fills,
-  //  );
-  //}
+  #[test]
+  fn sync_from_top_left_wrap_linebreak1() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(10, 10);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+    let expect = vec![
+      "Hello, ",
+      "RSVIM!\n",
+      "This is a ",
+      "quite ",
+      "simple and",
+      " small ",
+      "test lines",
+      ".\n",
+      "But still ",
+      "it ",
+    ];
+
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      3,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak2() {
+    test_log_init();
+
+    let buffer = make_buffer_from_lines(vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+      "  2. When the line is to\to long to be completely p\tut in a row of the window content widget, there're multiple cases:\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ]);
+    let expect = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and ",
+      "small test lines.\n",
+      "But still it contains ",
+      "several things we want to ",
+      "test:\n",
+      "  1. When the line is small",
+      " enough to completely put ",
+      "inside a row of the window ",
+      "content widget, then the ",
+      "line-wrap and word-wrap ",
+      "doesn't affect the ",
+      "rendering.\n",
+      "  2. When the line is to",
+      "\to long to be ",
+    ];
+
+    let size = U16Size::new(27, 15);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+      .into_iter()
+      .collect();
+    let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+      .into_iter()
+      .collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      5,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak3() {
+    let buffer = make_buffer_from_lines(vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ]);
+    let expect = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and ",
+      "small test lines.\n",
+      "But still it contains several ",
+      "things we want to test:\n",
+      "  1. When the line is small ",
+      "enough to completely put inside",
+      " a row of the window content ",
+      "widget, then the line-wrap and ",
+      "word-wrap doesn't affect the ",
+      "rendering.\n",
+      "",
+    ];
+
+    let size = U16Size::new(31, 11);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      4,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak4() {
+    test_log_init();
+
+    let buffer = make_empty_buffer();
+    let expect = vec![""];
+
+    let size = U16Size::new(10, 10);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_fills: BTreeMap<usize, usize> = vec![(0, 0)].into_iter().collect();
+    ensure_sync_from_top_left(buffer, &actual, &expect, 0, 1, &expect_fills, &expect_fills);
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak5() {
+    let buffer = make_buffer_from_lines(vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ]);
+    let expect = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and ",
+      "small test lines.\n",
+      "But still it contains several ",
+      "things we want to test:\n",
+      "  1. When the line is small ",
+      "enough to completely put inside",
+      " a row of the window content ",
+      "widget, then the line-wrap and ",
+      "word-wrap doesn't affect the ",
+    ];
+
+    let size = U16Size::new(31, 10);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      4,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak6() {
+    test_log_init();
+
+    let buffer = make_buffer_from_lines(vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
+      "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ]);
+    let expect = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and ",
+      "small test lines.\n",
+      "But still it contains several ",
+      "things we want to test:\n",
+      "\t\t第一，当一行文",
+      "本内容的长度足够短，短到可以完",
+      "整的放入一个窗口（的一行）之中",
+      "，那么基于行的换行和基于单词的",
+      "换行两个选项都不会影响渲染的最",
+    ];
+
+    let size = U16Size::new(31, 10);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      4,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak7() {
+    test_log_init();
+
+    let buffer = make_buffer_from_lines(vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
+      "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ]);
+    let expect = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and ",
+      "small test lines.\n",
+      "But still it contains several ",
+      "things we want to test:\n",
+      "\t\t第一，当一行文",
+      "本内容的长度足够短，短到可以完",
+      "整的放入一个窗口（的一行）之中",
+      "，那么基于行的换行和基于单词的",
+      "换行两个选项都不会影响渲染的最",
+      "终效果。\n",
+    ];
+
+    let size = U16Size::new(31, 11);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      4,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak8() {
+    test_log_init();
+
+    let buffer = make_buffer_from_lines(vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
+      "But still it contains several things we want to test:\n",
+      "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
+      "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ]);
+    let expect = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple ",
+      "andsmalltestlineswithoutevenane",
+      "wlinebreakbecausewewanttotestho",
+      "witwillhappensifthereisaverylon",
+      "gwordthatcannotbeenpplaceinside",
+      "arowofthewindowcontent.\n",
+      "But still it contains several ",
+      "things we want to test:\n",
+      "\t\t第一，当一行文",
+      "本内容的长度足够短，短到可以完",
+    ];
+
+    let size = U16Size::new(31, 11);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      4,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak9() {
+    test_log_init();
+
+    let buffer = make_buffer_from_lines(vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ]);
+    let expect = vec![
+      "Hello, ",
+      "RSVIM!\n",
+      "This is a ",
+      "quite ",
+      "simple and",
+      " small ",
+      "test lines",
+      ".\n",
+      "But still ",
+      "it ",
+    ];
+
+    let size = U16Size::new(10, 10);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      3,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak10() {
+    test_log_init();
+
+    let buffer = make_buffer_from_lines(vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contai\tseveral things we want to test:\n",
+      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ]);
+    let expect = vec![
+      "Hello, ",
+      "RSVIM!\n",
+      "This is a ",
+      "quite ",
+      "simple and",
+      " small ",
+      "test lines",
+      ".\n",
+      "But still ",
+      "it contai",
+    ];
+
+    let size = U16Size::new(10, 10);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 1)].into_iter().collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      3,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak11() {
+    test_log_init();
+
+    let buffer = make_buffer_from_lines(vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside a row of the window content widget, 那么行换行和单词换行选项都不会影响最终的渲染效果。\n",
+      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ]);
+    let expect = vec![
+      "Hello, RSVIM!",
+      "\n",
+      "This is a ",
+      "quite simple ",
+      "andsmalltestl",
+      "ineswithoutev",
+      "enanewlinebre",
+      "akbecausewewa",
+      "nttotesthowit",
+      "willhappensif",
+      "thereisaveryl",
+      "ongwordthatca",
+      "nnotbeenpplac",
+      "einsidearowof",
+      "thewindowcont",
+      "ent.\n",
+      "But still it ",
+      "contains ",
+      "several ",
+      "things we ",
+      "want to test:",
+      "\n",
+      "  1. When the",
+      " line is ",
+      "small enough ",
+      "to completely",
+      " put inside a",
+      " row of the ",
+      "window ",
+      "content ",
+      "widget, 那么",
+      "行换行和单词",
+      "换行选项都不",
+    ];
+
+    let size = U16Size::new(13, 31);
+    let options = WindowLocalOptions::builder()
+      .wrap(true)
+      .line_break(true)
+      .build();
+    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
+    ensure_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      4,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
 }
 // spellchecker:on

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1843,7 +1843,7 @@ mod tests {
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
-      vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     assert_sync_from_top_left(
       buffer,
       &actual,
@@ -2025,7 +2025,7 @@ mod tests {
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
-      vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     assert_sync_from_top_left(
       buffer,
       &actual,
@@ -2084,10 +2084,10 @@ mod tests {
       "small enough ",
       "to completely",
       " put inside a",
-      " row of the  ",
+      " row of the ",
       "window ",
       "content ",
-      "widget, 那么<",
+      "widget, 那么",
     ];
 
     let options = WindowLocalOptionsBuilder::default()
@@ -2099,7 +2099,7 @@ mod tests {
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
-      vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     assert_sync_from_top_left(
       buffer,
       &actual,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1965,15 +1965,21 @@ mod tests {
   fn sync_from_top_left_wrap_linebreak11() {
     test_log_init();
 
-    let buffer = make_buffer_from_lines(vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
-      "But still it contains several things we want to test:\n",
-      "  1. When the line is small enough to completely put inside a row of the window content widget, 那么行换行和单词换行选项都不会影响最终的渲染效果。\n",
-      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-    ]);
+    let terminal_size = U16Size::new(13, 31);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, 那么行换行和单词换行选项都不会影响最终的渲染效果。\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
     let expect = vec![
       "Hello, RSVIM!",
       "\n",
@@ -2010,17 +2016,17 @@ mod tests {
       "换行选项都不",
     ];
 
-    let size = U16Size::new(13, 31);
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1571,15 +1571,23 @@ mod tests {
 
   #[test]
   fn sync_from_top_left_wrap_linebreak3() {
-    let buffer = make_buffer_from_lines(vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple and small test lines.\n",
-      "But still it contains several things we want to test:\n",
-      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-    ]);
+    test_log_init();
+
+    let terminal_size = U16Size::new(27, 15);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
     let expect = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and ",

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1603,17 +1603,17 @@ mod tests {
       "",
     ];
 
-    let size = U16Size::new(31, 11);
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1573,7 +1573,7 @@ mod tests {
   fn sync_from_top_left_wrap_linebreak3() {
     test_log_init();
 
-    let terminal_size = U16Size::new(27, 15);
+    let terminal_size = U16Size::new(31, 11);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
     let buffer = make_buffer_from_lines(
       terminal_size.height(),
@@ -1673,16 +1673,17 @@ mod tests {
       "word-wrap doesn't affect the ",
     ];
 
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
+      .build()
+      .unwrap();
     let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,
@@ -1697,15 +1698,21 @@ mod tests {
   fn sync_from_top_left_wrap_linebreak6() {
     test_log_init();
 
-    let buffer = make_buffer_from_lines(vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple and small test lines.\n",
-      "But still it contains several things we want to test:\n",
-      "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
-      "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-    ]);
+    let terminal_size = U16Size::new(31, 10);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
+        "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
     let expect = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and ",
@@ -1719,17 +1726,17 @@ mod tests {
       "换行两个选项都不会影响渲染的最",
     ];
 
-    let size = U16Size::new(31, 10);
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,
@@ -1744,15 +1751,21 @@ mod tests {
   fn sync_from_top_left_wrap_linebreak7() {
     test_log_init();
 
-    let buffer = make_buffer_from_lines(vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple and small test lines.\n",
-      "But still it contains several things we want to test:\n",
-      "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
-      "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-    ]);
+    let terminal_size = U16Size::new(31, 11);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
+        "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
     let expect = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and ",
@@ -1767,17 +1780,17 @@ mod tests {
       "终效果。\n",
     ];
 
-    let size = U16Size::new(31, 11);
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,
@@ -1792,15 +1805,21 @@ mod tests {
   fn sync_from_top_left_wrap_linebreak8() {
     test_log_init();
 
-    let buffer = make_buffer_from_lines(vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
-      "But still it contains several things we want to test:\n",
-      "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
-      "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-    ]);
+    let terminal_size = U16Size::new(31, 11);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
+        "But still it contains several things we want to test:\n",
+        "\t\t第一，当一行文本内容的长度足够短，短到可以完整的放入一个窗口（的一行）之中，那么基于行的换行和基于单词的换行两个选项都不会影响渲染的最终效果。\n",
+        "\t\t第二，当一行内容文本的长度足够长，而无法放入窗口中，那么我们需要考虑很多种情况：\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
     let expect = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple ",
@@ -1815,12 +1834,12 @@ mod tests {
       "本内容的长度足够短，短到可以完",
     ];
 
-    let size = U16Size::new(31, 11);
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1488,16 +1488,17 @@ mod tests {
       "it ",
     ];
 
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,
@@ -1512,15 +1513,21 @@ mod tests {
   fn sync_from_top_left_wrap_linebreak2() {
     test_log_init();
 
-    let buffer = make_buffer_from_lines(vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple and small test lines.\n",
-      "But still it contains several things we want to test:\n",
-      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-      "  2. When the line is to\to long to be completely p\tut in a row of the window content widget, there're multiple cases:\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-    ]);
+    let terminal_size = U16Size::new(27, 15);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+        "  2. When the line is to\to long to be completely p\tut in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
     let expect = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and ",
@@ -1539,19 +1546,19 @@ mod tests {
       "\to long to be ",
     ];
 
-    let size = U16Size::new(27, 15);
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
       .into_iter()
       .collect();
     let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
       .into_iter()
       .collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -2036,5 +2036,79 @@ mod tests {
       &expect_end_fills,
     );
   }
+
+  #[test]
+  fn sync_from_top_left_wrap_linebreak12() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(13, 31);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple andsmalltestlineswithoutevenanewlinebreakbecausewewanttotesthowitwillhappensifthereisaverylongwordthatcannotbeenpplaceinsidearowofthewindowcontent.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, 那么行换行和单词换行选项都不会影响最终的渲染效果。\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+    let expect = vec![
+      "Hello, RSVIM!",
+      "\n",
+      "This is a ",
+      "quite simple ",
+      "andsmalltestl",
+      "ineswithoutev",
+      "enanewlinebre",
+      "akbecausewewa",
+      "nttotesthowit",
+      "willhappensif",
+      "thereisaveryl",
+      "ongwordthatca",
+      "nnotbeenpplac",
+      "einsidearowof",
+      "thewindowcont",
+      "ent.\n",
+      "But still it ",
+      "contains ",
+      "several ",
+      "things we ",
+      "want to test:",
+      "\n",
+      "  1. When the",
+      " line is ",
+      "small enough ",
+      "to completely",
+      " put inside a",
+      " row of the  ",
+      "window ",
+      "content ",
+      "widget, 那么<",
+    ];
+
+    let options = WindowLocalOptionsBuilder::default()
+      .wrap(true)
+      .line_break(true)
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
+    let expect_start_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+    let expect_end_fills: BTreeMap<usize, usize> =
+      vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
+    assert_sync_from_top_left(
+      buffer,
+      &actual,
+      &expect,
+      0,
+      4,
+      &expect_start_fills,
+      &expect_end_fills,
+    );
+  }
 }
 // spellchecker:on

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1628,30 +1628,38 @@ mod tests {
   fn sync_from_top_left_wrap_linebreak4() {
     test_log_init();
 
-    let buffer = make_empty_buffer();
+    let terminal_size = U16Size::new(10, 10);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_empty_buffer(terminal_size.height(), buf_opts);
     let expect = vec![""];
 
-    let size = U16Size::new(10, 10);
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_fills: BTreeMap<usize, usize> = vec![(0, 0)].into_iter().collect();
-    ensure_sync_from_top_left(buffer, &actual, &expect, 0, 1, &expect_fills, &expect_fills);
+    assert_sync_from_top_left(buffer, &actual, &expect, 0, 1, &expect_fills, &expect_fills);
   }
 
   #[test]
   fn sync_from_top_left_wrap_linebreak5() {
-    let buffer = make_buffer_from_lines(vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple and small test lines.\n",
-      "But still it contains several things we want to test:\n",
-      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-    ]);
+    let terminal_size = U16Size::new(31, 10);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
     let expect = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and ",
@@ -1665,12 +1673,11 @@ mod tests {
       "word-wrap doesn't affect the ",
     ];
 
-    let size = U16Size::new(31, 10);
     let options = WindowLocalOptions::builder()
       .wrap(true)
       .line_break(true)
       .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1844,7 +1844,7 @@ mod tests {
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,
@@ -1859,15 +1859,21 @@ mod tests {
   fn sync_from_top_left_wrap_linebreak9() {
     test_log_init();
 
-    let buffer = make_buffer_from_lines(vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple and small test lines.\n",
-      "But still it contains several things we want to test:\n",
-      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-    ]);
+    let terminal_size = U16Size::new(10, 10);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
     let expect = vec![
       "Hello, ",
       "RSVIM!\n",
@@ -1881,17 +1887,17 @@ mod tests {
       "it ",
     ];
 
-    let size = U16Size::new(10, 10);
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,
@@ -1906,15 +1912,21 @@ mod tests {
   fn sync_from_top_left_wrap_linebreak10() {
     test_log_init();
 
-    let buffer = make_buffer_from_lines(vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple and small test lines.\n",
-      "But still it contai\tseveral things we want to test:\n",
-      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-    ]);
+    let terminal_size = U16Size::new(10, 10);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buffer = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contai\tseveral things we want to test:\n",
+        "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+        "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+        "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+        "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
     let expect = vec![
       "Hello, ",
       "RSVIM!\n",
@@ -1928,17 +1940,17 @@ mod tests {
       "it contai",
     ];
 
-    let size = U16Size::new(10, 10);
-    let options = WindowLocalOptions::builder()
+    let options = WindowLocalOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
-      .build();
-    let actual = make_viewport_from_size(size, buffer.clone(), &options);
+      .build()
+      .unwrap();
+    let actual = make_viewport_from_size(terminal_size, buffer.clone(), &options);
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 1)].into_iter().collect();
-    ensure_sync_from_top_left(
+    assert_sync_from_top_left(
       buffer,
       &actual,
       &expect,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -1735,7 +1735,7 @@ mod tests {
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
-      vec![(0, 0), (1, 0), (2, 0), (3, 1)].into_iter().collect();
+      vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
     assert_sync_from_top_left(
       buffer,
       &actual,
@@ -1949,7 +1949,7 @@ mod tests {
     let expect_start_fills: BTreeMap<usize, usize> =
       vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
     let expect_end_fills: BTreeMap<usize, usize> =
-      vec![(0, 0), (1, 0), (2, 1)].into_iter().collect();
+      vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
     assert_sync_from_top_left(
       buffer,
       &actual,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -369,7 +369,7 @@ fn _from_top_left_wrap_nolinebreak(
 /// Returns the word index which contains this char, and whether the char is the last char in the
 /// word.
 fn find_word_by_char(
-  words: &Vec<&str>,
+  words: &[&str],
   word_end_chars_index: &HashMap<usize, usize>,
   char_idx: usize,
 ) -> (usize, usize, usize) {
@@ -398,12 +398,13 @@ fn find_word_by_char(
   unreachable!()
 }
 
+#[allow(clippy::too_many_arguments)]
 /// Part-1 of the processing algorithm in `_from_top_left_wrap_linebreak`.
-unsafe fn part1<'a>(
-  words: &Vec<&str>,
+unsafe fn part1(
+  words: &[&str],
   words_end_char_idx: &HashMap<usize, usize>,
   mut raw_buffer: NonNull<Buffer>,
-  bline: &ropey::RopeSlice<'a>,
+  bline: &ropey::RopeSlice<'_>,
   l: usize,
   c: usize,
   end_width: usize,
@@ -534,8 +535,7 @@ fn _from_top_left_wrap_linebreak(
               .iter()
               .enumerate()
               .scan(0_usize, |state, (i, wd)| {
-                let wd_chars = wd.chars().count();
-                *state = *state + wd_chars;
+                *state += wd.chars().count();
                 Some((i, *state))
               })
               .collect::<HashMap<usize, usize>>();

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -10,8 +10,9 @@ use ropey::RopeSlice;
 use std::collections::BTreeMap;
 use std::ops::Range;
 use std::ptr::NonNull;
-// use tracing::trace;
-// use unicode_segmentation::UnicodeSegmentation;
+#[allow(unused_imports)]
+use tracing::trace;
+use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 /// Lines index inside the viewport.
@@ -69,8 +70,7 @@ pub fn from_top_left(
       _from_top_left_wrap_nolinebreak(options, buffer, actual_shape, start_line, start_dcolumn)
     }
     (true, true) => {
-      unimplemented!();
-      //_from_top_left_wrap_linebreak(options, buffer, actual_shape, start_line, start_dcolumn)
+      _from_top_left_wrap_linebreak(options, buffer, actual_shape, start_line, start_dcolumn)
     }
   }
 }
@@ -85,7 +85,7 @@ fn slice2line(s: &RopeSlice) -> String {
 }
 
 #[allow(unused_variables, clippy::explicit_counter_loop)]
-// Implement [`from_top_left`] with option `wrap=false`.
+/// Implements [`from_top_left`] with option `wrap=false`.
 fn _from_top_left_nowrap(
   _options: &ViewportOptions,
   buffer: BufferWk,
@@ -209,7 +209,7 @@ fn _from_top_left_nowrap(
 }
 
 #[allow(unused_variables)]
-// Implement [`from_top_left`] with option `wrap=true` and `line-break=false`.
+/// Implements [`from_top_left`] with option `wrap=true` and `line-break=false`.
 fn _from_top_left_wrap_nolinebreak(
   _options: &ViewportOptions,
   buffer: BufferWk,
@@ -364,612 +364,612 @@ fn _from_top_left_wrap_nolinebreak(
   }
 }
 
-//#[allow(unused_variables)]
-// // Implement [`from_top_left`] with option `wrap=true` and `line-break=true`.
-//fn _from_top_left_wrap_linebreak(
-//  _options: &ViewportOptions,
-//  buffer: BufferWk,
-//  actual_shape: &U16Rect,
-//  start_line: usize,
-//  start_dcol_on_line: usize,
-//) -> (ViewportLineRange, BTreeMap<usize, LineViewport>) {
-//  let height = actual_shape.height();
-//  let width = actual_shape.width();
-//
-//  // trace!(
-//  //   "_collect_from_top_left_with_wrap_linebreak, actual_shape:{:?}, height/width:{:?}/{:?}",
-//  //   actual_shape,
-//  //   height,
-//  //   width
-//  // );
-//
-//  // Get buffer arc pointer, and lock for read.
-//  let buffer = buffer.upgrade().unwrap();
-//  let mut buffer = wlock!(buffer);
-//
-//  unsafe {
-//    // Fix mutable borrow on `buffer`.
-//    let mut raw_buffer = NonNull::new(&mut *buffer as *mut Buffer).unwrap();
-//
-//    // trace!(
-//    //   "buffer.get_line ({:?}):'{:?}'",
-//    //   start_line,
-//    //   match buffer.get_line(start_line) {
-//    //     Some(line) => slice2line(&line),
-//    //     None => "None".to_string(),
-//    //   }
-//    // );
-//
-//    let mut line_viewports: BTreeMap<usize, LineViewport> = BTreeMap::new();
-//
-//    match buffer.get_lines_at(start_line) {
-//      Some(buflines) => {
-//        // The `start_line` is inside the buffer.
-//
-//        // The first `wrow` in the window maps to the `start_line` in the buffer.
-//        let mut wrow = 0;
-//        let mut current_line = start_line;
-//
-//        for (l, bline) in buflines.enumerate() {
-//          // Current row goes out of viewport.
-//          if wrow >= height {
-//            break;
-//          }
-//
-//          let (rows, start_fills, end_fills) = if bline.len_chars() == 0 {
-//            let mut rows: BTreeMap<u16, RowViewport> = BTreeMap::new();
-//            rows.insert(wrow, RowViewport::new(0..0));
-//            (rows, 0_usize, 0_usize)
-//          } else {
-//            let mut rows: BTreeMap<u16, RowViewport> = BTreeMap::new();
-//
-//            // Here we clone the line with the max chars that can hold by current window/viewport,
-//            // i.e. the `height * width` cells count as the max chars in the line. This helps avoid
-//            // performance issue when iterating on super long lines.
-//            let cloned_line = raw_buffer.as_ref().clone_line(
-//              l,
-//              0,
-//              height as usize * width as usize * 2 + 16 + start_dcol_on_line,
-//            );
-//
-//            if cloned_line.is_none() {
-//              rows.insert(wrow, RowViewport::new(0..0));
-//              return (rows, 0_usize, 0_usize);
-//            }
-//
-//            let cloned_line = cloned_line.unwrap();
-//            let word_boundaries: Vec<&str> = cloned_line.split_word_bounds().collect();
-//
-//            let mut start_c = match raw_buffer.as_mut().char_until(l, start_dcol_on_line) {
-//              Some(c) => c,
-//              None => 0_usize,
-//            };
-//            let start_fills = {
-//              let start_width_until = raw_buffer.as_mut().width_before(l, start_c);
-//              start_width_until - start_dcol_on_line
-//            };
-//
-//            let mut end_dcol = start_dcol_on_line + width as usize;
-//            let mut end_c: Option<usize> = None;
-//            let mut eol = false;
-//            while wrow < height && !eol {
-//              end_c = match raw_buffer.as_mut().char_after(l, end_dcol) {
-//                Some(c) => Some(c),
-//                None => {
-//                  eol = true;
-//                  Some(raw_buffer.as_mut().last_char(l).unwrap())
-//                }
-//              };
-//              rows.insert(wrow, RowViewport::new(start_c..end_c.unwrap()));
-//              wrow += 1;
-//              start_c = end_c.unwrap();
-//              end_dcol = end_dcol + width as usize;
-//            }
-//            let end_fills = {
-//              let end_width_until = raw_buffer.as_mut().width_until(l, end_c.unwrap());
-//              if end_width_until >= end_dcol {
-//                end_width_until - end_dcol
-//              } else {
-//                0_usize
-//              }
-//            };
-//
-//            (rows, start_fills, end_fills)
-//          };
-//
-//          let mut rows: BTreeMap<u16, RowViewport> = BTreeMap::new();
-//          let mut wcol = 0_u16;
-//
-//          let mut bchars = 0_usize;
-//          let mut dcol = 0_usize;
-//          let mut start_dcol = 0_usize;
-//          let mut end_dcol = 0_usize;
-//
-//          let mut start_c_idx = 0_usize;
-//          let mut end_c_idx = 0_usize;
-//          let mut start_c_idx_init = false;
-//          let mut _end_c_idx_init = false;
-//
-//          let mut ch2dcols: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
-//
-//          let mut start_fills = 0_usize;
-//          let mut end_fills = 0_usize;
-//
-//          // Chop the line into maximum chars can hold by current window, thus avoid those super
-//          // long lines for iteration performance.
-//          // NOTE: Use `height * width * 4` simply for a much bigger size for the total characters in
-//          // a viewport.
-//          let truncated_line = truncate_line(
-//            &bline,
-//            start_dcol_on_line,
-//            height as usize * width as usize * 2 + height as usize * 2 + 16,
-//          );
-//          let word_boundaries: Vec<&str> = truncated_line.split_word_bounds().collect();
-//          // trace!(
-//          //   "0-truncated_line: {:?}, word_boundaries: {:?}, wrow/wcol:{}/{}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
-//          //   truncated_line, word_boundaries, wrow, wcol, dcol, start_dcol, end_dcol, start_c_idx, end_c_idx, start_fills, end_fills
-//          // );
-//
-//          for (i, wd) in word_boundaries.iter().enumerate() {
-//            let (wd_chars, wd_width) = wd.chars().map(|c| (1_usize, buffer.char_width(c))).fold(
-//              (0_usize, 0_usize),
-//              |(init_chars, init_width), (count, width)| (init_chars + count, init_width + width),
-//            );
-//
-//            // trace!(
-//            //   "1-l:{:?}, line:'{:?}', current_line:{:?}, i:{}, wd:{:?}",
-//            //   l,
-//            //   slice2line(&line),
-//            //   current_line,
-//            //   i,
-//            //   wd
-//            // );
-//
-//            // Prefix width is still before `start_dcolumn`.
-//            if dcol + wd_width < start_dcol_on_line {
-//              dcol += wd_width;
-//              bchars += wd_chars;
-//              end_dcol = dcol;
-//              end_c_idx = bchars;
-//              // trace!(
-//              //   "2-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, start_dcolumn:{}",
-//              //   wrow,
-//              //   wcol,
-//              //   dcol,
-//              //   start_dcol,
-//              //   end_dcol,
-//              //   bchars,
-//              //   start_c_idx,
-//              //   end_c_idx,
-//              //   start_fills,
-//              //   end_fills,
-//              //   wd_chars,
-//              //   wd_width,
-//              //   start_dcolumn
-//              // );
-//              continue;
-//            }
-//
-//            if !start_c_idx_init {
-//              start_c_idx_init = true;
-//              start_dcol = dcol;
-//              start_c_idx = bchars;
-//              start_fills = dcol - start_dcol_on_line;
-//              // trace!(
-//              //   "3-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
-//              //   wrow,
-//              //   wcol,
-//              //   dcol,
-//              //   start_dcol,
-//              //   end_dcol,
-//              //   bchars,
-//              //   start_c_idx,
-//              //   end_c_idx,
-//              //   start_fills,
-//              //   end_fills,
-//              //   wd_chars,
-//              //   wd_width
-//              // );
-//            }
-//
-//            // Row column with next char will goes out of the row.
-//            // i.e. there's not enough space to place this word in current row.
-//            // There're two cases:
-//            // 1. The word can be placed in next empty row, i.e. the word length is less or equal to
-//            //    the row length of the viewport.
-//            // 2. The word is too long to place in an entire row, i.e. the word length is greater
-//            //    than the row length of the viewport.
-//            // Anyway, we simply go to next row and force render all of the word. If the word is too
-//            // long to place in an entire row, it fallbacks back to the same behavior with
-//            // 'line-break' option is `false`.
-//            if wcol as usize + wd_width > width as usize {
-//              // trace!(
-//              //   "4.1-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-//              //   wrow,
-//              //   wcol,
-//              //   dcol,
-//              //   start_dcol,
-//              //   end_dcol,
-//              //   bchars,
-//              //   start_c_idx,
-//              //   end_c_idx,
-//              //   start_fills,
-//              //   end_fills,
-//              //   wd_chars,
-//              //   wd_width,
-//              //   width
-//              // );
-//
-//              // If it happens this word starts from the beginning of the row, then we don't need to
-//              // start from the next row. Because this is an empty of entire row.
-//              // If this word starts in the middle of the row, then we will have to start a new row.
-//              if wcol > 0 {
-//                rows.insert(
-//                  wrow,
-//                  RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-//                );
-//
-//                // NOTE: The `end_fills` only indicates the cells at the end of the bottom row in the
-//                // viewport cannot show the full unicode character for those ASCII control codes or
-//                // other unicodes such as CJK languages.
-//                // But for word-wrap rendering, i.e. `line-break` option is `true`, sometimes the whole
-//                // word display length is out of the end of the row and it will not be displayed (and
-//                // in such case, we don't set `end_fills` for it).
-//                // So, here we need to detect the real end fills position for the word.
-//
-//                let saved_end_fills = {
-//                  let mut tmp_wcol = wcol;
-//                  for c in wd.chars() {
-//                    let c_width = buffer.char_width(c);
-//
-//                    // Column with next char will goes out of the row.
-//                    if tmp_wcol as usize + c_width > width as usize {
-//                      break;
-//                    }
-//                    tmp_wcol += c_width as u16;
-//                    // Column already meets the end of the row.
-//                    if tmp_wcol >= width {
-//                      break;
-//                    }
-//                  }
-//                  //   trace!(
-//                  //   "4.2-wrow/wcol/tmp_wcol:{}/{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-//                  //   wrow,
-//                  //   wcol,
-//                  //   tmp_wcol,
-//                  //   dcol,
-//                  //   start_dcol,
-//                  //   end_dcol,
-//                  //   bchars,
-//                  //   start_c_idx,
-//                  //   end_c_idx,
-//                  //   start_fills,
-//                  //   end_fills,
-//                  //   wd_chars,
-//                  //   wd_width,
-//                  //   width
-//                  // );
-//                  width - tmp_wcol
-//                };
-//
-//                wrow += 1;
-//                wcol = 0_u16;
-//                start_dcol = end_dcol;
-//                start_c_idx = bchars;
-//                ch2dcols.clear();
-//
-//                if wrow >= height {
-//                  end_fills = saved_end_fills as usize;
-//                  //   trace!(
-//                  //   "5-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
-//                  //   wrow,
-//                  //   wcol,
-//                  //   dcol,
-//                  //   start_dcol,
-//                  //   end_dcol,
-//                  //   bchars,
-//                  //   start_c_idx,
-//                  //   end_c_idx,
-//                  //   start_fills,
-//                  //   end_fills,
-//                  //   wd_chars,
-//                  //   wd_width,
-//                  //   height
-//                  // );
-//                  break;
-//                }
-//              }
-//
-//              for (j, c) in wd.chars().enumerate() {
-//                let c_width = buffer.char_width(c);
-//
-//                // Column with next char will goes out of the row.
-//                if wcol as usize + c_width > width as usize {
-//                  // trace!(
-//                  //   "6-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-//                  //   wrow,
-//                  //   wcol,
-//                  //   dcol,
-//                  //   start_dcol,
-//                  //   end_dcol,
-//                  //   bchars,
-//                  //   j,
-//                  //   c,
-//                  //   start_c_idx,
-//                  //   end_c_idx,
-//                  //   start_fills,
-//                  //   end_fills,
-//                  //   wd_chars,
-//                  //   wd_width,
-//                  //   width
-//                  // );
-//                  rows.insert(
-//                    wrow,
-//                    RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-//                  );
-//
-//                  let saved_end_fills = width as usize - wcol as usize;
-//                  if j > 0 {
-//                    wrow += 1;
-//                  }
-//                  wcol = 0_u16;
-//                  start_dcol = end_dcol;
-//                  start_c_idx = bchars;
-//                  ch2dcols.clear();
-//
-//                  if wrow >= height {
-//                    end_fills = saved_end_fills;
-//                    // trace!(
-//                    //   "7-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
-//                    //   wrow,
-//                    //   wcol,
-//                    //   dcol,
-//                    //   start_dcol,
-//                    //   end_dcol,
-//                    //   bchars,
-//                    //   j,
-//                    //   c,
-//                    //   start_c_idx,
-//                    //   end_c_idx,
-//                    //   start_fills,
-//                    //   end_fills,
-//                    //   wd_chars,
-//                    //   wd_width,
-//                    //   height
-//                    // );
-//                    break;
-//                  }
-//                }
-//
-//                let saved_c_idx = bchars;
-//                let saved_start_dcol = dcol;
-//
-//                dcol += c_width;
-//                bchars += 1;
-//                end_dcol = dcol;
-//                end_c_idx = bchars;
-//                wcol += c_width as u16;
-//
-//                ch2dcols.insert(saved_c_idx, (saved_start_dcol, end_dcol));
-//
-//                // trace!(
-//                //   "8-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
-//                //   wrow,
-//                //   wcol,
-//                //   dcol,
-//                //   start_dcol,
-//                //   end_dcol,
-//                //   bchars,
-//                //   j,
-//                //   c,
-//                //   start_c_idx,
-//                //   end_c_idx,
-//                //   start_fills,
-//                //   end_fills,
-//                //   wd_chars,
-//                //   wd_width
-//                // );
-//
-//                // Column goes out of current row.
-//                if wcol >= width {
-//                  // trace!(
-//                  //   "9-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-//                  //   wrow,
-//                  //   wcol,
-//                  //   dcol,
-//                  //   start_dcol,
-//                  //   end_dcol,
-//                  //   bchars,
-//                  //   j,
-//                  //   c,
-//                  //   start_c_idx,
-//                  //   end_c_idx,
-//                  //   start_fills,
-//                  //   end_fills,
-//                  //   wd_chars,
-//                  //   wd_width,
-//                  //   width
-//                  // );
-//                  rows.insert(
-//                    wrow,
-//                    RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-//                  );
-//                  assert_eq!(wcol, width);
-//                  wrow += 1;
-//                  wcol = 0_u16;
-//                  start_dcol = end_dcol;
-//                  start_c_idx = end_c_idx;
-//                  ch2dcols.clear();
-//
-//                  if wrow >= height {
-//                    // trace!(
-//                    //   "10-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
-//                    //   wrow,
-//                    //   wcol,
-//                    //   dcol,
-//                    //   start_dcol,
-//                    //   end_dcol,
-//                    //   bchars,
-//                    //   j,
-//                    //   c,
-//                    //   start_c_idx,
-//                    //   end_c_idx,
-//                    //   start_fills,
-//                    //   end_fills,
-//                    //   wd_chars,
-//                    //   wd_width,
-//                    //   height
-//                    // );
-//                    break;
-//                  }
-//                }
-//              }
-//            } else {
-//              // Enough space to place this word in current row
-//              let saved_c_idx = bchars;
-//              let saved_start_dcol = dcol;
-//
-//              dcol += wd_width;
-//              bchars += wd_chars;
-//              end_dcol = dcol;
-//              end_c_idx = bchars;
-//              wcol += wd_width as u16;
-//
-//              let mut tmp_start_dcol = saved_start_dcol;
-//              for (k, c) in wd.chars().enumerate() {
-//                let c_width = buffer.char_width(c);
-//                let tmp_end_dcol = tmp_start_dcol + c_width;
-//                ch2dcols.insert(saved_c_idx + k, (tmp_start_dcol, tmp_end_dcol));
-//                tmp_start_dcol = tmp_end_dcol;
-//              }
-//            }
-//
-//            // trace!(
-//            //   "9-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
-//            //   wrow,
-//            //   wcol,
-//            //   dcol,
-//            //   start_dcol,
-//            //   end_dcol,
-//            //   bchars,
-//            //   start_c_idx,
-//            //   end_c_idx,
-//            //   start_fills,
-//            //   end_fills,
-//            //   wd_chars,
-//            //   wd_width
-//            // );
-//
-//            // End of the line.
-//            if i + 1 == word_boundaries.len() {
-//              // trace!(
-//              //   "10-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
-//              //   wrow,
-//              //   wcol,
-//              //   dcol,
-//              //   start_dcol,
-//              //   end_dcol,
-//              //   bchars,
-//              //   start_c_idx,
-//              //   end_c_idx,
-//              //   start_fills,
-//              //   end_fills,
-//              //   wd_chars,
-//              //   wd_width
-//              // );
-//              rows.insert(
-//                wrow,
-//                RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-//              );
-//              break;
-//            }
-//
-//            // Column goes out of current row.
-//            if wcol >= width {
-//              // trace!(
-//              //   "11-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-//              //   wrow,
-//              //   wcol,
-//              //   dcol,
-//              //   start_dcol,
-//              //   end_dcol,
-//              //   bchars,
-//              //   start_c_idx,
-//              //   end_c_idx,
-//              //   start_fills,
-//              //   end_fills,
-//              //   wd_chars,
-//              //   wd_width,
-//              //   width
-//              // );
-//              rows.insert(
-//                wrow,
-//                RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-//              );
-//              assert_eq!(wcol, width);
-//              wrow += 1;
-//              wcol = 0_u16;
-//              start_dcol = end_dcol;
-//              start_c_idx = end_c_idx;
-//              ch2dcols.clear();
-//
-//              if wrow >= height {
-//                // trace!(
-//                //   "12-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
-//                //   wrow,
-//                //   wcol,
-//                //   dcol,
-//                //   start_dcol,
-//                //   end_dcol,
-//                //   bchars,
-//                //   start_c_idx,
-//                //   end_c_idx,
-//                //   start_fills,
-//                //   end_fills,
-//                //   wd_chars,
-//                //   wd_width,
-//                //   height
-//                // );
-//                break;
-//              }
-//            }
-//          }
-//
-//          line_viewports.insert(
-//            current_line,
-//            LineViewport::new(rows, start_fills, end_fills),
-//          );
-//          // trace!(
-//          //   "13-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}",
-//          //   wrow,
-//          //   wcol,
-//          //   dcol,
-//          //   start_dcol,
-//          //   end_dcol,
-//          //   bchars,
-//          //   start_c_idx,
-//          //   end_c_idx,
-//          //   start_fills,
-//          //   end_fills
-//          // );
-//          current_line += 1;
-//          wrow += 1;
-//        }
-//
-//        // trace!("14-wrow:{}, current_line:{}", wrow, current_line);
-//        (
-//          ViewportLineRange::new(start_line..current_line),
-//          line_viewports,
-//        )
-//      }
-//      None => {
-//        // The `start_line` is outside of the buffer.
-//        // trace!("15-start_line:{}", start_line);
-//        (ViewportLineRange::default(), BTreeMap::new())
-//      }
-//    }
-//  }
-//}
+#[allow(unused_variables)]
+// Implements [`from_top_left`] with option `wrap=true` and `line-break=true`.
+fn _from_top_left_wrap_linebreak(
+  _options: &ViewportOptions,
+  buffer: BufferWk,
+  actual_shape: &U16Rect,
+  start_line: usize,
+  start_dcol_on_line: usize,
+) -> (ViewportLineRange, BTreeMap<usize, LineViewport>) {
+  let height = actual_shape.height();
+  let width = actual_shape.width();
+
+  // trace!(
+  //   "_collect_from_top_left_with_wrap_linebreak, actual_shape:{:?}, height/width:{:?}/{:?}",
+  //   actual_shape,
+  //   height,
+  //   width
+  // );
+
+  // Get buffer arc pointer, and lock for read.
+  let buffer = buffer.upgrade().unwrap();
+  let mut buffer = wlock!(buffer);
+
+  unsafe {
+    // Fix mutable borrow on `buffer`.
+    let mut raw_buffer = NonNull::new(&mut *buffer as *mut Buffer).unwrap();
+
+    // trace!(
+    //   "buffer.get_line ({:?}):'{:?}'",
+    //   start_line,
+    //   match buffer.get_line(start_line) {
+    //     Some(line) => slice2line(&line),
+    //     None => "None".to_string(),
+    //   }
+    // );
+
+    let mut line_viewports: BTreeMap<usize, LineViewport> = BTreeMap::new();
+
+    match raw_buffer.as_ref().get_rope().get_lines_at(start_line) {
+      Some(buflines) => {
+        // The `start_line` is inside the buffer.
+
+        // The first `wrow` in the window maps to the `start_line` in the buffer.
+        let mut wrow = 0;
+        let mut current_line = start_line;
+
+        for (l, bline) in buflines.enumerate() {
+          // Current row goes out of viewport.
+          if wrow >= height {
+            break;
+          }
+
+          let (rows, start_fills, end_fills) = if bline.len_chars() == 0 {
+            let mut rows: BTreeMap<u16, RowViewport> = BTreeMap::new();
+            rows.insert(wrow, RowViewport::new(0..0));
+            (rows, 0_usize, 0_usize)
+          } else {
+            let mut rows: BTreeMap<u16, RowViewport> = BTreeMap::new();
+
+            // Here we clone the line with the max chars that can hold by current window/viewport,
+            // i.e. the `height * width` cells count as the max chars in the line. This helps avoid
+            // performance issue when iterating on super long lines.
+            let cloned_line = raw_buffer.as_ref().clone_line(
+              l,
+              0,
+              height as usize * width as usize * 2 + 16 + start_dcol_on_line,
+            );
+
+            if cloned_line.is_none() {
+              rows.insert(wrow, RowViewport::new(0..0));
+              return (rows, 0_usize, 0_usize);
+            }
+
+            let cloned_line = cloned_line.unwrap();
+            let word_boundaries: Vec<&str> = cloned_line.split_word_bounds().collect();
+
+            let mut start_c = match raw_buffer.as_mut().char_until(l, start_dcol_on_line) {
+              Some(c) => c,
+              None => 0_usize,
+            };
+            let start_fills = {
+              let start_width_until = raw_buffer.as_mut().width_before(l, start_c);
+              start_width_until - start_dcol_on_line
+            };
+
+            let mut end_dcol = start_dcol_on_line + width as usize;
+            let mut end_c: Option<usize> = None;
+            let mut eol = false;
+            while wrow < height && !eol {
+              end_c = match raw_buffer.as_mut().char_after(l, end_dcol) {
+                Some(c) => Some(c),
+                None => {
+                  eol = true;
+                  Some(raw_buffer.as_mut().last_char(l).unwrap())
+                }
+              };
+              rows.insert(wrow, RowViewport::new(start_c..end_c.unwrap()));
+              wrow += 1;
+              start_c = end_c.unwrap();
+              end_dcol = end_dcol + width as usize;
+            }
+            let end_fills = {
+              let end_width_until = raw_buffer.as_mut().width_until(l, end_c.unwrap());
+              if end_width_until >= end_dcol {
+                end_width_until - end_dcol
+              } else {
+                0_usize
+              }
+            };
+
+            (rows, start_fills, end_fills)
+          };
+
+          let mut rows: BTreeMap<u16, RowViewport> = BTreeMap::new();
+          let mut wcol = 0_u16;
+
+          let mut bchars = 0_usize;
+          let mut dcol = 0_usize;
+          let mut start_dcol = 0_usize;
+          let mut end_dcol = 0_usize;
+
+          let mut start_c_idx = 0_usize;
+          let mut end_c_idx = 0_usize;
+          let mut start_c_idx_init = false;
+          let mut _end_c_idx_init = false;
+
+          let mut ch2dcols: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
+
+          let mut start_fills = 0_usize;
+          let mut end_fills = 0_usize;
+
+          // Chop the line into maximum chars can hold by current window, thus avoid those super
+          // long lines for iteration performance.
+          // NOTE: Use `height * width * 4` simply for a much bigger size for the total characters in
+          // a viewport.
+          let truncated_line = truncate_line(
+            &bline,
+            start_dcol_on_line,
+            height as usize * width as usize * 2 + height as usize * 2 + 16,
+          );
+          let word_boundaries: Vec<&str> = truncated_line.split_word_bounds().collect();
+          // trace!(
+          //   "0-truncated_line: {:?}, word_boundaries: {:?}, wrow/wcol:{}/{}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
+          //   truncated_line, word_boundaries, wrow, wcol, dcol, start_dcol, end_dcol, start_c_idx, end_c_idx, start_fills, end_fills
+          // );
+
+          for (i, wd) in word_boundaries.iter().enumerate() {
+            let (wd_chars, wd_width) = wd.chars().map(|c| (1_usize, buffer.char_width(c))).fold(
+              (0_usize, 0_usize),
+              |(init_chars, init_width), (count, width)| (init_chars + count, init_width + width),
+            );
+
+            // trace!(
+            //   "1-l:{:?}, line:'{:?}', current_line:{:?}, i:{}, wd:{:?}",
+            //   l,
+            //   slice2line(&line),
+            //   current_line,
+            //   i,
+            //   wd
+            // );
+
+            // Prefix width is still before `start_dcolumn`.
+            if dcol + wd_width < start_dcol_on_line {
+              dcol += wd_width;
+              bchars += wd_chars;
+              end_dcol = dcol;
+              end_c_idx = bchars;
+              // trace!(
+              //   "2-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, start_dcolumn:{}",
+              //   wrow,
+              //   wcol,
+              //   dcol,
+              //   start_dcol,
+              //   end_dcol,
+              //   bchars,
+              //   start_c_idx,
+              //   end_c_idx,
+              //   start_fills,
+              //   end_fills,
+              //   wd_chars,
+              //   wd_width,
+              //   start_dcolumn
+              // );
+              continue;
+            }
+
+            if !start_c_idx_init {
+              start_c_idx_init = true;
+              start_dcol = dcol;
+              start_c_idx = bchars;
+              start_fills = dcol - start_dcol_on_line;
+              // trace!(
+              //   "3-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
+              //   wrow,
+              //   wcol,
+              //   dcol,
+              //   start_dcol,
+              //   end_dcol,
+              //   bchars,
+              //   start_c_idx,
+              //   end_c_idx,
+              //   start_fills,
+              //   end_fills,
+              //   wd_chars,
+              //   wd_width
+              // );
+            }
+
+            // Row column with next char will goes out of the row.
+            // i.e. there's not enough space to place this word in current row.
+            // There're two cases:
+            // 1. The word can be placed in next empty row, i.e. the word length is less or equal to
+            //    the row length of the viewport.
+            // 2. The word is too long to place in an entire row, i.e. the word length is greater
+            //    than the row length of the viewport.
+            // Anyway, we simply go to next row and force render all of the word. If the word is too
+            // long to place in an entire row, it fallbacks back to the same behavior with
+            // 'line-break' option is `false`.
+            if wcol as usize + wd_width > width as usize {
+              // trace!(
+              //   "4.1-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+              //   wrow,
+              //   wcol,
+              //   dcol,
+              //   start_dcol,
+              //   end_dcol,
+              //   bchars,
+              //   start_c_idx,
+              //   end_c_idx,
+              //   start_fills,
+              //   end_fills,
+              //   wd_chars,
+              //   wd_width,
+              //   width
+              // );
+
+              // If it happens this word starts from the beginning of the row, then we don't need to
+              // start from the next row. Because this is an empty of entire row.
+              // If this word starts in the middle of the row, then we will have to start a new row.
+              if wcol > 0 {
+                rows.insert(
+                  wrow,
+                  RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
+                );
+
+                // NOTE: The `end_fills` only indicates the cells at the end of the bottom row in the
+                // viewport cannot show the full unicode character for those ASCII control codes or
+                // other unicodes such as CJK languages.
+                // But for word-wrap rendering, i.e. `line-break` option is `true`, sometimes the whole
+                // word display length is out of the end of the row and it will not be displayed (and
+                // in such case, we don't set `end_fills` for it).
+                // So, here we need to detect the real end fills position for the word.
+
+                let saved_end_fills = {
+                  let mut tmp_wcol = wcol;
+                  for c in wd.chars() {
+                    let c_width = buffer.char_width(c);
+
+                    // Column with next char will goes out of the row.
+                    if tmp_wcol as usize + c_width > width as usize {
+                      break;
+                    }
+                    tmp_wcol += c_width as u16;
+                    // Column already meets the end of the row.
+                    if tmp_wcol >= width {
+                      break;
+                    }
+                  }
+                  //   trace!(
+                  //   "4.2-wrow/wcol/tmp_wcol:{}/{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+                  //   wrow,
+                  //   wcol,
+                  //   tmp_wcol,
+                  //   dcol,
+                  //   start_dcol,
+                  //   end_dcol,
+                  //   bchars,
+                  //   start_c_idx,
+                  //   end_c_idx,
+                  //   start_fills,
+                  //   end_fills,
+                  //   wd_chars,
+                  //   wd_width,
+                  //   width
+                  // );
+                  width - tmp_wcol
+                };
+
+                wrow += 1;
+                wcol = 0_u16;
+                start_dcol = end_dcol;
+                start_c_idx = bchars;
+                ch2dcols.clear();
+
+                if wrow >= height {
+                  end_fills = saved_end_fills as usize;
+                  //   trace!(
+                  //   "5-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
+                  //   wrow,
+                  //   wcol,
+                  //   dcol,
+                  //   start_dcol,
+                  //   end_dcol,
+                  //   bchars,
+                  //   start_c_idx,
+                  //   end_c_idx,
+                  //   start_fills,
+                  //   end_fills,
+                  //   wd_chars,
+                  //   wd_width,
+                  //   height
+                  // );
+                  break;
+                }
+              }
+
+              for (j, c) in wd.chars().enumerate() {
+                let c_width = buffer.char_width(c);
+
+                // Column with next char will goes out of the row.
+                if wcol as usize + c_width > width as usize {
+                  // trace!(
+                  //   "6-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+                  //   wrow,
+                  //   wcol,
+                  //   dcol,
+                  //   start_dcol,
+                  //   end_dcol,
+                  //   bchars,
+                  //   j,
+                  //   c,
+                  //   start_c_idx,
+                  //   end_c_idx,
+                  //   start_fills,
+                  //   end_fills,
+                  //   wd_chars,
+                  //   wd_width,
+                  //   width
+                  // );
+                  rows.insert(
+                    wrow,
+                    RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
+                  );
+
+                  let saved_end_fills = width as usize - wcol as usize;
+                  if j > 0 {
+                    wrow += 1;
+                  }
+                  wcol = 0_u16;
+                  start_dcol = end_dcol;
+                  start_c_idx = bchars;
+                  ch2dcols.clear();
+
+                  if wrow >= height {
+                    end_fills = saved_end_fills;
+                    // trace!(
+                    //   "7-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
+                    //   wrow,
+                    //   wcol,
+                    //   dcol,
+                    //   start_dcol,
+                    //   end_dcol,
+                    //   bchars,
+                    //   j,
+                    //   c,
+                    //   start_c_idx,
+                    //   end_c_idx,
+                    //   start_fills,
+                    //   end_fills,
+                    //   wd_chars,
+                    //   wd_width,
+                    //   height
+                    // );
+                    break;
+                  }
+                }
+
+                let saved_c_idx = bchars;
+                let saved_start_dcol = dcol;
+
+                dcol += c_width;
+                bchars += 1;
+                end_dcol = dcol;
+                end_c_idx = bchars;
+                wcol += c_width as u16;
+
+                ch2dcols.insert(saved_c_idx, (saved_start_dcol, end_dcol));
+
+                // trace!(
+                //   "8-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
+                //   wrow,
+                //   wcol,
+                //   dcol,
+                //   start_dcol,
+                //   end_dcol,
+                //   bchars,
+                //   j,
+                //   c,
+                //   start_c_idx,
+                //   end_c_idx,
+                //   start_fills,
+                //   end_fills,
+                //   wd_chars,
+                //   wd_width
+                // );
+
+                // Column goes out of current row.
+                if wcol >= width {
+                  // trace!(
+                  //   "9-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+                  //   wrow,
+                  //   wcol,
+                  //   dcol,
+                  //   start_dcol,
+                  //   end_dcol,
+                  //   bchars,
+                  //   j,
+                  //   c,
+                  //   start_c_idx,
+                  //   end_c_idx,
+                  //   start_fills,
+                  //   end_fills,
+                  //   wd_chars,
+                  //   wd_width,
+                  //   width
+                  // );
+                  rows.insert(
+                    wrow,
+                    RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
+                  );
+                  assert_eq!(wcol, width);
+                  wrow += 1;
+                  wcol = 0_u16;
+                  start_dcol = end_dcol;
+                  start_c_idx = end_c_idx;
+                  ch2dcols.clear();
+
+                  if wrow >= height {
+                    // trace!(
+                    //   "10-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
+                    //   wrow,
+                    //   wcol,
+                    //   dcol,
+                    //   start_dcol,
+                    //   end_dcol,
+                    //   bchars,
+                    //   j,
+                    //   c,
+                    //   start_c_idx,
+                    //   end_c_idx,
+                    //   start_fills,
+                    //   end_fills,
+                    //   wd_chars,
+                    //   wd_width,
+                    //   height
+                    // );
+                    break;
+                  }
+                }
+              }
+            } else {
+              // Enough space to place this word in current row
+              let saved_c_idx = bchars;
+              let saved_start_dcol = dcol;
+
+              dcol += wd_width;
+              bchars += wd_chars;
+              end_dcol = dcol;
+              end_c_idx = bchars;
+              wcol += wd_width as u16;
+
+              let mut tmp_start_dcol = saved_start_dcol;
+              for (k, c) in wd.chars().enumerate() {
+                let c_width = buffer.char_width(c);
+                let tmp_end_dcol = tmp_start_dcol + c_width;
+                ch2dcols.insert(saved_c_idx + k, (tmp_start_dcol, tmp_end_dcol));
+                tmp_start_dcol = tmp_end_dcol;
+              }
+            }
+
+            // trace!(
+            //   "9-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
+            //   wrow,
+            //   wcol,
+            //   dcol,
+            //   start_dcol,
+            //   end_dcol,
+            //   bchars,
+            //   start_c_idx,
+            //   end_c_idx,
+            //   start_fills,
+            //   end_fills,
+            //   wd_chars,
+            //   wd_width
+            // );
+
+            // End of the line.
+            if i + 1 == word_boundaries.len() {
+              // trace!(
+              //   "10-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
+              //   wrow,
+              //   wcol,
+              //   dcol,
+              //   start_dcol,
+              //   end_dcol,
+              //   bchars,
+              //   start_c_idx,
+              //   end_c_idx,
+              //   start_fills,
+              //   end_fills,
+              //   wd_chars,
+              //   wd_width
+              // );
+              rows.insert(
+                wrow,
+                RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
+              );
+              break;
+            }
+
+            // Column goes out of current row.
+            if wcol >= width {
+              // trace!(
+              //   "11-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
+              //   wrow,
+              //   wcol,
+              //   dcol,
+              //   start_dcol,
+              //   end_dcol,
+              //   bchars,
+              //   start_c_idx,
+              //   end_c_idx,
+              //   start_fills,
+              //   end_fills,
+              //   wd_chars,
+              //   wd_width,
+              //   width
+              // );
+              rows.insert(
+                wrow,
+                RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
+              );
+              assert_eq!(wcol, width);
+              wrow += 1;
+              wcol = 0_u16;
+              start_dcol = end_dcol;
+              start_c_idx = end_c_idx;
+              ch2dcols.clear();
+
+              if wrow >= height {
+                // trace!(
+                //   "12-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
+                //   wrow,
+                //   wcol,
+                //   dcol,
+                //   start_dcol,
+                //   end_dcol,
+                //   bchars,
+                //   start_c_idx,
+                //   end_c_idx,
+                //   start_fills,
+                //   end_fills,
+                //   wd_chars,
+                //   wd_width,
+                //   height
+                // );
+                break;
+              }
+            }
+          }
+
+          line_viewports.insert(
+            current_line,
+            LineViewport::new(rows, start_fills, end_fills),
+          );
+          // trace!(
+          //   "13-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}",
+          //   wrow,
+          //   wcol,
+          //   dcol,
+          //   start_dcol,
+          //   end_dcol,
+          //   bchars,
+          //   start_c_idx,
+          //   end_c_idx,
+          //   start_fills,
+          //   end_fills
+          // );
+          current_line += 1;
+          wrow += 1;
+        }
+
+        // trace!("14-wrow:{}, current_line:{}", wrow, current_line);
+        (
+          ViewportLineRange::new(start_line..current_line),
+          line_viewports,
+        )
+      }
+      None => {
+        // The `start_line` is outside of the buffer.
+        // trace!("15-start_line:{}", start_line);
+        (ViewportLineRange::default(), BTreeMap::new())
+      }
+    }
+  }
+}
 
 #[allow(unused_imports)]
 #[cfg(test)]

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -373,10 +373,11 @@ fn find_word_by_char(
   word_end_chars_index: &HashMap<usize, usize>,
   char_idx: usize,
 ) -> (usize, usize, usize) {
+  // trace!("words:{words:?}, words_end_chars:{word_end_chars_index:?},char_idx:{char_idx}");
   let mut low = 0;
   let mut high = words.len() - 1;
 
-  while low < high {
+  while low <= high {
     let mid = (low + high) / 2;
 
     let start_char_idx = if mid > 0 {
@@ -386,7 +387,13 @@ fn find_word_by_char(
     };
     let end_char_idx = *word_end_chars_index.get(&mid).unwrap();
 
+    // trace!(
+    //   "low:{low},high:{high},mid:{mid},start_char_idx:{start_char_idx},end_char_idx:{end_char_idx},char_idx:{char_idx}"
+    // );
     if start_char_idx <= char_idx && end_char_idx > char_idx {
+      // trace!(
+      //   "return mid:{mid},start_char_idx:{start_char_idx},end_char_idx:{end_char_idx},char_idx:{char_idx}"
+      // );
       return (mid, start_char_idx, end_char_idx);
     } else if start_char_idx > char_idx {
       high = mid - 1;

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -564,7 +564,7 @@ fn _from_top_left_wrap_linebreak(
             // 1. Word index.
             // 2. Start char of the word.
             // 3. End char of the word.
-            // 4. Continued start char index of the word (which should be continue to rendering on
+            // 4. Continued start char index of the word (which should be continued to rendering on
             //    current row).
             let mut last_word_is_too_long: Option<(usize, usize, usize, usize)> = None;
 

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -519,11 +519,31 @@ fn _from_top_left_wrap_linebreak(
                       continued_char_of_last_wd,
                     )) => {
                       // Part-2
-                      // This is the following logic of part-1, you should first see part-1 before
+                      // This is the following logic of part-1.2, you should see part-1 before
                       // this.
-                      // This part is to process the case-2 of the tricky part, i.e. if the word is
-                      // too long to put in an entire row, and we cut it into pieces and force
-                      // rendering it with no-line-break behavior.
+                      //
+                      // If the word is too long to put in an entire row, and we cut it into
+                      // pieces. In this part, we need to continue rendering the rest part of the
+                      // word on current row.
+                      //
+                      // Here we also have two sub-cases:
+                      // 1. If the rest part of the word is still too long to put in current row.
+                      // 2. If the rest part of the word is not long and can be put in current row.
+
+                      match raw_buffer.as_mut().char_at(l, end_width) {
+                        Some(c) => {
+                          if end_char_of_last_wd > c {
+                            // Part-2.1, the rest part of the word is still too long.
+                          } else {
+                            // Part-2.2, the rest part of the word is not long.
+                          }
+                        }
+                        None => {
+                          // If the char not found, it means the `end_width` is too long than the
+                          // whole buffer line.
+                          // So the char next to the line's last char is the end char.
+                        }
+                      }
 
                       (0_usize, 0_usize)
                     }
@@ -546,7 +566,7 @@ fn _from_top_left_wrap_linebreak(
                         //    never enough places to put the whole word).
 
                         if start_c_of_wd > start_char {
-                          // Case-1, simply wrapped this word to next row.
+                          // Part-1.1, simply wrapped this word to next row.
                           // Here we actually use the `start_c_of_wd` as the end char for current row.
 
                           // If the `start_c_of_wd` width is greater than `end_width`, it is the end
@@ -558,7 +578,7 @@ fn _from_top_left_wrap_linebreak(
                             end_width.saturating_sub(start_c_width_before),
                           )
                         } else {
-                          // Case-2, cut this word and force rendering it ignoring line-break behavior.
+                          // Part-1.2, cut this word and force rendering it ignoring line-break behavior.
                           assert_eq!(start_c_of_wd, start_char);
                           // Record the position (c) where we cut the words into pieces.
                           last_word_is_too_long = Some((wd_idx, start_c_of_wd, end_c_of_wd, c));

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -368,8 +368,8 @@ fn _from_top_left_wrap_nolinebreak(
 ///
 /// Returns the word index which contains this char, and whether the char is the last char in the
 /// word.
-fn find_word_by_char<'a>(
-  words: &'a Vec<&str>,
+fn find_word_by_char(
+  words: &Vec<&str>,
   word_end_chars_index: &HashMap<usize, usize>,
   char_idx: usize,
 ) -> (usize, usize, usize) {

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -387,18 +387,18 @@ fn _from_top_left_wrap_linebreak(
   let buffer = buffer.upgrade().unwrap();
   let mut buffer = wlock!(buffer);
 
+  trace!(
+    "buffer.get_line ({:?}):'{:?}'",
+    start_line,
+    match buffer.get_rope().get_line(start_line) {
+      Some(line) => slice2line(&line),
+      None => "None".to_string(),
+    }
+  );
+
   unsafe {
     // Fix mutable borrow on `buffer`.
     let mut raw_buffer = NonNull::new(&mut *buffer as *mut Buffer).unwrap();
-
-    // trace!(
-    //   "buffer.get_line ({:?}):'{:?}'",
-    //   start_line,
-    //   match buffer.get_line(start_line) {
-    //     Some(line) => slice2line(&line),
-    //     None => "None".to_string(),
-    //   }
-    // );
 
     let mut line_viewports: BTreeMap<usize, LineViewport> = BTreeMap::new();
 

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -595,8 +595,7 @@ fn _from_top_left_wrap_linebreak(
 
                             // If the char `c` width is greater than `end_width`, the `c` itself is
                             // the end char.
-                            let c_width_before = raw_buffer.as_mut().width_before(l, c);
-                            (c, end_width.saturating_sub(c_width_before))
+                            end_char_and_prefills(raw_buffer, &bline, l, c, end_width)
                           } else {
                             // Part-2.2, the rest part of the word is not long.
                             // Thus we can go back to *normal* algorithm just like part-1.

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -399,7 +399,7 @@ fn find_word_by_char<'a>(
 }
 
 /// Part-1 of the processing algorithm in `_from_top_left_wrap_linebreak`.
-unsafe fn wrap_linebreak_part1<'a>(
+unsafe fn part1<'a>(
   words: &Vec<&str>,
   words_end_char_idx: &HashMap<usize, usize>,
   mut raw_buffer: NonNull<Buffer>,
@@ -549,10 +549,6 @@ fn _from_top_left_wrap_linebreak(
               width_before.saturating_sub(start_dcol_on_line)
             };
 
-            // // First char, first word.
-            // let (mut wd_idx, mut start_char_of_wd, mut end_char_of_wd) =
-            //   find_word_by_char(&words, &words_end_char_idx, start_char);
-
             let mut end_width = start_dcol_on_line + width as usize;
             let mut end_fills = 0_usize;
 
@@ -605,7 +601,7 @@ fn _from_top_left_wrap_linebreak(
                             // Part-2.2, the rest part of the word is not long.
                             // Thus we can go back to *normal* algorithm just like part-1.
 
-                            wrap_linebreak_part1(
+                            part1(
                               &words,
                               &words_end_char_idx,
                               raw_buffer,
@@ -628,7 +624,7 @@ fn _from_top_left_wrap_linebreak(
                     }
                     None => {
                       // Part-1
-                      wrap_linebreak_part1(
+                      part1(
                         &words,
                         &words_end_char_idx,
                         raw_buffer,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -469,10 +469,10 @@ fn _from_top_left_wrap_linebreak(
               )
               .unwrap();
 
-            let cloned_line = cloned_line.unwrap();
+            // Words.
             let words: Vec<&str> = cloned_line.split_word_bounds().collect();
-            // Word index => end char index (from the first char until current word).
-            let word_end_chars_index: HashMap<usize, usize> = words
+            // Word index => its end char index (from the first char until current word).
+            let words_end_char_idx = words
               .iter()
               .enumerate()
               .scan(0_usize, |state, (i, wd)| {
@@ -480,7 +480,7 @@ fn _from_top_left_wrap_linebreak(
                 *state = *state + wd_chars;
                 Some((i, *state))
               })
-              .collect();
+              .collect::<HashMap<usize, usize>>();
 
             let mut start_char = raw_buffer
               .as_mut()
@@ -490,531 +490,56 @@ fn _from_top_left_wrap_linebreak(
               let width_before = raw_buffer.as_mut().width_before(l, start_char);
               width_before.saturating_sub(start_dcol_on_line)
             };
+            let (start_word_idx, start_char_of_start_word, end_char_of_start_word) =
+              find_word_by_char(&words, &words_end_char_idx, start_char);
 
-            let mut prev_end_width = start_dcol_on_line;
             let mut end_width = start_dcol_on_line + width as usize;
-            let mut end_char: Option<usize> = None;
+            let mut end_fills = 0_usize;
 
             assert!(wrow < height);
             while wrow < height {
-              end_char = match raw_buffer.as_mut().char_at(l, end_width) {
+              let (end_char, end_fills_result) = match raw_buffer.as_mut().char_at(l, end_width) {
                 Some(c) => {
-                  let (wd_idx, start_char_in_wd, end_char_in_wd) =
-                    find_word_by_char(&words, &word_end_chars_index, c);
-                  if end_char_in_wd == c + 1 {
-                    // This is fortunately the word ends at the end of the row, i.e. the last
-                    // char in the `wd` happens to be at the end of the row. So this word can be
-                    // put at the end of the row, don't need to be wrapped to the next row.
-                    Some(c)
-                  } else if end_char_in_wd > c + 1 {
-                    // Or unfortunatedly, this word is longer than current row, i.e. it needs to
-                    // be put into the next row (instead of current row).
-
-                    // Here's the tricky part, there are two sub-cases in this scenario:
-                    // 1. For most (happy) cases, the word is not longer than a whole row in the
-                    //    window, so it can be completely put to next row. It is quite simple and
-                    //    we don't need to handle any edge cases.
-                    // 2. For very rare cases, the word is just too long to put in an entire row
-                    //    in the window. And in this case, we fallback to non-line-break
-                    //    rendering behavior, i.e. just cut the word in the middle, and force
-                    //    rendering the word on multiple rows in the window (because otherwise
-                    //    there will be never enough places to put the whole word).
-                    if start_char_in_wd <= prev_end_width {
-                      // Case-2: The word is too long to put in the whole row.
-                    } else {
-                      // Case-1: The word is not too long.
-                    }
-                    let wd = words[wd_idx];
+                  let c_width = raw_buffer.as_mut().width_at(l, c);
+                  if c_width > end_width {
+                    // If the char `c` width is greater than `end_width`, the `c` itself is the end char.
+                    let c_width_before = raw_buffer.as_mut().width_before(l, c);
+                    (c, end_width.saturating_sub(c_width_before))
                   } else {
-                    unreachable!()
+                    // If the char `c` width is less than or equal to `end_width`, the char next to `c` is the end char.
+                    let c_next = std::cmp::min(c + 1, bline.len_chars() - 1);
+                    (c_next, 0_usize)
                   }
                 }
                 None => {
-                  let c_next = std::cmp::min(c + 1, bline.len_chars() - 1);
-                  // (c_next, 0_usize)
-                  Some(raw_buffer.as_mut().last_char(l).unwrap())
+                  // If the char not found, it means the `end_width` is too long than the whole line.
+                  // So the char next to the line's last char is the end char.
+                  (bline.len_chars(), 0_usize)
                 }
               };
-              rows.insert(wrow, RowViewport::new(start_char..end_char.unwrap()));
-              wrow += 1;
-              start_char = end_char.unwrap();
-              end_width = end_width + width as usize;
-            }
+              end_fills = end_fills_result;
 
-            let end_fills = {
-              let end_width_until = raw_buffer.as_mut().width_until(l, end_char.unwrap());
-              if end_width_until >= end_width {
-                end_width_until - end_width
-              } else {
-                0_usize
+              rows.insert(wrow, RowViewport::new(start_char..end_char));
+
+              // Goes out of line.
+              if end_char >= bline.len_chars() {
+                break;
               }
-            };
+
+              // Prepare next row.
+              wrow += 1;
+              start_char = end_char;
+              end_width = raw_buffer.as_mut().width_before(l, end_char) + width as usize;
+            }
 
             (rows, start_fills, end_fills)
           };
-
-          let mut rows: BTreeMap<u16, RowViewport> = BTreeMap::new();
-          let mut wcol = 0_u16;
-
-          let mut bchars = 0_usize;
-          let mut dcol = 0_usize;
-          let mut start_dcol = 0_usize;
-          let mut end_dcol = 0_usize;
-
-          let mut start_c_idx = 0_usize;
-          let mut end_c_idx = 0_usize;
-          let mut start_c_idx_init = false;
-          let mut _end_c_idx_init = false;
-
-          let mut ch2dcols: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
-
-          let mut start_fills = 0_usize;
-          let mut end_fills = 0_usize;
-
-          // Chop the line into maximum chars can hold by current window, thus avoid those super
-          // long lines for iteration performance.
-          // NOTE: Use `height * width * 4` simply for a much bigger size for the total characters in
-          // a viewport.
-          let truncated_line = truncate_line(
-            &bline,
-            start_dcol_on_line,
-            height as usize * width as usize * 2 + height as usize * 2 + 16,
-          );
-          let word_boundaries: Vec<&str> = truncated_line.split_word_bounds().collect();
-          // trace!(
-          //   "0-truncated_line: {:?}, word_boundaries: {:?}, wrow/wcol:{}/{}, dcol:{}/{}/{}, c_idx:{}/{}, fills:{}/{}",
-          //   truncated_line, word_boundaries, wrow, wcol, dcol, start_dcol, end_dcol, start_c_idx, end_c_idx, start_fills, end_fills
-          // );
-
-          for (i, wd) in word_boundaries.iter().enumerate() {
-            let (wd_chars, wd_width) = wd.chars().map(|c| (1_usize, buffer.char_width(c))).fold(
-              (0_usize, 0_usize),
-              |(init_chars, init_width), (count, width)| (init_chars + count, init_width + width),
-            );
-
-            // trace!(
-            //   "1-l:{:?}, line:'{:?}', current_line:{:?}, i:{}, wd:{:?}",
-            //   l,
-            //   slice2line(&line),
-            //   current_line,
-            //   i,
-            //   wd
-            // );
-
-            // Prefix width is still before `start_dcolumn`.
-            if dcol + wd_width < start_dcol_on_line {
-              dcol += wd_width;
-              bchars += wd_chars;
-              end_dcol = dcol;
-              end_c_idx = bchars;
-              // trace!(
-              //   "2-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, start_dcolumn:{}",
-              //   wrow,
-              //   wcol,
-              //   dcol,
-              //   start_dcol,
-              //   end_dcol,
-              //   bchars,
-              //   start_c_idx,
-              //   end_c_idx,
-              //   start_fills,
-              //   end_fills,
-              //   wd_chars,
-              //   wd_width,
-              //   start_dcolumn
-              // );
-              continue;
-            }
-
-            if !start_c_idx_init {
-              start_c_idx_init = true;
-              start_dcol = dcol;
-              start_c_idx = bchars;
-              start_fills = dcol - start_dcol_on_line;
-              // trace!(
-              //   "3-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
-              //   wrow,
-              //   wcol,
-              //   dcol,
-              //   start_dcol,
-              //   end_dcol,
-              //   bchars,
-              //   start_c_idx,
-              //   end_c_idx,
-              //   start_fills,
-              //   end_fills,
-              //   wd_chars,
-              //   wd_width
-              // );
-            }
-
-            // Row column with next char will goes out of the row.
-            // i.e. there's not enough space to place this word in current row.
-            // There're two cases:
-            // 1. The word can be placed in next empty row, i.e. the word length is less or equal to
-            //    the row length of the viewport.
-            // 2. The word is too long to place in an entire row, i.e. the word length is greater
-            //    than the row length of the viewport.
-            // Anyway, we simply go to next row and force render all of the word. If the word is too
-            // long to place in an entire row, it fallbacks back to the same behavior with
-            // 'line-break' option is `false`.
-            if wcol as usize + wd_width > width as usize {
-              // trace!(
-              //   "4.1-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-              //   wrow,
-              //   wcol,
-              //   dcol,
-              //   start_dcol,
-              //   end_dcol,
-              //   bchars,
-              //   start_c_idx,
-              //   end_c_idx,
-              //   start_fills,
-              //   end_fills,
-              //   wd_chars,
-              //   wd_width,
-              //   width
-              // );
-
-              // If it happens this word starts from the beginning of the row, then we don't need to
-              // start from the next row. Because this is an empty of entire row.
-              // If this word starts in the middle of the row, then we will have to start a new row.
-              if wcol > 0 {
-                rows.insert(
-                  wrow,
-                  RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-                );
-
-                // NOTE: The `end_fills` only indicates the cells at the end of the bottom row in the
-                // viewport cannot show the full unicode character for those ASCII control codes or
-                // other unicodes such as CJK languages.
-                // But for word-wrap rendering, i.e. `line-break` option is `true`, sometimes the whole
-                // word display length is out of the end of the row and it will not be displayed (and
-                // in such case, we don't set `end_fills` for it).
-                // So, here we need to detect the real end fills position for the word.
-
-                let saved_end_fills = {
-                  let mut tmp_wcol = wcol;
-                  for c in wd.chars() {
-                    let c_width = buffer.char_width(c);
-
-                    // Column with next char will goes out of the row.
-                    if tmp_wcol as usize + c_width > width as usize {
-                      break;
-                    }
-                    tmp_wcol += c_width as u16;
-                    // Column already meets the end of the row.
-                    if tmp_wcol >= width {
-                      break;
-                    }
-                  }
-                  //   trace!(
-                  //   "4.2-wrow/wcol/tmp_wcol:{}/{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-                  //   wrow,
-                  //   wcol,
-                  //   tmp_wcol,
-                  //   dcol,
-                  //   start_dcol,
-                  //   end_dcol,
-                  //   bchars,
-                  //   start_c_idx,
-                  //   end_c_idx,
-                  //   start_fills,
-                  //   end_fills,
-                  //   wd_chars,
-                  //   wd_width,
-                  //   width
-                  // );
-                  width - tmp_wcol
-                };
-
-                wrow += 1;
-                wcol = 0_u16;
-                start_dcol = end_dcol;
-                start_c_idx = bchars;
-                ch2dcols.clear();
-
-                if wrow >= height {
-                  end_fills = saved_end_fills as usize;
-                  //   trace!(
-                  //   "5-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
-                  //   wrow,
-                  //   wcol,
-                  //   dcol,
-                  //   start_dcol,
-                  //   end_dcol,
-                  //   bchars,
-                  //   start_c_idx,
-                  //   end_c_idx,
-                  //   start_fills,
-                  //   end_fills,
-                  //   wd_chars,
-                  //   wd_width,
-                  //   height
-                  // );
-                  break;
-                }
-              }
-
-              for (j, c) in wd.chars().enumerate() {
-                let c_width = buffer.char_width(c);
-
-                // Column with next char will goes out of the row.
-                if wcol as usize + c_width > width as usize {
-                  // trace!(
-                  //   "6-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-                  //   wrow,
-                  //   wcol,
-                  //   dcol,
-                  //   start_dcol,
-                  //   end_dcol,
-                  //   bchars,
-                  //   j,
-                  //   c,
-                  //   start_c_idx,
-                  //   end_c_idx,
-                  //   start_fills,
-                  //   end_fills,
-                  //   wd_chars,
-                  //   wd_width,
-                  //   width
-                  // );
-                  rows.insert(
-                    wrow,
-                    RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-                  );
-
-                  let saved_end_fills = width as usize - wcol as usize;
-                  if j > 0 {
-                    wrow += 1;
-                  }
-                  wcol = 0_u16;
-                  start_dcol = end_dcol;
-                  start_c_idx = bchars;
-                  ch2dcols.clear();
-
-                  if wrow >= height {
-                    end_fills = saved_end_fills;
-                    // trace!(
-                    //   "7-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
-                    //   wrow,
-                    //   wcol,
-                    //   dcol,
-                    //   start_dcol,
-                    //   end_dcol,
-                    //   bchars,
-                    //   j,
-                    //   c,
-                    //   start_c_idx,
-                    //   end_c_idx,
-                    //   start_fills,
-                    //   end_fills,
-                    //   wd_chars,
-                    //   wd_width,
-                    //   height
-                    // );
-                    break;
-                  }
-                }
-
-                let saved_c_idx = bchars;
-                let saved_start_dcol = dcol;
-
-                dcol += c_width;
-                bchars += 1;
-                end_dcol = dcol;
-                end_c_idx = bchars;
-                wcol += c_width as u16;
-
-                ch2dcols.insert(saved_c_idx, (saved_start_dcol, end_dcol));
-
-                // trace!(
-                //   "8-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
-                //   wrow,
-                //   wcol,
-                //   dcol,
-                //   start_dcol,
-                //   end_dcol,
-                //   bchars,
-                //   j,
-                //   c,
-                //   start_c_idx,
-                //   end_c_idx,
-                //   start_fills,
-                //   end_fills,
-                //   wd_chars,
-                //   wd_width
-                // );
-
-                // Column goes out of current row.
-                if wcol >= width {
-                  // trace!(
-                  //   "9-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-                  //   wrow,
-                  //   wcol,
-                  //   dcol,
-                  //   start_dcol,
-                  //   end_dcol,
-                  //   bchars,
-                  //   j,
-                  //   c,
-                  //   start_c_idx,
-                  //   end_c_idx,
-                  //   start_fills,
-                  //   end_fills,
-                  //   wd_chars,
-                  //   wd_width,
-                  //   width
-                  // );
-                  rows.insert(
-                    wrow,
-                    RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-                  );
-                  assert_eq!(wcol, width);
-                  wrow += 1;
-                  wcol = 0_u16;
-                  start_dcol = end_dcol;
-                  start_c_idx = end_c_idx;
-                  ch2dcols.clear();
-
-                  if wrow >= height {
-                    // trace!(
-                    //   "10-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, j/c:{}/{:?}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
-                    //   wrow,
-                    //   wcol,
-                    //   dcol,
-                    //   start_dcol,
-                    //   end_dcol,
-                    //   bchars,
-                    //   j,
-                    //   c,
-                    //   start_c_idx,
-                    //   end_c_idx,
-                    //   start_fills,
-                    //   end_fills,
-                    //   wd_chars,
-                    //   wd_width,
-                    //   height
-                    // );
-                    break;
-                  }
-                }
-              }
-            } else {
-              // Enough space to place this word in current row
-              let saved_c_idx = bchars;
-              let saved_start_dcol = dcol;
-
-              dcol += wd_width;
-              bchars += wd_chars;
-              end_dcol = dcol;
-              end_c_idx = bchars;
-              wcol += wd_width as u16;
-
-              let mut tmp_start_dcol = saved_start_dcol;
-              for (k, c) in wd.chars().enumerate() {
-                let c_width = buffer.char_width(c);
-                let tmp_end_dcol = tmp_start_dcol + c_width;
-                ch2dcols.insert(saved_c_idx + k, (tmp_start_dcol, tmp_end_dcol));
-                tmp_start_dcol = tmp_end_dcol;
-              }
-            }
-
-            // trace!(
-            //   "9-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
-            //   wrow,
-            //   wcol,
-            //   dcol,
-            //   start_dcol,
-            //   end_dcol,
-            //   bchars,
-            //   start_c_idx,
-            //   end_c_idx,
-            //   start_fills,
-            //   end_fills,
-            //   wd_chars,
-            //   wd_width
-            // );
-
-            // End of the line.
-            if i + 1 == word_boundaries.len() {
-              // trace!(
-              //   "10-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}",
-              //   wrow,
-              //   wcol,
-              //   dcol,
-              //   start_dcol,
-              //   end_dcol,
-              //   bchars,
-              //   start_c_idx,
-              //   end_c_idx,
-              //   start_fills,
-              //   end_fills,
-              //   wd_chars,
-              //   wd_width
-              // );
-              rows.insert(
-                wrow,
-                RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-              );
-              break;
-            }
-
-            // Column goes out of current row.
-            if wcol >= width {
-              // trace!(
-              //   "11-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, width:{}",
-              //   wrow,
-              //   wcol,
-              //   dcol,
-              //   start_dcol,
-              //   end_dcol,
-              //   bchars,
-              //   start_c_idx,
-              //   end_c_idx,
-              //   start_fills,
-              //   end_fills,
-              //   wd_chars,
-              //   wd_width,
-              //   width
-              // );
-              rows.insert(
-                wrow,
-                RowViewport::new(start_dcol..end_dcol, start_c_idx..end_c_idx, &ch2dcols),
-              );
-              assert_eq!(wcol, width);
-              wrow += 1;
-              wcol = 0_u16;
-              start_dcol = end_dcol;
-              start_c_idx = end_c_idx;
-              ch2dcols.clear();
-
-              if wrow >= height {
-                // trace!(
-                //   "12-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}, wd:{}/{}, height:{}",
-                //   wrow,
-                //   wcol,
-                //   dcol,
-                //   start_dcol,
-                //   end_dcol,
-                //   bchars,
-                //   start_c_idx,
-                //   end_c_idx,
-                //   start_fills,
-                //   end_fills,
-                //   wd_chars,
-                //   wd_width,
-                //   height
-                // );
-                break;
-              }
-            }
-          }
 
           line_viewports.insert(
             current_line,
             LineViewport::new(rows, start_fills, end_fills),
           );
+
           // trace!(
           //   "13-wrow/wcol:{}/{}, dcol:{}/{}/{}, bchars:{}, c_idx:{}/{}, fills:{}/{}",
           //   wrow,
@@ -1028,6 +553,7 @@ fn _from_top_left_wrap_linebreak(
           //   start_fills,
           //   end_fills
           // );
+
           current_line += 1;
           wrow += 1;
         }

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -421,7 +421,7 @@ unsafe fn part1(
   let (wd_idx, start_c_of_wd, end_c_of_wd) = find_word_by_char(words, words_end_char_idx, c);
 
   unsafe {
-    let end_c_width = raw_buffer.as_mut().width_at(l, end_c_of_wd);
+    let end_c_width = raw_buffer.as_mut().width_before(l, end_c_of_wd);
     if end_c_width > end_width {
       // The current word is longer than current row, it needs to be put to next row.
 
@@ -457,8 +457,9 @@ unsafe fn part1(
         (c, end_width.saturating_sub(c_width_before))
       }
     } else {
+      assert_eq!(c + 1, end_c_of_wd);
       // The current word is not long, it can be put in current row.
-      let c_next = std::cmp::min(c + 1, bline.len_chars() - 1);
+      let c_next = std::cmp::min(end_c_of_wd, bline.len_chars());
       (c_next, 0_usize)
     }
   }

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -626,17 +626,20 @@ fn _from_top_left_wrap_linebreak(
                         }
                       }
                     }
-                    None => wrap_linebreak_part1(
-                      &words,
-                      &words_end_char_idx,
-                      raw_buffer,
-                      &bline,
-                      l,
-                      c,
-                      end_width,
-                      start_char,
-                      &mut last_word_is_too_long,
-                    ),
+                    None => {
+                      // Part-1
+                      wrap_linebreak_part1(
+                        &words,
+                        &words_end_char_idx,
+                        raw_buffer,
+                        &bline,
+                        l,
+                        c,
+                        end_width,
+                        start_char,
+                        &mut last_word_is_too_long,
+                      )
+                    }
                   }
                 }
                 None => {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.85.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This PR re-implements (rewritten) text rendering in TUI window with `line-break` option is on, which has been disabled in previous #253 .