### PR TITLE
fix(miri): fix potential memory safety issue previously detected by cargo miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,23 +27,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: crate-ci/typos@master
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: miri,rust-src
-      - uses: actions/checkout@v4
-      - name: (Experimental) Cargo miri
-        env:
-          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-permissive-provenance"
-          RUSTC_WRAPPER: "sccache"
-          SCCACHE_GHA_ENABLED: "true"
-        # Disable simd features
-        run: |
-          # sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' Cargo.toml
-          # sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' ./rsvim_core/Cargo.toml
-          git diff --color=always
-          cargo +nightly miri test --no-default-features
   lint:
     name: Lint
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: (Experimental) Cargo miri
         env:
-          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-permissive-provenance -Zmiri-disable-stacked-borrows"
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-permissive-provenance"
           RUSTC_WRAPPER: "sccache"
           SCCACHE_GHA_ENABLED: "true"
         # Disable simd features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ env:
   RUSTFLAGS: "-Dwarnings"
   RUST_BACKTRACE: "full"
 jobs:
-  lint:
-    name: Lint
+  check:
+    name: Check
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,21 +17,15 @@ env:
   RUSTFLAGS: "-Dwarnings"
   RUST_BACKTRACE: "full"
 jobs:
-  pr:
-    name: PR
+  lint:
+    name: Lint
     runs-on: ubuntu-22.04
-    if: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: crate-ci/typos@master
-  lint:
-    name: Lint
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
           SCCACHE_GHA_ENABLED: "true"
         # Disable simd features
         run: |
-          sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' Cargo.toml
-          sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' ./rsvim_core/Cargo.toml
+          # sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' Cargo.toml
+          # sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' ./rsvim_core/Cargo.toml
           git diff --color=always
-          cargo +nightly miri test
+          cargo +nightly miri test --no-default-features
   lint:
     name: Lint
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly_miri.yml
+++ b/.github/workflows/nightly_miri.yml
@@ -38,7 +38,5 @@ jobs:
           RUSTC_WRAPPER: "sccache"
           SCCACHE_GHA_ENABLED: "true"
         run: |
-          # sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' Cargo.toml
-          # sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' ./rsvim_core/Cargo.toml
           git diff --color=always
-          cargo +nightly miri test --no-default-features
+          cargo +nightly miri test -p rsvim_core -F unicode_lines --no-default-features

--- a/.github/workflows/nightly_miri.yml
+++ b/.github/workflows/nightly_miri.yml
@@ -1,0 +1,44 @@
+name: Cargo Miri
+permissions:
+  contents: write
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: false
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CARGO_NET_RETRY: 3
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+  RUST_BACKTRACE: "full"
+  RUSTUP_MAX_RETRIES: 3
+  GH_TOKEN: ${{ github.token }}
+defaults:
+  run:
+    shell: bash
+jobs:
+  miri:
+    name: (Experimental) Cargo Miri
+    runs-on: ubuntu-22.04
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri,rust-src
+      - name: miri
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-permissive-provenance"
+          RUSTC_WRAPPER: "sccache"
+          SCCACHE_GHA_ENABLED: "true"
+        run: |
+          # sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' Cargo.toml
+          # sed -i 's/ropey[[:space:]]*=[[:space:]]*{/ropey = { default-features=false, features=["unicode_lines"],/' ./rsvim_core/Cargo.toml
+          git diff --color=always
+          cargo +nightly miri test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,7 @@ futures = "0.3"
 # bytes = { version = "1" }
 # serde_json = "1.0.132"
 compact_str = { version = "0.9", features = ["bytes"] }
-ropey = { version = "1.6.1", default-features = false, features = [
-  "unicode_lines",
-] }
+ropey = { version = "1.6.1", default-features = false }
 geo = { version = "0.28.0" }
 num-traits = "0.2.19"
 parking_lot = "0.12.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,9 @@ futures = "0.3"
 # bytes = { version = "1" }
 # serde_json = "1.0.132"
 compact_str = { version = "0.9", features = ["bytes"] }
-ropey = { version = "1.6.1" }
+ropey = { version = "1.6.1", default-features = false, features = [
+  "unicode_lines",
+] }
 geo = { version = "0.28.0" }
 num-traits = "0.2.19"
 parking_lot = "0.12.3"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The VIM editor reinvented in Rust+TypeScript.
   <a href="https://docs.rs/rsvim_core/latest/"><img alt="rsvim_core" src="https://img.shields.io/docsrs/rsvim_core?label=docs.rs" /></a>
   <a href="https://github.com/rsvim/rsvim/actions/workflows/release.yml"><img alt="release.yml" src="https://img.shields.io/github/actions/workflow/status/rsvim/rsvim/release.yml" /></a>
   <a href="https://github.com/rsvim/rsvim/actions/workflows/ci.yml"><img alt="ci.yml" src="https://img.shields.io/github/actions/workflow/status/rsvim/rsvim/ci.yml?branch=main&label=ci" /></a>
