### PR TITLE
fix(cursor): fix cursor position at eol when move vertically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: crate-ci/typos@master
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri,rust-src
-      - uses: mozilla-actions/sccache-action@v0.0.8
       - uses: actions/checkout@v4
       - name: (Experimental) Cargo miri
         env:
@@ -66,9 +66,9 @@ jobs:
           echo "show PWD=${PWD}"
           echo "tsc"
           tsc
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: dtolnay/rust-toolchain@stable
       - uses: cargo-bins/cargo-binstall@main
-      - uses: mozilla-actions/sccache-action@v0.0.8
       - name: Rustfmt
         run: cargo fmt --check
       - name: Taplo
@@ -122,8 +122,8 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "true"
     steps:
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.8
       - uses: actions/checkout@v4
       - name: Cargo test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: crate-ci/typos@master
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri,rust-src
@@ -38,6 +37,7 @@ jobs:
         env:
           MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-permissive-provenance"
           RUSTC_WRAPPER: "sccache"
+          SCCACHE_GHA_ENABLED: "true"
         # Disable simd features
         run: |
           sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' Cargo.toml
@@ -67,7 +67,6 @@ jobs:
           echo "tsc"
           tsc
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - uses: cargo-bins/cargo-binstall@main
       - uses: mozilla-actions/sccache-action@v0.0.8
       - name: Rustfmt
@@ -84,6 +83,7 @@ jobs:
       - name: Clippy
         env:
           RUSTC_WRAPPER: "sccache"
+          SCCACHE_GHA_ENABLED: "true"
         run: cargo clippy --all-targets --all-features
       - name: MSRV
         run: |