-  <!-- <a href="https://github.com/rsvim/rsvim/actions/workflows/js.yml"><img alt="js.yml" src="https://img.shields.io/github/actions/workflow/status/rsvim/rsvim/js.yml?branch=main&label=js" /></a> -->
+  <a href="https://github.com/rsvim/rsvim/actions/workflows/nightly_miri.yml"><img alt="nightly_miri.yml" src="https://img.shields.io/github/actions/workflow/status/rsvim/rsvim/nightly_miri.yml?branch=main&label=nightly%20miri" /></a>
   <a href="https://app.codecov.io/gh/rsvim/rsvim"><img alt="codecov" src="https://img.shields.io/codecov/c/github/rsvim/rsvim/main" /></a>
   <!-- <a href="https://app.codacy.com/gh/rsvim/rsvim/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img alt="codacy" src="https://img.shields.io/codacy/grade/1c6a3d21352c4f8bb84ff6c7e3ef0399/main" /></a> -->
   <a href="https://discord.gg/5KtRUCAByB"><img alt="discord" src="https://img.shields.io/discord/1220171472329379870?label=discord" /></a>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The VIM editor reinvented in Rust+TypeScript.
   <!-- <a href="https://github.com/rsvim/rsvim/actions/workflows/js.yml"><img alt="js.yml" src="https://img.shields.io/github/actions/workflow/status/rsvim/rsvim/js.yml?branch=main&label=js" /></a> -->
   <a href="https://app.codecov.io/gh/rsvim/rsvim"><img alt="codecov" src="https://img.shields.io/codecov/c/github/rsvim/rsvim/main" /></a>
   <!-- <a href="https://app.codacy.com/gh/rsvim/rsvim/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img alt="codacy" src="https://img.shields.io/codacy/grade/1c6a3d21352c4f8bb84ff6c7e3ef0399/main" /></a> -->
-  <a href="https://discord.gg/5KtRUCAByB"><img alt="push.yml" src="https://img.shields.io/discord/1220171472329379870?label=discord" /></a>
+  <a href="https://discord.gg/5KtRUCAByB"><img alt="discord" src="https://img.shields.io/discord/1220171472329379870?label=discord" /></a>
 </p>
 
 > [!CAUTION]

--- a/dev.py
+++ b/dev.py
@@ -251,7 +251,7 @@ if __name__ == "__main__":
     )
 
     parser = parser.parse_args()
-    print(parser)
+    # print(parser)
 
     if parser.subcommand == "clippy" or parser.subcommand == "c":
         clippy(parser.watch, parser.recache)

--- a/dev.py
+++ b/dev.py
@@ -61,7 +61,7 @@ def test(name, recache, miri):
         )
         cpu_cores = os.cpu_count()
         cpu_cores = cpu_cores if cpu_cores is not None else 1
-        workers = max(4, cpu_cores * 4 + 1)
+        workers = max(8, cpu_cores * 8 + 1)
         command = (
             f"{command} cargo +nightly miri test {name} -- --test-threads {workers}"
         )

--- a/dev.py
+++ b/dev.py
@@ -14,6 +14,14 @@ WINDOWS = platform.system().startswith("Windows") or platform.system().startswit
 )
 
 
+def now_millisecs():
+    return time.time_ns() // 1_000_000
+
+
+def format_millisecs_in_secs(ms):
+    return format(ms / 1000, ".3f")
+
+
 def set_env(command, name, value):
     assert isinstance(command, str)
     if WINDOWS:
@@ -73,12 +81,14 @@ def test(name, recache, miri):
 
     command = command.strip()
     print(command)
-    start_at = time.time_ns() // 1_000_000
-    print(f"start at: {start_at}ms")
+    start_at = now_millisecs()
+    print(f"start at: {format_millisecs_in_secs(start_at)}s")
     os.system(command)
-    stop_at = time.time_ns() // 1_000_000
+    stop_at = now_millisecs()
     used = stop_at - start_at
-    print(f"stop at: {stop_at}ms, used: {used}ms")
+    print(
+        f"stop at: {format_millisecs_in_secs(stop_at)}s, used: {format_millisecs_in_secs(used)}s"
+    )
 
 
 def list_test(recache):

--- a/dev.py
+++ b/dev.py
@@ -73,10 +73,10 @@ def test(name, recache, miri):
 
     command = command.strip()
     print(command)
-    start_at = time.time_ns()
+    start_at = time.time_ns() // 1_000_000
     print(f"start at: {start_at}ms")
     os.system(command)
-    stop_at = time.time_ns()
+    stop_at = time.time_ns() // 1_000_000
     used = stop_at - start_at
     print(f"stop at: {stop_at}ms, used: {used}ms")
 

--- a/dev.py
+++ b/dev.py
@@ -56,7 +56,15 @@ def test(name, recache, miri):
     command = ""
 
     if miri:
-        command = f"cargo +nightly miri test --no-default-features {name}"
+        command = set_env(
+            "", "MIRIFLAGS", "'-Zmiri-disable-isolation -Zmiri-permissive-provenance'"
+        )
+        cpu_cores = os.cpu_count()
+        cpu_cores = cpu_cores if cpu_cores is not None else 1
+        workers = max(4, cpu_cores * 4 + 1)
+        command = (
+            f"{command} cargo +nightly miri test {name} -- --test-threads {workers}"
+        )
     else:
         command = set_env("", "RSVIM_LOG", "trace")
         command = set_sccache(command, recache)

--- a/dev.py
+++ b/dev.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import pathlib
 import platform
+import time
 
 WINDOWS = platform.system().startswith("Windows") or platform.system().startswith(
     "CYGWIN_NT"
@@ -72,7 +73,12 @@ def test(name, recache, miri):
 
     command = command.strip()
     print(command)
+    start_at = time.time_ns()
+    print(f"start at: {start_at}ms")
     os.system(command)
+    stop_at = time.time_ns()
+    used = stop_at - start_at
+    print(f"stop at: {stop_at}ms, used: {used}ms")
 
 
 def list_test(recache):

--- a/dev.py
+++ b/dev.py
@@ -181,6 +181,7 @@ if __name__ == "__main__":
         "-l",
         "--list",
         action="store_true",
+        dest="list_test",
         help="List all test cases instead of running them",
     )
     test_subparser.add_argument(
@@ -202,7 +203,7 @@ if __name__ == "__main__":
     test_subparser.add_argument(
         "--threads",
         type=int,
-        dest="N",
+        metavar="N",
         help="Run tests (include `miri`) concurrently with multiple threads",
     )
 
@@ -250,7 +251,7 @@ if __name__ == "__main__":
     )
 
     parser = parser.parse_args()
-    # print(parser)
+    print(parser)
 
     if parser.subcommand == "clippy" or parser.subcommand == "c":
         clippy(parser.watch, parser.recache)

--- a/rsvim_core/Cargo.toml
+++ b/rsvim_core/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 
 [features]
 default = ["simd", "unicode_lines"]
-simd = ["ropey/simd", "str_indices/simd"]
+simd = ["ropey/simd"]
 unicode_lines = ["ropey/unicode_lines"]
 
 [dependencies]

--- a/rsvim_core/Cargo.toml
+++ b/rsvim_core/Cargo.toml
@@ -17,6 +17,10 @@ description = "The core library for the RSVIM editor."
 [lib]
 doctest = false
 
+[features]
+default = ["simd"]
+simd = ["ropey/simd"]
+
 [dependencies]
 crossterm = { workspace = true, features = ["event-stream"] }
 jiff = { workspace = true, features = ["tzdb-bundle-always"] }
@@ -31,7 +35,9 @@ tokio-util = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive", "unicode"] }
 futures = { workspace = true }
 compact_str = { workspace = true, features = ["bytes"] }
-ropey = { workspace = true }
+ropey = { workspace = true, default-features = false, features = [
+  "unicode_lines",
+] }
 geo = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }

--- a/rsvim_core/Cargo.toml
+++ b/rsvim_core/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 
 [features]
 default = ["simd", "unicode_lines"]
-simd = ["ropey/simd"]
+simd = ["ropey/simd", "str_indices/simd"]
 unicode_lines = ["ropey/unicode_lines"]
 
 [dependencies]

--- a/rsvim_core/Cargo.toml
+++ b/rsvim_core/Cargo.toml
@@ -17,6 +17,11 @@ description = "The core library for the RSVIM editor."
 [lib]
 doctest = false
 
+[features]
+default = ["simd", "unicode_lines"]
+simd = ["ropey/simd"]
+unicode_lines = ["ropey/unicode_lines"]
+
 [dependencies]
 crossterm = { workspace = true, features = ["event-stream"] }
 jiff = { workspace = true, features = ["tzdb-bundle-always"] }
@@ -31,9 +36,7 @@ tokio-util = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive", "unicode"] }
 futures = { workspace = true }
 compact_str = { workspace = true, features = ["bytes"] }
-ropey = { workspace = true, default-features = false, features = [
-  "unicode_lines",
-] }
+ropey = { workspace = true, default-features = false }
 geo = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }

--- a/rsvim_core/Cargo.toml
+++ b/rsvim_core/Cargo.toml
@@ -17,10 +17,6 @@ description = "The core library for the RSVIM editor."
 [lib]
 doctest = false
 
-[features]
-default = ["simd"]
-simd = ["ropey/simd"]
-
 [dependencies]
 crossterm = { workspace = true, features = ["event-stream"] }
 jiff = { workspace = true, features = ["tzdb-bundle-always"] }


### PR DESCRIPTION
Actually when running `cargo miri` again, the memory safety issue already disappears (mentioned in https://github.com/cessen/ropey/issues/103). Guess it is been fixed in my previous refactor PRs.

This PR also adjusts some workflows, avoid running `cargo miri` on every PRs and pushes because it uses too much time of github actions. Instead I will run `cargo miri` nightly.