@@ -120,9 +120,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - uses: mozilla-actions/sccache-action@v0.0.8
       - uses: actions/checkout@v4
       - name: Cargo test

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -21,6 +21,7 @@ pub struct BufferLocalOptions {
 
 impl BufferLocalOptions {
   /// Buffer 'tab-stop' option.
+  ///
   /// See: <https://vimhelp.org/options.txt.html#%27tabstop%27>.
   pub fn tab_stop(&self) -> u16 {
     self.tab_stop
@@ -31,6 +32,7 @@ impl BufferLocalOptions {
   }
 
   /// Buffer 'file-encoding' option.
+  ///
   /// See: <https://vimhelp.org/options.txt.html#%27fileencoding%27>.
   pub fn file_encoding(&self) -> FileEncodingOption {
     self.file_encoding

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -13,17 +13,15 @@ pub mod file_encoding;
 /// Local buffer options.
 pub struct BufferLocalOptions {
   #[builder(default = defaults::buf::TAB_STOP)]
-  /// Buffer 'tab-stop' option.
-  /// See: <https://vimhelp.org/options.txt.html#%27tabstop%27>.
   tab_stop: u16,
 
   #[builder(default = defaults::buf::FILE_ENCODING)]
-  /// Buffer 'file-encoding' option.
-  /// See: <https://vimhelp.org/options.txt.html#%27fileencoding%27>.
   file_encoding: FileEncodingOption,
 }
 
 impl BufferLocalOptions {
+  /// Buffer 'tab-stop' option.
+  /// See: <https://vimhelp.org/options.txt.html#%27tabstop%27>.
   pub fn tab_stop(&self) -> u16 {
     self.tab_stop
   }
@@ -32,6 +30,8 @@ impl BufferLocalOptions {
     self.tab_stop = value;
   }
 
+  /// Buffer 'file-encoding' option.
+  /// See: <https://vimhelp.org/options.txt.html#%27fileencoding%27>.
   pub fn file_encoding(&self) -> FileEncodingOption {
     self.file_encoding
   }

--- a/rsvim_core/src/defaults/buf.rs
+++ b/rsvim_core/src/defaults/buf.rs
@@ -2,10 +2,6 @@
 
 use crate::buf::FileEncodingOption;
 
-/// Buffer 'tab-stop' option.
-/// See: <https://vimhelp.org/options.txt.html#%27tabstop%27>.
 pub const TAB_STOP: u16 = 8;
 
-/// Buffer 'file-encoding' option.
-/// See: <https://vimhelp.org/options.txt.html#%27fileencoding%27>.
 pub const FILE_ENCODING: FileEncodingOption = FileEncodingOption::Utf8;

--- a/rsvim_core/src/defaults/buf.rs
+++ b/rsvim_core/src/defaults/buf.rs
@@ -1,4 +1,5 @@
 //! Vim buffer's default options.
+//!
 //! See: [`crate::buf::BufferLocalOptions`].
 
 use crate::buf::FileEncodingOption;

--- a/rsvim_core/src/defaults/buf.rs
+++ b/rsvim_core/src/defaults/buf.rs
@@ -1,4 +1,5 @@
 //! Vim buffer's default options.
+//! See: [`crate::buf::BufferLocalOptions`].
 
 use crate::buf::FileEncodingOption;
 

--- a/rsvim_core/src/defaults/win.rs
+++ b/rsvim_core/src/defaults/win.rs
@@ -1,4 +1,5 @@
 //! Vim window's default options.
+//! See: [`crate::ui::widget::window::WindowLocalOptions`].
 
 pub const WRAP: bool = true;
 

--- a/rsvim_core/src/defaults/win.rs
+++ b/rsvim_core/src/defaults/win.rs
@@ -1,13 +1,7 @@
 //! Vim window's default options.
 
-/// Window 'wrap' option, also known as 'line-wrap', default to `true`.
-/// See: <https://vimhelp.org/options.txt.html#%27wrap%27>.
 pub const WRAP: bool = true;
 
-/// Window 'line-break' option, also known as 'word-wrap', default to `false`.
-/// See: <https://vimhelp.org/options.txt.html#%27linebreak%27>.
 pub const LINE_BREAK: bool = false;
 
-/// Window 'scroll-off' option, default to `0`.
-/// See: <https://vimhelp.org/options.txt.html#%27scrolloff%27>.
 pub const SCROLL_OFF: u16 = 0_u16;

--- a/rsvim_core/src/defaults/win.rs
+++ b/rsvim_core/src/defaults/win.rs
@@ -1,4 +1,5 @@
 //! Vim window's default options.
+//!
 //! See: [`crate::ui::widget::window::WindowLocalOptions`].
 
 pub const WRAP: bool = true;

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -8,22 +8,18 @@ use derive_builder::Builder;
 /// Window local options.
 pub struct WindowLocalOptions {
   #[builder(default = defaults::win::WRAP)]
-  /// The 'wrap' option, also known as 'line-wrap', default to `true`.
-  /// See: <https://vimhelp.org/options.txt.html#%27wrap%27>.
   wrap: bool,
 
   #[builder(default = defaults::win::LINE_BREAK)]
-  /// The 'line-break' option, also known as 'word-wrap', default to `false`.
-  /// See: <https://vimhelp.org/options.txt.html#%27linebreak%27>.
   line_break: bool,
 
   #[builder(default = defaults::win::SCROLL_OFF)]
-  /// The 'scroll-off' option, default to `0`.
-  /// See: <https://vimhelp.org/options.txt.html#%27scrolloff%27>.
   scroll_off: u16,
 }
 
 impl WindowLocalOptions {
+  /// The 'wrap' option, also known as 'line-wrap', default to `true`.
+  /// See: <https://vimhelp.org/options.txt.html#%27wrap%27>.
   pub fn wrap(&self) -> bool {
     self.wrap
   }
@@ -32,6 +28,8 @@ impl WindowLocalOptions {
     self.wrap = value;
   }
 
+  /// The 'line-break' option, also known as 'word-wrap', default to `false`.
+  /// See: <https://vimhelp.org/options.txt.html#%27linebreak%27>.
   pub fn line_break(&self) -> bool {
     self.line_break
   }
@@ -40,6 +38,8 @@ impl WindowLocalOptions {
     self.line_break = value;
   }
 
+  /// The 'scroll-off' option, default to `0`.
+  /// See: <https://vimhelp.org/options.txt.html#%27scrolloff%27>.
   pub fn scroll_off(&self) -> u16 {
     self.scroll_off
   }

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -19,6 +19,7 @@ pub struct WindowLocalOptions {
 
 impl WindowLocalOptions {
   /// The 'wrap' option, also known as 'line-wrap', default to `true`.
+  ///
   /// See: <https://vimhelp.org/options.txt.html#%27wrap%27>.
   pub fn wrap(&self) -> bool {
     self.wrap
@@ -29,6 +30,7 @@ impl WindowLocalOptions {
   }
 
   /// The 'line-break' option, also known as 'word-wrap', default to `false`.
+  ///
   /// See: <https://vimhelp.org/options.txt.html#%27linebreak%27>.
   pub fn line_break(&self) -> bool {
     self.line_break
@@ -39,6 +41,7 @@ impl WindowLocalOptions {
   }
 
   /// The 'scroll-off' option, default to `0`.
+  ///
   /// See: <https://vimhelp.org/options.txt.html#%27scrolloff%27>.
   pub fn scroll_off(&self) -> u16 {
     self.scroll_off


### PR DESCRIPTION
This PR fixes the edge case: when cursor moving vertically from the end position of a longer line to shorter line, the cursor will have to re-locate its position to the end of the shorter line (because the shorter line has less chars and doesn't have the same char position compared with the longer line).