### PR TITLE
feat(cursor): add search viewport anchor upward api

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -325,7 +325,7 @@ if __name__ == "__main__":
     )
 
     parser = parser.parse_args()
-    print(parser)
+    # print(parser)
 
     if parser.recache:
         RECACHE_SCCACHE = True

--- a/dev.py
+++ b/dev.py
@@ -98,7 +98,7 @@ def clippy(watch):
     os.system(command)
 
 
-def test(name, miri):
+def test(name, miri, jobs):
     append_lld_rustflags()
 
     if len(name) == 0:
@@ -107,6 +107,11 @@ def test(name, miri):
     else:
         name = " ".join(list(dict.fromkeys(name)))
         logging.info(f"Run 'test' for '{name}'")
+
+    if jobs is None:
+        jobs = ""
+    else:
+        jobs = f" -j {jobs[0]}"
 
     if miri is not None:
         command = set_env(
@@ -119,14 +124,14 @@ def test(name, miri):
         command = set_rustflags(command)
         if name is None:
             name = ""
-        command = f"{command} cargo +nightly miri nextest run -F unicode_lines --no-default-features -p {miri} {name}"
+        command = f"{command} cargo +nightly miri nextest run{jobs} -F unicode_lines --no-default-features -p {miri} {name}"
     else:
         command = set_env("", "RSVIM_LOG", "trace")
         command = set_sccache(command)
         command = set_rustflags(command)
         if name is None:
             name = "--all"
-        command = f"{command} cargo nextest run --no-capture {name}"
+        command = f"{command} cargo nextest run{jobs} --no-capture {name}"
 
     command = command.strip()
     logging.info(command)
@@ -259,6 +264,13 @@ if __name__ == "__main__":
         metavar="PACKAGE",
         help="Run `cargo +nightly miri test` on specified [PACKAGE]",
     )
+    test_subparser.add_argument(
+        "-j",
+        "--job",
+        nargs=1,
+        metavar="N",
+        help="Run `cargo nextest run` with N threads",
+    )
 
     build_subparser = subparsers.add_parser(
         "build",
@@ -313,7 +325,7 @@ if __name__ == "__main__":
     )
 
     parser = parser.parse_args()
-    logging.debug(parser)
+    print(parser)
 
     if parser.recache:
         RECACHE_SCCACHE = True
@@ -326,7 +338,7 @@ if __name__ == "__main__":
         if parser.list_test:
             list_test()
         else:
-            test(parser.name, parser.miri)
+            test(parser.name, parser.miri, parser.job)
     elif parser.subcommand == "build" or parser.subcommand == "b":
         build(parser.release, parser.features, parser.all_features)
     elif parser.subcommand == "doc" or parser.subcommand == "d":

--- a/rsvim_core/src/buf/cidx.rs
+++ b/rsvim_core/src/buf/cidx.rs
@@ -462,7 +462,6 @@ mod tests {
 
   use crate::buf::BufferLocalOptionsBuilder;
   use crate::test::buf::{make_buffer_from_rope, make_rope_from_lines, print_buffer_line_details};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
 
   use ropey::Rope;

--- a/rsvim_core/src/envar/path_config.rs
+++ b/rsvim_core/src/envar/path_config.rs
@@ -12,7 +12,6 @@ pub struct PathConfig {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 struct CachedDirs {
   config_dir: PathBuf,
   home_dir: PathBuf,

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -37,7 +37,6 @@ pub mod msg;
 pub mod transpiler;
 
 #[derive(Debug, Default, Clone)]
-#[allow(dead_code)]
 pub struct JsRuntimeOptions {
   // // The seed used in Math.random() method.
   // pub seed: Option<i64>,

--- a/rsvim_core/src/ui/canvas/frame/cell.rs
+++ b/rsvim_core/src/ui/canvas/frame/cell.rs
@@ -1,7 +1,5 @@
 //! Basic unit of canvas frame.
 
-#![allow(dead_code)]
-
 use compact_str::{CompactString, ToCompactString};
 use crossterm::style::{Attributes, Color};
 

--- a/rsvim_core/src/ui/tree.rs
+++ b/rsvim_core/src/ui/tree.rs
@@ -1,7 +1,5 @@
 //! The widget tree that manages all the widget components.
 
-#![allow(dead_code)]
-
 use crate::prelude::*;
 use crate::ui::canvas::{Canvas, CanvasArc};
 use crate::ui::widget::Widgetable;

--- a/rsvim_core/src/ui/widget/window.rs
+++ b/rsvim_core/src/ui/widget/window.rs
@@ -21,7 +21,6 @@ pub mod opt;
 pub mod root;
 pub mod viewport;
 
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 /// The Vim window, it manages all descendant widget nodes, i.e. all widgets in the
 /// [`crate::ui::widget::window`] module.
@@ -354,7 +353,6 @@ mod tests {
   use crate::buf::{Buffer, BufferArc, BufferLocalOptions, BufferLocalOptionsBuilder};
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Tree;
 

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6421,19 +6421,13 @@ mod tests_search_anchor_upwnward_nowrap {
       );
     }
 
-    // Search-1
+    // Prepare
     {
-      let expect = vec![
-        "Hello, RSVIM!\n",
-        "This is a quite s",
-        "But still it cont",
-        "\t1. When",
-        "\t2. When",
-      ];
+      let expect = vec!["\t1. ", "\t2. ", "\t\t3", "\t\t4", ""];
 
       let actual = {
-        let target_cursor_line = 2;
-        let target_cursor_char = 15;
+        let target_cursor_line = 7;
+        let target_cursor_char = 0;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5709,7 +5709,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         &actual,
         &expect,
         0,
-        3,
+        2,
         &expect_start_fills,
         &expect_end_fills,
       );
@@ -5717,17 +5717,11 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
 
     // Search-1
     {
-      let expect = vec![
-        "Hello, RSVIM!\n",
-        "This is a quite s",
-        "imple and small t",
-        "est lines.\n",
-        "But still it cont",
-      ];
+      let expect = vec!["line\tis", "\tsmall", "\tenough", "\tto", "\tcompletel"];
 
       let actual = {
         let target_cursor_line = 1;
-        let target_cursor_char = 43;
+        let target_cursor_char = 37;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
@@ -5740,8 +5734,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 0);
-        assert_eq!(start_column, 0);
+        assert_eq!(start_line, 1);
+        assert_eq!(start_column, 34);
 
         let viewport = Viewport::view(
           &buf,
@@ -5760,15 +5754,65 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> =
-        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> =
-        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        0,
+        1,
+        2,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-2
+    {
+      let expect = vec!["t\t\t", "too\tlong", "\tto", "\tcompletel", "y\tput:\n"];
+
+      let actual = {
+        let target_cursor_line = 2;
+        let target_cursor_char = 37;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 24);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        2,
         3,
         &expect_start_fills,
         &expect_end_fills,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6348,4 +6348,1024 @@ mod tests_search_anchor_downward_wrap_linebreak {
     }
   }
 }
+#[allow(unused_imports)]
+#[cfg(test)]
+mod tests_search_anchor_upwnward_nowrap {
+  use super::tests_util::*;
+  use super::*;
+
+  use crate::buf::BufferLocalOptionsBuilder;
+  use crate::lock;
+  use crate::prelude::*;
+  use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
+  #[allow(dead_code)]
+  use crate::test::log::init as test_log_init;
+  use crate::ui::tree::Inodeable;
+
+  use std::cell::RefCell;
+  use std::rc::Rc;
+
+  #[test]
+  fn new1() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(17, 5);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let win_opts = make_nowrap();
+
+    let buf = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+
+    let window = Rc::new(RefCell::new(make_window(
+      terminal_size,
+      buf.clone(),
+      &win_opts,
+    )));
+
+    // Initialize
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+      ];
+
+      let actual = lock!(window.borrow().viewport()).clone();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+      ];
+
+      let actual = {
+        let target_cursor_line = 2;
+        let target_cursor_char = 15;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-2
+    {
+      let expect = vec![
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+        "\t\t3",
+      ];
+
+      let actual = {
+        let target_cursor_line = 5;
+        let target_cursor_char = 1;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 1);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 2), (4, 2), (5, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        1,
+        6,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-3
+    {
+      let expect = vec!["ut still it conta", "1. When", "2. When", "\t3.", "\t4."];
+
+      let actual = {
+        let target_cursor_line = 6;
+        let target_cursor_char = 3;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 1);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 7), (4, 7), (5, 7), (6, 7)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 3), (4, 3), (5, 0), (6, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        2,
+        7,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-4
+    {
+      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
+
+      let actual = {
+        let target_cursor_line = 7;
+        let target_cursor_char = 3;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+  }
+
+  #[test]
+  fn new2() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(17, 5);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let win_opts = make_nowrap();
+
+    let buf = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+
+    let window = Rc::new(RefCell::new(make_window(
+      terminal_size,
+      buf.clone(),
+      &win_opts,
+    )));
+
+    // Initialize
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+      ];
+
+      let actual = lock!(window.borrow().viewport()).clone();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec![
+        "",
+        "nd small test lin",
+        "veral things we w",
+        "he\tline",
+        "t\t\t",
+      ];
+
+      let actual = {
+        let target_cursor_line = 2;
+        let target_cursor_char = 40;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 24);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 3), (4, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-2
+    {
+      let expect = vec!["", "", "", "ut\tinside.", ""];
+
+      let actual = {
+        let target_cursor_line = 3;
+        let target_cursor_char = 130;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 112);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-3
+    {
+      let expect = vec!["", "", "", "mpletely\tp", ":\n"];
+
+      let actual = {
+        let target_cursor_line = 4;
+        let target_cursor_char = 100;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 95);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-4
+    {
+      let expect = vec!["", "", "", "", "not\tset."];
+
+      let actual = {
+        let target_cursor_line = 5;
+        let target_cursor_char = 100;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 1);
+        assert_eq!(start_column, 145);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 2)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        1,
+        6,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-5
+    {
+      let expect = vec!["", "\tcompletel", "put:\n", "\tand", "if\teither"];
+
+      let actual = {
+        let target_cursor_line = 6;
+        let target_cursor_char = 50;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 85);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 7), (5, 0), (6, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 6), (6, 1)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        2,
+        7,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-6
+    {
+      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
+
+      let actual = {
+        let target_cursor_line = 7;
+        let target_cursor_char = 0;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+  }
+
+  #[test]
+  fn new3() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(17, 5);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let win_opts = make_nowrap();
+
+    let buf = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+
+    let window = Rc::new(RefCell::new(make_window(
+      terminal_size,
+      buf.clone(),
+      &win_opts,
+    )));
+
+    // Initialize
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+      ];
+
+      let actual = lock!(window.borrow().viewport()).clone();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec![
+        "",
+        "nd small test lin",
+        "veral things we w",
+        "he\tline",
+        "t\t\t",
+      ];
+
+      let actual = {
+        let target_cursor_line = 2;
+        let target_cursor_char = 40;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 24);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 3), (4, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-2
+    {
+      let expect = vec!["", "", "", "ut\tinside.", ""];
+
+      let actual = {
+        let target_cursor_line = 3;
+        let target_cursor_char = 130;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 112);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-3
+    {
+      let expect = vec!["", "", "", "to\tcom", "etely\tput:"];
+
+      let actual = {
+        let target_cursor_line = 4;
+        let target_cursor_char = 30;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 79);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 4), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-4
+    {
+      let expect = vec!["", "", "inside.\n", "", "options\ta"];
+
+      let actual = {
+        let target_cursor_line = 5;
+        let target_cursor_char = 80;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 1);
+        assert_eq!(start_column, 120);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 2), (4, 0), (5, 1)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        1,
+        6,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-5
+    {
+      let expect = vec![
+        "l it contains sev",
+        "1. When\tth",
+        "2. When\tit",
+        "\t3. The ex",
+        "\t4. The ex",
+      ];
+
+      let actual = {
+        let target_cursor_line = 6;
+        let target_cursor_char = 1;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 8);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        2,
+        7,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-6
+    {
+      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
+
+      let actual = {
+        let target_cursor_line = 7;
+        let target_cursor_char = 0;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor_downward(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+  }
+}
 // spellchecker:on

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7847,7 +7847,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
   }
 
   #[test]
-  fn _new2() {
+  fn new2() {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5488,7 +5488,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 4);
-        assert_eq!(start_column, 11);
+        assert_eq!(start_column, 8);
 
         let viewport = Viewport::view(
           &buf,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7443,6 +7443,64 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
       );
     }
 
+    // Prepare
+    {
+      let expect = vec![
+        "But still it cont",
+        "ains several thin",
+        "gs we want to tes",
+        "t:\n",
+        "\t1. When",
+      ];
+
+      let actual = {
+        let target_cursor_line = 7;
+        let target_cursor_char = 0;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 2)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        2,
+        4,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
     // Search-1
     {
       let expect = vec![
@@ -7454,14 +7512,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
       ];
 
       let actual = {
-        let target_cursor_line = 2;
-        let target_cursor_char = 15;
+        let target_cursor_line = 6;
+        let target_cursor_char = 280;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7512,14 +7570,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
       ];
 
       let actual = {
-        let target_cursor_line = 3;
+        let target_cursor_line = 5;
         let target_cursor_char = 60;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7566,7 +7624,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7611,14 +7669,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
       ];
 
       let actual = {
-        let target_cursor_line = 5;
+        let target_cursor_line = 3;
         let target_cursor_char = 82;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7663,7 +7721,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
       ];
 
       let actual = {
-        let target_cursor_line = 6;
+        let target_cursor_line = 2;
         let target_cursor_char = 82;
 
         let mut window = window.borrow_mut();
@@ -7709,8 +7767,54 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
       let expect = vec![""];
 
       let actual = {
-        let target_cursor_line = 7;
+        let target_cursor_line = 1;
         let target_cursor_char = 0;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 7);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        7,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-7
+    {
+      let expect = vec![""];
+
+      let actual = {
+        let target_cursor_line = 0;
+        let target_cursor_char = 8;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
@@ -7752,7 +7856,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
   }
 
   #[test]
-  fn new2() {
+  fn _new2() {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5997,7 +5997,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
 
     // Search-3
     {
-      let expect = vec!["When\tit", "\t\t", "too\tlong", "\tto", "\t"];
+      let expect = vec!["too\tlong", "\tto", "\t", "completely", "\tput:\n"];
 
       let actual = {
         let target_cursor_line = 4;

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6834,6 +6834,62 @@ mod tests_search_anchor_upward_nowrap {
         &expect_end_fills,
       );
     }
+
+    // Search-7
+    {
+      let expect = vec![
+        "SVIM!\n",
+        "a quite simple an",
+        "l it contains sev",
+        "1. When\tth",
+        "2. When\tit",
+      ];
+
+      let actual = {
+        let target_cursor_line = 0;
+        let target_cursor_char = 8;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 8);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
   }
 
   #[test]

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -488,7 +488,6 @@ impl CursorViewport {
 /// 3. Start from bottom left corner.
 /// 4. Start from bottom right corner.
 // spellchecker:on
-#[allow(dead_code)]
 pub struct Viewport {
   // Start line index (in the buffer), starts from 0.
   start_line_idx: usize,
@@ -504,6 +503,8 @@ pub struct Viewport {
 }
 
 arc_impl!(Viewport);
+
+pub struct ViewportSearchDirection {}
 
 impl Viewport {
   /// Calculate viewport downward, from top to bottom.
@@ -681,7 +682,7 @@ impl Viewport {
 }
 
 // spellchecker:off
-#[allow(unused_imports, dead_code)]
+#[allow(unused_imports)]
 #[cfg(test)]
 mod tests_util {
   use super::*;
@@ -690,7 +691,6 @@ mod tests_util {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Tree;
   use crate::ui::tree::*;
@@ -861,7 +861,6 @@ mod tests_view_nowrap {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
 
   #[test]
@@ -1320,7 +1319,6 @@ mod tests_view_nowrap_startcol {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Inodeable;
 
@@ -1650,7 +1648,6 @@ mod tests_view_nowrap_startcol {
 //   use crate::buf::BufferLocalOptionsBuilder;
 //   use crate::prelude::*;
 //   use crate::test::buf::make_buffer_from_lines;
-//   #[allow(dead_code)]
 //   use crate::test::log::init as test_log_init;
 //   use crate::ui::tree::*;
 //   use crate::wlock;
@@ -1907,7 +1904,6 @@ mod tests_view_wrap_nolinebreak {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::*;
 
@@ -2596,7 +2592,6 @@ mod tests_view_wrap_nolinebreak_startcol {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::*;
 
@@ -2851,7 +2846,6 @@ mod tests_view_wrap_linebreak {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
 
   #[test]
@@ -3581,7 +3575,6 @@ mod tests_view_wrap_linebreak_startcol {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Inodeable;
 
@@ -3887,7 +3880,6 @@ mod tests_search_anchor_downward_nowrap {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Inodeable;
 
@@ -4907,7 +4899,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Inodeable;
 
@@ -5638,7 +5629,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Inodeable;
 
@@ -6357,7 +6347,6 @@ mod tests_search_anchor_upwnward_nowrap {
   use crate::lock;
   use crate::prelude::*;
   use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  #[allow(dead_code)]
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Inodeable;
 

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6578,8 +6578,8 @@ mod tests_search_anchor_upward_nowrap {
       let expect = vec!["ut still it conta", "1. When", "2. When", "\t3.", "\t4."];
 
       let actual = {
-        let target_cursor_line = 6;
-        let target_cursor_char = 3;
+        let target_cursor_line = 5;
+        let target_cursor_char = 60;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
@@ -6592,8 +6592,8 @@ mod tests_search_anchor_upward_nowrap {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 2);
-        assert_eq!(start_column, 1);
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 79);
 
         let viewport = Viewport::view(
           &buf,
@@ -6606,18 +6606,18 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 7), (4, 7), (5, 7), (6, 7)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 1), (4, 7), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 3), (4, 3), (5, 0), (6, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 1), (4, 6), (5, 6), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        2,
-        7,
+        3,
+        8,
         &expect_start_fills,
         &expect_end_fills,
       );

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6486,7 +6486,7 @@ mod tests_search_anchor_upwnward_nowrap {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 7);
+        assert_eq!(start_line, 3);
         assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
@@ -6534,8 +6534,8 @@ mod tests_search_anchor_upwnward_nowrap {
       ];
 
       let actual = {
-        let target_cursor_line = 5;
-        let target_cursor_char = 1;
+        let target_cursor_line = 6;
+        let target_cursor_char = 40;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
@@ -6548,7 +6548,7 @@ mod tests_search_anchor_upwnward_nowrap {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 1);
+        assert_eq!(start_line, 3);
         assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
@@ -6562,18 +6562,18 @@ mod tests_search_anchor_upwnward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 2), (4, 2), (5, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        1,
-        6,
+        3,
+        8,
         &expect_start_fills,
         &expect_end_fills,
       );

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7637,7 +7637,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
       };
 
       let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0), (5, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0), (5, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0), (5, 6)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6722,6 +6722,56 @@ mod tests_search_anchor_upward_nowrap {
         &expect_end_fills,
       );
     }
+
+    // Search-5
+    {
+      let expect = vec!["things we want to", "line\ti", "\ttoo", "arts are been tru", "arts are split in"];
+
+      let actual = {
+        let target_cursor_line = 2;
+        let target_cursor_char = 30;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 30);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2,0), (3, 4), (4, 3), (5, 0), (6, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2,0), (3, 0), (4, 3), (5, 0), (6, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        2,
+        7,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
   }
 
   #[test]

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6575,7 +6575,7 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-2
     {
-      let expect = vec!["ut still it conta", "1. When", "2. When", "\t3.", "\t4."];
+      let expect = vec!["to\tcom", "etely\tput:", "e-wrap\tand", "if\te", ""];
 
       let actual = {
         let target_cursor_line = 5;
@@ -6606,10 +6606,10 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 1), (4, 7), (5, 0), (6, 0), (7, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 4), (4, 0), (5, 0), (6, 6), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 1), (4, 6), (5, 6), (6, 0), (7, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6778,6 +6778,62 @@ mod tests_search_anchor_upward_nowrap {
         &expect_end_fills,
       );
     }
+
+    // Search-6
+    {
+      let expect = vec![
+        "ll test lines.\n",
+        "things we want to",
+        "line\ti",
+        "\ttoo",
+        "arts are been tru",
+      ];
+
+      let actual = {
+        let target_cursor_line = 1;
+        let target_cursor_char = 32;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 1);
+        assert_eq!(start_column, 30);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 4), (4, 3), (5, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 3), (5, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        1,
+        6,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
   }
 
   #[test]

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -8051,7 +8051,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
 
     // Search-3
     {
-      let expect = vec!["\tput:\n"];
+      let expect = vec!["t\t\t", "too\tlong", "\tto", "\tcompletel", "y\tput:\n"];
 
       let actual = {
         let target_cursor_line = 4;
@@ -8069,7 +8069,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 4);
-        assert_eq!(start_column, 84);
+        assert_eq!(start_column, 24);
 
         let viewport = Viewport::view(
           &buf,
@@ -8082,14 +8082,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0), (5, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0), (5, 6)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
         4,
-        6,
+        5,
         &expect_start_fills,
         &expect_end_fills,
       );
@@ -8098,11 +8098,11 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
     // Search-4
     {
       let expect = vec![
-        "both\tline-",
-        "wrap\tand",
-        "\tword-wrap",
-        "\toptions",
-        "\tare",
+        "small\tenou",
+        "gh\tto",
+        "\tcompletel",
+        "y\tput",
+        "\tinside.\n",
       ];
 
       let actual = {
@@ -8120,8 +8120,8 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 5);
-        assert_eq!(start_column, 64);
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 56);
 
         let viewport = Viewport::view(
           &buf,
@@ -8134,14 +8134,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(5, 6)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        5,
-        6,
+        3,
+        4,
         &expect_start_fills,
         &expect_end_fills,
       );
@@ -8150,11 +8150,11 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
     // Search-5
     {
       let expect = vec![
-        "if\teither",
-        "\tline-wrap",
-        "\tor",
-        "\tword-wrap",
-        "\toptions",
+        "But still it cont",
+        "ains several thin",
+        "gs we want to tes",
+        "t:\n",
+        "\t1. When",
       ];
 
       let actual = {
@@ -8165,15 +8165,15 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 6);
-        assert_eq!(start_column, 85);
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
           &buf,
@@ -8186,14 +8186,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(6, 2)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 2)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        6,
-        7,
+        2,
+        4,
         &expect_start_fills,
         &expect_end_fills,
       );
@@ -8201,7 +8201,13 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
 
     // Search-6
     {
-      let expect = vec![""];
+      let expect = vec![
+        "This is a quite s",
+        "imple and small t",
+        "est lines.\n",
+        "But still it cont",
+        "ains several thin",
+      ];
 
       let actual = {
         let target_cursor_line = 1;
@@ -8211,14 +8217,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 7);
+        assert_eq!(start_line, 1);
         assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
@@ -8232,14 +8238,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        7,
-        8,
+        1,
+        3,
         &expect_start_fills,
         &expect_end_fills,
       );
@@ -8247,7 +8253,13 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
 
     // Search-7
     {
-      let expect = vec![""];
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "imple and small t",
+        "est lines.\n",
+        "But still it cont",
+      ];
 
       let actual = {
         let target_cursor_line = 0;
@@ -8257,14 +8269,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 7);
+        assert_eq!(start_line, 0);
         assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
@@ -8278,14 +8290,16 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        7,
-        8,
+        0,
+        3,
         &expect_start_fills,
         &expect_end_fills,
       );
@@ -8346,19 +8360,13 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
       );
     }
 
-    // Search-1
+    // Prepare
     {
-      let expect = vec![
-        "Hello, RSVIM!\n",
-        "This is a quite s",
-        "imple and small t",
-        "est lines.\n",
-        "But still it cont",
-      ];
+      let expect = vec![""];
 
       let actual = {
-        let target_cursor_line = 1;
-        let target_cursor_char = 43;
+        let target_cursor_line = 7;
+        let target_cursor_char = 0;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
@@ -8371,7 +8379,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 0);
+        assert_eq!(start_line, 7);
         assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
@@ -8391,121 +8399,66 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> =
-        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> =
-        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        0,
-        3,
+        7,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec!["next\trow,", "\tif", "\teither", "\tline-wrap", "\tor"];
+
+      let actual = {
+        let target_cursor_line = 6;
+        let target_cursor_char = 70;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 6);
+        assert_eq!(start_column, 61);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(6, 7)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        6,
+        7,
         &expect_start_fills,
         &expect_end_fills,
       );
     }
 
     // Search-2
-    {
-      let expect = vec![
-        "small\tenou",
-        "gh\tto",
-        "\tcompletel",
-        "y\tput",
-        "\tinside.\n",
-      ];
-
-      let actual = {
-        let target_cursor_line = 3;
-        let target_cursor_char = 58;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 3);
-        assert_eq!(start_column, 56);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
-      info!("actual:{:?}", actual);
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        3,
-        4,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-3
-    {
-      let expect = vec!["2. When\tit", "\t\tt", "oo\tlong", "\tto", "\tcompletel"];
-
-      let actual = {
-        let target_cursor_line = 4;
-        let target_cursor_char = 30;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 4);
-        assert_eq!(start_column, 8);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        4,
-        5,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-4
     {
       let expect = vec![
         "both\tline-",
@@ -8517,13 +8470,13 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
 
       let actual = {
         let target_cursor_line = 5;
-        let target_cursor_char = 82;
+        let target_cursor_char = 80;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8557,32 +8510,26 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
       );
     }
 
-    // Search-5
+    // Search-3
     {
-      let expect = vec![
-        "xtra parts are sp",
-        "lit into the",
-        "\tnext",
-        "\trow,",
-        "\tif",
-      ];
+      let expect = vec!["t\t\t", "too\tlong", "\tto", "\tcompletel", "y\tput:\n"];
 
       let actual = {
-        let target_cursor_line = 6;
-        let target_cursor_char = 10;
+        let target_cursor_line = 4;
+        let target_cursor_char = 35;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 6);
+        assert_eq!(start_line, 4);
         assert_eq!(start_column, 24);
 
         let viewport = Viewport::view(
@@ -8596,39 +8543,91 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(6, 7)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        6,
-        7,
+        4,
+        5,
         &expect_start_fills,
         &expect_end_fills,
       );
     }
 
-    // Search-6
+    // Search-4
     {
-      let expect = vec![""];
+      let expect = vec!["line\tis", "\tsmall", "\tenough", "\tto", "\tcompletel"];
 
       let actual = {
-        let target_cursor_line = 7;
-        let target_cursor_char = 0;
+        let target_cursor_line = 3;
+        let target_cursor_char = 36;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 7);
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 34);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        4,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-5
+    {
+      let expect = vec![
+        "But still it cont",
+        "ains several thin",
+        "gs we want to tes",
+        "t:\n",
+        "\t1. When",
+      ];
+
+      let actual = {
+        let target_cursor_line = 2;
+        let target_cursor_char = 30;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
         assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
@@ -8642,14 +8641,120 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 2)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        7,
-        8,
+        2,
+        4,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-6
+    {
+      let expect = vec![
+        "This is a quite s",
+        "imple and small t",
+        "est lines.\n",
+        "But still it cont",
+        "ains several thin",
+      ];
+
+      let actual = {
+        let target_cursor_line = 1;
+        let target_cursor_char = 32;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 1);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        1,
+        3,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-7
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "imple and small t",
+        "est lines.\n",
+        "But still it cont",
+      ];
+
+      let actual = {
+        let target_cursor_line = 0;
+        let target_cursor_char = 8;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        3,
         &expect_start_fills,
         &expect_end_fills,
       );

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6397,7 +6397,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
 }
 #[allow(unused_imports)]
 #[cfg(test)]
-mod tests_search_anchor_upwnward_nowrap {
+mod tests_search_anchor_upward_nowrap {
   use super::tests_util::*;
   use super::*;
 

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5677,8 +5677,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
       terminal_size.height(),
       buf_opts,
       vec![
-        "Hello, RSVIM!\n",
-        "This is a quite simple and small test lines.\n",
         "But still it contains several things we want to test:\n",
         "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
         "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
@@ -5696,18 +5694,16 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
     // Initialize
     {
       let expect = vec![
-        "Hello, RSVIM!\n",
-        "This is a quite s",
-        "imple and small t",
-        "est lines.\n",
         "But still it cont",
+        "ains several thin",
+        "gs we want to tes",
+        "t:\n",
+        "\t1. When",
       ];
 
       let actual = lock!(window.borrow().viewport()).clone();
-      let expect_start_fills: BTreeMap<usize, usize> =
-        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> =
-        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 2)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6654,7 +6654,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
 
     // Search-2
     {
-      let expect = vec!["too\tlong", "\tto", "\t", "completely", "\tput:\n"];
+      let expect = vec!["\tlong", "\tto", "\t", "completely", "\tput:\n"];
 
       let actual = {
         let target_cursor_line = 2;
@@ -6672,7 +6672,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 2);
-        assert_eq!(start_column, 41);
+        assert_eq!(start_column, 44);
 
         let viewport = Viewport::view(
           &buf,
@@ -6701,7 +6701,13 @@ mod tests_search_anchor_downward_wrap_linebreak {
 
     // Search-3
     {
-      let expect = vec!["\t\t", "too\tlong", "\tto", "\t", "completely"];
+      let expect = vec![
+        " truncated if",
+        "\tboth",
+        "\tline-wrap",
+        "\tand",
+        "\tword-wrap",
+      ];
 
       let actual = {
         let target_cursor_line = 3;
@@ -6719,7 +6725,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 3);
-        assert_eq!(start_column, 41);
+        assert_eq!(start_column, 43);
 
         let viewport = Viewport::view(
           &buf,
@@ -6747,13 +6753,53 @@ mod tests_search_anchor_downward_wrap_linebreak {
 
     // Search-4
     {
-      let expect = vec![
-        "both\tline-",
-        "wrap\tand",
-        "\tword-wrap",
-        "\toptions",
-        "\tare",
-      ];
+      let expect = vec![" split into the", "\tnext", "\trow,", "\tif", "\teither"];
+
+      let actual = {
+        let target_cursor_line = 4;
+        let target_cursor_char = 30;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 4);
+        assert_eq!(start_column, 38);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        4,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-5
+    {
+      let expect = vec![""];
 
       let actual = {
         let target_cursor_line = 5;
@@ -6771,7 +6817,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 5);
-        assert_eq!(start_column, 64);
+        assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
           &buf,
@@ -6792,104 +6838,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         &expect,
         5,
         6,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-5
-    {
-      let expect = vec![
-        " extra parts are ",
-        "split into the",
-        "\tnext",
-        "\trow,",
-        "\tif",
-      ];
-
-      let actual = {
-        let target_cursor_line = 6;
-        let target_cursor_char = 10;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 6);
-        assert_eq!(start_column, 22);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        6,
-        7,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-6
-    {
-      let expect = vec![""];
-
-      let actual = {
-        let target_cursor_line = 7;
-        let target_cursor_char = 0;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 7);
-        assert_eq!(start_column, 0);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        7,
-        8,
         &expect_start_fills,
         &expect_end_fills,
       );

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6015,7 +6015,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 4);
-        assert_eq!(start_column, 13);
+        assert_eq!(start_column, 41);
 
         let viewport = Viewport::view(
           &buf,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -504,7 +504,13 @@ pub struct Viewport {
 
 arc_impl!(Viewport);
 
-pub struct ViewportSearchDirection {}
+#[derive(Debug, Copy, Clone)]
+pub enum ViewportSearchDirection {
+  Up,
+  Down,
+  Left,
+  Right,
+}
 
 impl Viewport {
   /// Calculate viewport downward, from top to bottom.
@@ -542,22 +548,34 @@ impl Viewport {
   /// NOTE: If target cursor line/char position cannot be correctly shown in new viewport, the
   /// viewport will be adjusted to show target cursor correctly, with a minimal movement (for
   /// better user visuals).
-  pub fn search_anchor_downward(
+  pub fn search_anchor(
     &self,
+    direction: ViewportSearchDirection,
     buffer: &Buffer,
     window_actual_shape: &U16Rect,
     window_local_options: &WindowLocalOptions,
     target_cursor_line_idx: usize,
     target_cursor_char_idx: usize,
   ) -> (usize, usize) {
-    sync::search_anchor_downward(
-      self,
-      buffer,
-      window_actual_shape,
-      window_local_options,
-      target_cursor_line_idx,
-      target_cursor_char_idx,
-    )
+    match direction {
+      ViewportSearchDirection::Down => sync::search_anchor_downward(
+        self,
+        buffer,
+        window_actual_shape,
+        window_local_options,
+        target_cursor_line_idx,
+        target_cursor_char_idx,
+      ),
+      ViewportSearchDirection::Up => sync::search_anchor_upward(
+        self,
+        buffer,
+        window_actual_shape,
+        window_local_options,
+        target_cursor_line_idx,
+        target_cursor_char_idx,
+      ),
+      _ => unimplemented!(),
+    }
   }
 
   // /// Calculate viewport upward, from bottom to top.
@@ -3959,7 +3977,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4020,7 +4039,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4069,7 +4089,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4118,7 +4139,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4230,7 +4252,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4285,7 +4308,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4334,7 +4358,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4383,7 +4408,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4432,7 +4458,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4481,7 +4508,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4593,7 +4621,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4648,7 +4677,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4697,7 +4727,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4746,7 +4777,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4801,7 +4833,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4850,7 +4883,8 @@ mod tests_search_anchor_downward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4976,7 +5010,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5033,7 +5068,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5079,7 +5115,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5130,7 +5167,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5181,7 +5219,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5226,7 +5265,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5332,7 +5372,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5391,7 +5432,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5437,7 +5479,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5488,7 +5531,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5539,7 +5583,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5584,7 +5629,8 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5706,7 +5752,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5757,7 +5804,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5803,7 +5851,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5854,7 +5903,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5905,7 +5955,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5950,7 +6001,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6056,7 +6108,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6109,7 +6162,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6155,7 +6209,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6206,7 +6261,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6257,7 +6313,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6302,7 +6359,8 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6420,7 +6478,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6481,7 +6540,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6530,7 +6590,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6579,7 +6640,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6691,7 +6753,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6746,7 +6809,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6795,7 +6859,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6844,7 +6909,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6893,7 +6959,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6942,7 +7009,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7054,7 +7122,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7109,7 +7178,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7158,7 +7228,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7207,7 +7278,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7262,7 +7334,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7311,7 +7384,8 @@ mod tests_search_anchor_upwnward_nowrap {
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor_downward(
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6469,7 +6469,7 @@ mod tests_search_anchor_upward_nowrap {
 
     // Prepare
     {
-      let expect = vec!["\t1. ", "\t2. ", "\t\t3", "\t\t4", ""];
+      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
 
       let actual = {
         let target_cursor_line = 7;
@@ -6509,7 +6509,7 @@ mod tests_search_anchor_upward_nowrap {
       let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(
@@ -6525,13 +6525,7 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-1
     {
-      let expect = vec![
-        "This is a quite s",
-        "But still it cont",
-        "\t1. When",
-        "\t2. When",
-        "\t\t3",
-      ];
+      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
 
       let actual = {
         let target_cursor_line = 6;
@@ -6549,7 +6543,7 @@ mod tests_search_anchor_upward_nowrap {
           target_cursor_char,
         );
         assert_eq!(start_line, 3);
-        assert_eq!(start_column, 0);
+        assert_eq!(start_column, 45);
 
         let viewport = Viewport::view(
           &buf,
@@ -6565,7 +6559,7 @@ mod tests_search_anchor_upward_nowrap {
       let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5470,7 +5470,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
 
     // Search-3
     {
-      let expect = vec!["2. When\tit", "\t\tt", "oo\tlong", "\tto", "\tcompletel"];
+      let expect = vec!["t\t\t", "too\tlong", "\tto", "\tcompletel", "y\tput:\n"];
 
       let actual = {
         let target_cursor_line = 4;
@@ -5488,7 +5488,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 4);
-        assert_eq!(start_column, 8);
+        assert_eq!(start_column, 24);
 
         let viewport = Viewport::view(
           &buf,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6893,7 +6893,7 @@ mod tests_search_anchor_upward_nowrap {
   }
 
   #[test]
-  fn _new2() {
+  fn new2() {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
@@ -6948,25 +6948,75 @@ mod tests_search_anchor_upward_nowrap {
       );
     }
 
-    // Search-1
+    // Prepare
     {
-      let expect = vec![
-        "",
-        "nd small test lin",
-        "veral things we w",
-        "he\tline",
-        "t\t\t",
-      ];
+      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
 
       let actual = {
-        let target_cursor_line = 2;
-        let target_cursor_char = 40;
+        let target_cursor_line = 7;
+        let target_cursor_char = 0;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
+
+      let actual = {
+        let target_cursor_line = 6;
+        let target_cursor_char = 0;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -8051,10 +8051,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
 
     // Search-3
     {
-      let expect = vec![
-        "\tput:\n",
-        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
-      ];
+      let expect = vec!["\tput:\n"];
 
       let actual = {
         let target_cursor_line = 4;

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5664,6 +5664,121 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
       );
     }
   }
+
+  #[test]
+  fn new3() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(17, 5);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let win_opts = make_wrap_nolinebreak();
+
+    let buf = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+
+    let window = Rc::new(RefCell::new(make_window(
+      terminal_size,
+      buf.clone(),
+      &win_opts,
+    )));
+
+    // Initialize
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "imple and small t",
+        "est lines.\n",
+        "But still it cont",
+      ];
+
+      let actual = lock!(window.borrow().viewport()).clone();
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        3,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "imple and small t",
+        "est lines.\n",
+        "But still it cont",
+      ];
+
+      let actual = {
+        let target_cursor_line = 1;
+        let target_cursor_char = 43;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        3,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+  }
 }
 #[allow(unused_imports)]
 #[cfg(test)]

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6725,7 +6725,13 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-5
     {
-      let expect = vec!["things we want to", "line\ti", "\ttoo", "arts are been tru", "arts are split in"];
+      let expect = vec![
+        "things we want to",
+        "line\ti",
+        "\ttoo",
+        "arts are been tru",
+        "arts are split in",
+      ];
 
       let actual = {
         let target_cursor_line = 2;
@@ -6756,10 +6762,10 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(2,0), (3, 4), (4, 3), (5, 0), (6, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 4), (4, 3), (5, 0), (6, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(2,0), (3, 0), (4, 3), (5, 0), (6, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 3), (5, 0), (6, 0)]
         .into_iter()
         .collect();
       assert_viewport(

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6625,17 +6625,17 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-3
     {
-      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
+      let expect = vec!["to\tcom", "etely\tput:", "e-wrap\tand", "if\te", ""];
 
       let actual = {
-        let target_cursor_line = 7;
-        let target_cursor_char = 3;
+        let target_cursor_line = 4;
+        let target_cursor_char = 38;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6643,7 +6643,7 @@ mod tests_search_anchor_upward_nowrap {
           target_cursor_char,
         );
         assert_eq!(start_line, 3);
-        assert_eq!(start_column, 0);
+        assert_eq!(start_column, 79);
 
         let viewport = Viewport::view(
           &buf,
@@ -6656,10 +6656,60 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 4), (4, 0), (5, 0), (6, 6), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-4
+    {
+      let expect = vec!["put\tinsi", "", "wrap\toptio", "line-wrap\t", ""];
+
+      let actual = {
+        let target_cursor_line = 3;
+        let target_cursor_char = 55;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 109);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(
@@ -6675,7 +6725,7 @@ mod tests_search_anchor_upward_nowrap {
   }
 
   #[test]
-  fn new2() {
+  fn _new2() {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
@@ -7044,7 +7094,7 @@ mod tests_search_anchor_upward_nowrap {
   }
 
   #[test]
-  fn new3() {
+  fn _new3() {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -535,7 +535,6 @@ impl Viewport {
     }
   }
 
-  #[allow(clippy::too_many_arguments)]
   /// Search for a new viewport anchor (i.e. `start_line`/`start_column`) with target cursor
   /// line/char position, when cursor moves downward.
   ///
@@ -6439,7 +6438,7 @@ mod tests_search_anchor_upwnward_nowrap {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 0);
+        assert_eq!(start_line, 7);
         assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
@@ -6459,24 +6458,24 @@ mod tests_search_anchor_upwnward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        0,
-        5,
+        3,
+        8,
         &expect_start_fills,
         &expect_end_fills,
       );
     }
 
-    // Search-2
+    // Search-1
     {
       let expect = vec![
         "This is a quite s",

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7555,13 +7555,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
 
     // Search-2
     {
-      let expect = vec![
-        "small\tenou",
-        "gh\tto",
-        "\tcompletel",
-        "y\tput",
-        "\tinside.\n",
-      ];
+      let expect = vec!["d\tword-wra", "p\toptions", "\tare", "\tnot", "\tset.\n"];
 
       let actual = {
         let target_cursor_line = 5;
@@ -7578,8 +7572,8 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 3);
-        assert_eq!(start_column, 56);
+        assert_eq!(start_line, 5);
+        assert_eq!(start_column, 95);
 
         let viewport = Viewport::view(
           &buf,
@@ -7592,15 +7586,15 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
       info!("actual:{:?}", actual);
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        3,
-        4,
+        5,
+        6,
         &expect_start_fills,
         &expect_end_fills,
       );
@@ -7608,7 +7602,10 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
 
     // Search-3
     {
-      let expect = vec!["t\t\t", "too\tlong", "\tto", "\tcompletel", "y\tput:\n"];
+      let expect = vec![
+        "\tput:\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+      ];
 
       let actual = {
         let target_cursor_line = 4;
@@ -7626,7 +7623,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 4);
-        assert_eq!(start_column, 24);
+        assert_eq!(start_column, 84);
 
         let viewport = Viewport::view(
           &buf,
@@ -7639,14 +7636,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0), (5, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0), (5, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
         4,
-        5,
+        6,
         &expect_start_fills,
         &expect_end_fills,
       );

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6525,7 +6525,7 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-1
     {
-      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
+      let expect = vec!["is\tsmall", "long", "runcated if", "into the\tn", ""];
 
       let actual = {
         let target_cursor_line = 6;
@@ -6556,10 +6556,10 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 1), (4, 7), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 1), (4, 6), (5, 6), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(
@@ -6573,7 +6573,7 @@ mod tests_search_anchor_upward_nowrap {
       );
     }
 
-    // Search-3
+    // Search-2
     {
       let expect = vec!["ut still it conta", "1. When", "2. When", "\t3.", "\t4."];
 
@@ -6623,7 +6623,7 @@ mod tests_search_anchor_upward_nowrap {
       );
     }
 
-    // Search-4
+    // Search-3
     {
       let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
 

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5488,7 +5488,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 4);
-        assert_eq!(start_column, 8);
+        assert_eq!(start_column, 11);
 
         let viewport = Viewport::view(
           &buf,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -505,7 +505,7 @@ pub struct Viewport {
 arc_impl!(Viewport);
 
 #[derive(Debug, Copy, Clone)]
-pub enum ViewportSearchDirection {
+pub enum ViewportSearchAnchorDirection {
   Up,
   Down,
   Left,
@@ -550,7 +550,7 @@ impl Viewport {
   /// better user visuals).
   pub fn search_anchor(
     &self,
-    direction: ViewportSearchDirection,
+    direction: ViewportSearchAnchorDirection,
     buffer: &Buffer,
     window_actual_shape: &U16Rect,
     window_local_options: &WindowLocalOptions,
@@ -558,7 +558,7 @@ impl Viewport {
     target_cursor_char_idx: usize,
   ) -> (usize, usize) {
     match direction {
-      ViewportSearchDirection::Down => sync::search_anchor_downward(
+      ViewportSearchAnchorDirection::Down => sync::search_anchor_downward(
         self,
         buffer,
         window_actual_shape,
@@ -566,7 +566,7 @@ impl Viewport {
         target_cursor_line_idx,
         target_cursor_char_idx,
       ),
-      ViewportSearchDirection::Up => sync::search_anchor_upward(
+      ViewportSearchAnchorDirection::Up => sync::search_anchor_upward(
         self,
         buffer,
         window_actual_shape,
@@ -3978,7 +3978,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4040,7 +4040,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4090,7 +4090,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4140,7 +4140,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4253,7 +4253,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4309,7 +4309,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4359,7 +4359,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4409,7 +4409,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4459,7 +4459,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4509,7 +4509,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4622,7 +4622,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4678,7 +4678,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4728,7 +4728,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4778,7 +4778,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4834,7 +4834,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4884,7 +4884,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5011,7 +5011,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5069,7 +5069,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5116,7 +5116,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5168,7 +5168,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5220,7 +5220,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5266,7 +5266,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5373,7 +5373,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5433,7 +5433,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5480,7 +5480,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5532,7 +5532,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5584,7 +5584,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5630,7 +5630,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5753,7 +5753,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5805,7 +5805,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5852,7 +5852,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5904,7 +5904,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5956,7 +5956,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6002,7 +6002,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6109,7 +6109,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6163,7 +6163,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6210,7 +6210,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6262,7 +6262,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6314,7 +6314,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6360,7 +6360,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6479,7 +6479,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6541,7 +6541,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6591,7 +6591,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6641,7 +6641,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6754,7 +6754,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6810,7 +6810,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6860,7 +6860,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6910,7 +6910,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6960,7 +6960,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7010,7 +7010,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7123,7 +7123,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7179,7 +7179,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7229,7 +7229,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7279,7 +7279,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7335,7 +7335,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7385,7 +7385,7 @@ mod tests_search_anchor_upwnward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchDirection::Down,
+          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7056,11 +7056,11 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-2
     {
-      let expect = vec!["to\tcom", "etely\tput:", "e-wrap\tand", "if\te", ""];
+      let expect = vec!["inside.\n", "", "options\ta", "or\tw", ""];
 
       let actual = {
         let target_cursor_line = 5;
-        let target_cursor_char = 60;
+        let target_cursor_char = 80;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
@@ -7074,7 +7074,7 @@ mod tests_search_anchor_upward_nowrap {
           target_cursor_char,
         );
         assert_eq!(start_line, 3);
-        assert_eq!(start_column, 79);
+        assert_eq!(start_column, 120);
 
         let viewport = Viewport::view(
           &buf,
@@ -7087,7 +7087,7 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 4), (4, 0), (5, 0), (6, 6), (7, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 0), (5, 1), (6, 6), (7, 0)]
         .into_iter()
         .collect();
       let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
@@ -7106,11 +7106,11 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-3
     {
-      let expect = vec!["to\tcom", "etely\tput:", "e-wrap\tand", "if\te", ""];
+      let expect = vec!["o\tcomplete", "\tput:\n", "p\tand", "if\teither", ""];
 
       let actual = {
         let target_cursor_line = 4;
-        let target_cursor_char = 38;
+        let target_cursor_char = 35;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
@@ -7124,7 +7124,7 @@ mod tests_search_anchor_upward_nowrap {
           target_cursor_char,
         );
         assert_eq!(start_line, 3);
-        assert_eq!(start_column, 79);
+        assert_eq!(start_column, 84);
 
         let viewport = Viewport::view(
           &buf,
@@ -7137,10 +7137,10 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 4), (4, 0), (5, 0), (6, 6), (7, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 1), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 5), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7156,11 +7156,11 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-4
     {
-      let expect = vec!["put\tinsi", "", "wrap\toptio", "line-wrap\t", ""];
+      let expect = vec!["o\tcomplete", "\tput:\n", "p\tand", "if\teither", ""];
 
       let actual = {
         let target_cursor_line = 3;
-        let target_cursor_char = 55;
+        let target_cursor_char = 36;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
@@ -7174,7 +7174,7 @@ mod tests_search_anchor_upward_nowrap {
           target_cursor_char,
         );
         assert_eq!(start_line, 3);
-        assert_eq!(start_column, 109);
+        assert_eq!(start_column, 84);
 
         let viewport = Viewport::view(
           &buf,
@@ -7187,10 +7187,10 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 0), (5, 0), (6, 0), (7, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 1), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 5), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6355,7 +6355,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
 
     // Search-3
     {
-      let expect = vec!["\t\t", "too\tlong", "\tto", "\t", "completely"];
+      let expect = vec!["too\tlong", "\tto", "\t", "completely", "\tput:\n"];
 
       let actual = {
         let target_cursor_line = 4;
@@ -6373,7 +6373,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 4);
-        assert_eq!(start_column, 25);
+        assert_eq!(start_column, 41);
 
         let viewport = Viewport::view(
           &buf,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7373,4 +7373,746 @@ mod tests_search_anchor_upward_nowrap {
     }
   }
 }
+#[allow(unused_imports)]
+#[cfg(test)]
+mod tests_search_anchor_upward_wrap_nolinebreak {
+  use super::tests_util::*;
+  use super::*;
+
+  use crate::buf::BufferLocalOptionsBuilder;
+  use crate::lock;
+  use crate::prelude::*;
+  use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
+  use crate::test::log::init as test_log_init;
+  use crate::ui::tree::Inodeable;
+
+  use std::cell::RefCell;
+  use std::rc::Rc;
+
+  #[test]
+  fn new1() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(17, 5);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let win_opts = make_wrap_nolinebreak();
+
+    let buf = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+
+    let window = Rc::new(RefCell::new(make_window(
+      terminal_size,
+      buf.clone(),
+      &win_opts,
+    )));
+
+    // Initialize
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "imple and small t",
+        "est lines.\n",
+        "But still it cont",
+      ];
+
+      let actual = lock!(window.borrow().viewport()).clone();
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        3,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec![
+        "But still it cont",
+        "ains several thin",
+        "gs we want to tes",
+        "t:\n",
+        "\t1. When",
+      ];
+
+      let actual = {
+        let target_cursor_line = 2;
+        let target_cursor_char = 15;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 2)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        2,
+        4,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-2
+    {
+      let expect = vec![
+        "small\tenou",
+        "gh\tto",
+        "\tcompletel",
+        "y\tput",
+        "\tinside.\n",
+      ];
+
+      let actual = {
+        let target_cursor_line = 3;
+        let target_cursor_char = 60;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 56);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      info!("actual:{:?}", actual);
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        4,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-3
+    {
+      let expect = vec!["t\t\t", "too\tlong", "\tto", "\tcompletel", "y\tput:\n"];
+
+      let actual = {
+        let target_cursor_line = 4;
+        let target_cursor_char = 35;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 4);
+        assert_eq!(start_column, 24);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        4,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-4
+    {
+      let expect = vec![
+        "both\tline-",
+        "wrap\tand",
+        "\tword-wrap",
+        "\toptions",
+        "\tare",
+      ];
+
+      let actual = {
+        let target_cursor_line = 5;
+        let target_cursor_char = 82;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 5);
+        assert_eq!(start_column, 64);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(5, 6)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        5,
+        6,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-5
+    {
+      let expect = vec![
+        "if\teither",
+        "\tline-wrap",
+        "\tor",
+        "\tword-wrap",
+        "\toptions",
+      ];
+
+      let actual = {
+        let target_cursor_line = 6;
+        let target_cursor_char = 82;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 6);
+        assert_eq!(start_column, 85);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(6, 2)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        6,
+        7,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-6
+    {
+      let expect = vec![""];
+
+      let actual = {
+        let target_cursor_line = 7;
+        let target_cursor_char = 0;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 7);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        7,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+  }
+
+  #[test]
+  fn new2() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(17, 5);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let win_opts = make_wrap_nolinebreak();
+
+    let buf = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+
+    let window = Rc::new(RefCell::new(make_window(
+      terminal_size,
+      buf.clone(),
+      &win_opts,
+    )));
+
+    // Initialize
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "imple and small t",
+        "est lines.\n",
+        "But still it cont",
+      ];
+
+      let actual = lock!(window.borrow().viewport()).clone();
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        3,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "imple and small t",
+        "est lines.\n",
+        "But still it cont",
+      ];
+
+      let actual = {
+        let target_cursor_line = 1;
+        let target_cursor_char = 43;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        3,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-2
+    {
+      let expect = vec![
+        "small\tenou",
+        "gh\tto",
+        "\tcompletel",
+        "y\tput",
+        "\tinside.\n",
+      ];
+
+      let actual = {
+        let target_cursor_line = 3;
+        let target_cursor_char = 58;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 56);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      info!("actual:{:?}", actual);
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        4,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-3
+    {
+      let expect = vec!["2. When\tit", "\t\tt", "oo\tlong", "\tto", "\tcompletel"];
+
+      let actual = {
+        let target_cursor_line = 4;
+        let target_cursor_char = 30;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 4);
+        assert_eq!(start_column, 8);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        4,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-4
+    {
+      let expect = vec![
+        "both\tline-",
+        "wrap\tand",
+        "\tword-wrap",
+        "\toptions",
+        "\tare",
+      ];
+
+      let actual = {
+        let target_cursor_line = 5;
+        let target_cursor_char = 82;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 5);
+        assert_eq!(start_column, 64);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(5, 6)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        5,
+        6,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-5
+    {
+      let expect = vec![
+        "xtra parts are sp",
+        "lit into the",
+        "\tnext",
+        "\trow,",
+        "\tif",
+      ];
+
+      let actual = {
+        let target_cursor_line = 6;
+        let target_cursor_char = 10;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 6);
+        assert_eq!(start_column, 24);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(6, 7)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        6,
+        7,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-6
+    {
+      let expect = vec![""];
+
+      let actual = {
+        let target_cursor_line = 7;
+        let target_cursor_char = 0;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 7);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        7,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+  }
+}
 // spellchecker:on

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6585,7 +6585,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5997,7 +5997,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
 
     // Search-3
     {
-      let expect = vec!["too\tlong", "\tto", "\t", "completely", "\tput:\n"];
+      let expect = vec!["When\tit", "\t\t", "too\tlong", "\tto", "\t"];
 
       let actual = {
         let target_cursor_line = 4;
@@ -6015,7 +6015,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 4);
-        assert_eq!(start_column, 41);
+        assert_eq!(start_column, 13);
 
         let viewport = Viewport::view(
           &buf,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7006,11 +7006,11 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-1
     {
-      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
+      let expect = vec!["put\tinsid", "", "rap\toption", "ine-wrap\to", ""];
 
       let actual = {
         let target_cursor_line = 6;
-        let target_cursor_char = 0;
+        let target_cursor_char = 70;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
@@ -7023,264 +7023,8 @@ mod tests_search_anchor_upward_nowrap {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 0);
-        assert_eq!(start_column, 24);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
-          &viewport,
-          &buf,
-          target_cursor_line,
-          target_cursor_char,
-        )));
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 3), (4, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        0,
-        5,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-2
-    {
-      let expect = vec!["", "", "", "ut\tinside.", ""];
-
-      let actual = {
-        let target_cursor_line = 3;
-        let target_cursor_char = 130;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 0);
-        assert_eq!(start_column, 112);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        0,
-        5,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-3
-    {
-      let expect = vec!["", "", "", "mpletely\tp", ":\n"];
-
-      let actual = {
-        let target_cursor_line = 4;
-        let target_cursor_char = 100;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 0);
-        assert_eq!(start_column, 95);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        0,
-        5,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-4
-    {
-      let expect = vec!["", "", "", "", "not\tset."];
-
-      let actual = {
-        let target_cursor_line = 5;
-        let target_cursor_char = 100;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 1);
-        assert_eq!(start_column, 145);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 2)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        1,
-        6,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-5
-    {
-      let expect = vec!["", "\tcompletel", "put:\n", "\tand", "if\teither"];
-
-      let actual = {
-        let target_cursor_line = 6;
-        let target_cursor_char = 50;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 2);
-        assert_eq!(start_column, 85);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 7), (5, 0), (6, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 6), (6, 1)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        2,
-        7,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-6
-    {
-      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
-
-      let actual = {
-        let target_cursor_line = 7;
-        let target_cursor_char = 0;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
         assert_eq!(start_line, 3);
-        assert_eq!(start_column, 0);
+        assert_eq!(start_column, 110);
 
         let viewport = Viewport::view(
           &buf,
@@ -7293,10 +7037,10 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 1), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(
@@ -7309,196 +7053,27 @@ mod tests_search_anchor_upward_nowrap {
         &expect_end_fills,
       );
     }
-  }
-
-  #[test]
-  fn _new3() {
-    test_log_init();
-
-    let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = make_nowrap();
-
-    let buf = make_buffer_from_lines(
-      terminal_size.height(),
-      buf_opts,
-      vec![
-        "Hello, RSVIM!\n",
-        "This is a quite simple and small test lines.\n",
-        "But still it contains several things we want to test:\n",
-        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
-        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
-        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
-        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-      ],
-    );
-
-    let window = Rc::new(RefCell::new(make_window(
-      terminal_size,
-      buf.clone(),
-      &win_opts,
-    )));
-
-    // Initialize
-    {
-      let expect = vec![
-        "Hello, RSVIM!\n",
-        "This is a quite s",
-        "But still it cont",
-        "\t1. When",
-        "\t2. When",
-      ];
-
-      let actual = lock!(window.borrow().viewport()).clone();
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        0,
-        5,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-1
-    {
-      let expect = vec![
-        "",
-        "nd small test lin",
-        "veral things we w",
-        "he\tline",
-        "t\t\t",
-      ];
-
-      let actual = {
-        let target_cursor_line = 2;
-        let target_cursor_char = 40;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 0);
-        assert_eq!(start_column, 24);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
-          &viewport,
-          &buf,
-          target_cursor_line,
-          target_cursor_char,
-        )));
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 3), (4, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        0,
-        5,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
 
     // Search-2
     {
-      let expect = vec!["", "", "", "ut\tinside.", ""];
+      let expect = vec!["to\tcom", "etely\tput:", "e-wrap\tand", "if\te", ""];
 
       let actual = {
-        let target_cursor_line = 3;
-        let target_cursor_char = 130;
+        let target_cursor_line = 5;
+        let target_cursor_char = 60;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 0);
-        assert_eq!(start_column, 112);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        0,
-        5,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-3
-    {
-      let expect = vec!["", "", "", "to\tcom", "etely\tput:"];
-
-      let actual = {
-        let target_cursor_line = 4;
-        let target_cursor_char = 30;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 0);
+        assert_eq!(start_line, 3);
         assert_eq!(start_column, 79);
 
         let viewport = Viewport::view(
@@ -7512,44 +7087,44 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 4), (4, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 4), (4, 0), (5, 0), (6, 6), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        0,
-        5,
+        3,
+        8,
         &expect_start_fills,
         &expect_end_fills,
       );
     }
 
-    // Search-4
+    // Search-3
     {
-      let expect = vec!["", "", "inside.\n", "", "options\ta"];
+      let expect = vec!["to\tcom", "etely\tput:", "e-wrap\tand", "if\te", ""];
 
       let actual = {
-        let target_cursor_line = 5;
-        let target_cursor_char = 80;
+        let target_cursor_line = 4;
+        let target_cursor_char = 38;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 1);
-        assert_eq!(start_column, 120);
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 79);
 
         let viewport = Viewport::view(
           &buf,
@@ -7562,18 +7137,68 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 2), (4, 0), (5, 1)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 4), (4, 0), (5, 0), (6, 6), (7, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
         .into_iter()
         .collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        1,
-        6,
+        3,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-4
+    {
+      let expect = vec!["put\tinsi", "", "wrap\toptio", "line-wrap\t", ""];
+
+      let actual = {
+        let target_cursor_line = 3;
+        let target_cursor_char = 55;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 109);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        8,
         &expect_start_fills,
         &expect_end_fills,
       );
@@ -7582,22 +7207,22 @@ mod tests_search_anchor_upward_nowrap {
     // Search-5
     {
       let expect = vec![
-        "l it contains sev",
-        "1. When\tth",
-        "2. When\tit",
-        "\t3. The ex",
-        "\t4. The ex",
+        "things we want to",
+        "line\ti",
+        "\ttoo",
+        "arts are been tru",
+        "arts are split in",
       ];
 
       let actual = {
-        let target_cursor_line = 6;
-        let target_cursor_char = 1;
+        let target_cursor_line = 2;
+        let target_cursor_char = 30;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7605,7 +7230,7 @@ mod tests_search_anchor_upward_nowrap {
           target_cursor_char,
         );
         assert_eq!(start_line, 2);
-        assert_eq!(start_column, 8);
+        assert_eq!(start_column, 30);
 
         let viewport = Viewport::view(
           &buf,
@@ -7618,10 +7243,10 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 4), (4, 3), (5, 0), (6, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 3), (5, 0), (6, 0)]
         .into_iter()
         .collect();
       assert_viewport(
@@ -7637,25 +7262,31 @@ mod tests_search_anchor_upward_nowrap {
 
     // Search-6
     {
-      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
+      let expect = vec![
+        "ll test lines.\n",
+        "things we want to",
+        "line\ti",
+        "\ttoo",
+        "arts are been tru",
+      ];
 
       let actual = {
-        let target_cursor_line = 7;
-        let target_cursor_char = 0;
+        let target_cursor_line = 1;
+        let target_cursor_char = 32;
 
         let mut window = window.borrow_mut();
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
           window.options(),
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 3);
-        assert_eq!(start_column, 0);
+        assert_eq!(start_line, 1);
+        assert_eq!(start_column, 30);
 
         let viewport = Viewport::view(
           &buf,
@@ -7668,18 +7299,74 @@ mod tests_search_anchor_upward_nowrap {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 4), (4, 3), (5, 0)]
         .into_iter()
         .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 3), (5, 0)]
         .into_iter()
         .collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        3,
-        8,
+        1,
+        6,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-7
+    {
+      let expect = vec![
+        "SVIM!\n",
+        "a quite simple an",
+        "l it contains sev",
+        "1. When\tth",
+        "2. When\tit",
+      ];
+
+      let actual = {
+        let target_cursor_line = 0;
+        let target_cursor_char = 8;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Up,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 8);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
         &expect_start_fills,
         &expect_end_fills,
       );

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7445,13 +7445,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
 
     // Prepare
     {
-      let expect = vec![
-        "But still it cont",
-        "ains several thin",
-        "gs we want to tes",
-        "t:\n",
-        "\t1. When",
-      ];
+      let expect = vec![""];
 
       let actual = {
         let target_cursor_line = 7;
@@ -7468,7 +7462,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 2);
+        assert_eq!(start_line, 7);
         assert_eq!(start_column, 0);
 
         let viewport = Viewport::view(
@@ -7488,14 +7482,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 2)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        2,
-        4,
+        7,
+        8,
         &expect_start_fills,
         &expect_end_fills,
       );
@@ -7504,11 +7498,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
     // Search-1
     {
       let expect = vec![
-        "But still it cont",
-        "ains several thin",
-        "gs we want to tes",
-        "t:\n",
-        "\t1. When",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
       ];
 
       let actual = {
@@ -7526,8 +7516,8 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
           target_cursor_line,
           target_cursor_char,
         );
-        assert_eq!(start_line, 2);
-        assert_eq!(start_column, 0);
+        assert_eq!(start_line, 6);
+        assert_eq!(start_column, 287);
 
         let viewport = Viewport::view(
           &buf,
@@ -7546,14 +7536,14 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0)].into_iter().collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 2)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,
         &expect,
-        2,
-        4,
+        6,
+        7,
         &expect_start_fills,
         &expect_end_fills,
       );

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6549,6 +6549,352 @@ mod tests_search_anchor_downward_wrap_linebreak {
       );
     }
   }
+
+  #[test]
+  fn new3() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(17, 5);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let win_opts = make_wrap_linebreak();
+
+    let buf = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "But still it contains several things we want to test:\n",
+        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+
+    let window = Rc::new(RefCell::new(make_window(
+      terminal_size,
+      buf.clone(),
+      &win_opts,
+    )));
+
+    // Initialize
+    {
+      let expect = vec![
+        "But still it ",
+        "contains several ",
+        "things we want to",
+        " test:\n",
+        "\t1. When",
+      ];
+
+      let actual = lock!(window.borrow().viewport()).clone();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        2,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec!["is\tsmall", "\tenough", "\tto", "\t", "completely"];
+
+      let actual = {
+        let target_cursor_line = 1;
+        let target_cursor_char = 37;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 1);
+        assert_eq!(start_column, 46);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        1,
+        2,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-2
+    {
+      let expect = vec!["too\tlong", "\tto", "\t", "completely", "\tput:\n"];
+
+      let actual = {
+        let target_cursor_line = 2;
+        let target_cursor_char = 37;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 41);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0)].into_iter().collect();
+      info!("actual:{:?}", actual);
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        2,
+        3,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-3
+    {
+      let expect = vec!["\t\t", "too\tlong", "\tto", "\t", "completely"];
+
+      let actual = {
+        let target_cursor_line = 3;
+        let target_cursor_char = 30;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 41);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        4,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-4
+    {
+      let expect = vec![
+        "both\tline-",
+        "wrap\tand",
+        "\tword-wrap",
+        "\toptions",
+        "\tare",
+      ];
+
+      let actual = {
+        let target_cursor_line = 5;
+        let target_cursor_char = 82;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 5);
+        assert_eq!(start_column, 64);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        5,
+        6,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-5
+    {
+      let expect = vec![
+        " extra parts are ",
+        "split into the",
+        "\tnext",
+        "\trow,",
+        "\tif",
+      ];
+
+      let actual = {
+        let target_cursor_line = 6;
+        let target_cursor_char = 10;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 6);
+        assert_eq!(start_column, 22);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(6, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        6,
+        7,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-6
+    {
+      let expect = vec![""];
+
+      let actual = {
+        let target_cursor_line = 7;
+        let target_cursor_char = 0;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 7);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        7,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+  }
 }
 #[allow(unused_imports)]
 #[cfg(test)]

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -7498,7 +7498,11 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
     // Search-1
     {
       let expect = vec![
-        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+        "nd again. This op",
+        "eration also eats",
+        " more rows in the",
+        " window, thus it ",
+        "may contains less",
       ];
 
       let actual = {

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -959,7 +959,6 @@ fn _revert_search_line_start_wrap_nolinebreak(
 fn _adjust_left_wrap_onlinebreak(
   buffer: &Buffer,
   _window_actual_shape: &U16Rect,
-  _viewport_start_line: usize,
   viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
@@ -968,8 +967,8 @@ fn _adjust_left_wrap_onlinebreak(
   let on_left_side = match buffer.char_after(target_cursor_line, viewport_start_column) {
     Some(c) => {
       trace!(
-        "target_cursor_line:{},target_cursor_char:{},viewport_start_line:{},viewport_start_column:{},c:{}",
-        target_cursor_line, target_cursor_char, _viewport_start_line, viewport_start_column, c
+        "target_cursor_line:{},target_cursor_char:{},viewport_start_column:{},c:{}",
+        target_cursor_line, target_cursor_char, viewport_start_column, c
       );
       c > target_cursor_char
     }
@@ -989,7 +988,6 @@ fn _adjust_left_wrap_onlinebreak(
 fn _adjust_right_wrap_nolinebreak(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
-  _viewport_start_line: usize,
   _viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
@@ -1020,21 +1018,17 @@ fn _adjust_right_wrap_nolinebreak(
 }
 
 fn _adjust_horizontally_wrap_nolinebreak(
-  viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
+  target_viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
   start_line: usize,
 ) -> (usize, usize) {
-  let viewport_start_line = viewport.start_line_idx();
-  let viewport_start_column = viewport.start_column_idx();
-
   let (on_left_side, start_column_on_left_side) = _adjust_left_wrap_onlinebreak(
     buffer,
     window_actual_shape,
-    viewport_start_line,
-    viewport_start_column,
+    target_viewport_start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -1046,8 +1040,7 @@ fn _adjust_horizontally_wrap_nolinebreak(
   let (on_right_side, start_column_on_right_side) = _adjust_right_wrap_nolinebreak(
     buffer,
     window_actual_shape,
-    viewport_start_line,
-    viewport_start_column,
+    target_viewport_start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -1056,7 +1049,7 @@ fn _adjust_horizontally_wrap_nolinebreak(
     return (start_line, start_column_on_right_side);
   }
 
-  (start_line, viewport_start_column)
+  (start_line, target_viewport_start_column)
 }
 
 fn _adjust_current_line(
@@ -1152,9 +1145,9 @@ fn search_anchor_downward_wrap_nolinebreak(
   };
 
   _adjust_horizontally_wrap_nolinebreak(
-    viewport,
     buffer,
     window_actual_shape,
+    viewport.start_column_idx(),
     target_cursor_line,
     target_cursor_char,
     start_line,
@@ -1607,9 +1600,9 @@ fn search_anchor_upward_wrap_nolinebreak(
   };
 
   _adjust_horizontally_wrap_nolinebreak(
-    viewport,
     buffer,
     window_actual_shape,
+    viewport.start_column_idx(),
     target_cursor_line,
     target_cursor_char,
     start_line,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -694,10 +694,10 @@ pub fn search_anchor_downward(
 // spellchecker:on
 //
 // Returns
-// 1. If target cursor is on the left side of viewport, and we need to adjust/move the viewport to
-//    left.
+// 1. If target cursor is on the left side of viewport, and we need to move the viewport more to
+//    the left side.
 // 2. If 1st is true, this is the new "start_column" after adjustments.
-fn _adjust_left_nowrap(
+fn _move_more_to_left_nowrap(
   buffer: &Buffer,
   _window_actual_shape: &U16Rect,
   viewport_start_column: usize,
@@ -730,7 +730,7 @@ fn _adjust_left_nowrap(
 // 1. If target cursor is on the right side of viewport, and we need to adjust/move the viewport to
 //    right.
 // 2. If 1st is true, this is the new "start_column" after adjustments.
-fn _adjust_right_nowrap(
+fn _move_more_to_right_nowrap(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
   viewport_start_column: usize,
@@ -771,7 +771,7 @@ fn _adjust_horizontally_nowrap(
   start_line: usize,
   start_column: usize,
 ) -> (usize, usize) {
-  let (on_left_side, start_column_on_left_side) = _adjust_left_nowrap(
+  let (on_left_side, start_column_on_left_side) = _move_more_to_left_nowrap(
     buffer,
     window_actual_shape,
     start_column,
@@ -783,7 +783,7 @@ fn _adjust_horizontally_nowrap(
     return (start_line, start_column_on_left_side);
   }
 
-  let (on_right_side, start_column_on_right_side) = _adjust_right_nowrap(
+  let (on_right_side, start_column_on_right_side) = _move_more_to_right_nowrap(
     buffer,
     window_actual_shape,
     start_column,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1557,7 +1557,7 @@ fn search_anchor_upward_wrap_nolinebreak(
   let target_cursor_line_not_fully_show = line_head_not_show(viewport, target_cursor_line)
     || line_tail_not_show(viewport, buffer, target_cursor_line);
 
-  let start_line = if target_cursor_line <= first_line && !target_cursor_line_not_fully_show {
+  let start_line = if target_cursor_line >= first_line && !target_cursor_line_not_fully_show {
     viewport_start_line
   } else {
     target_cursor_line
@@ -1603,7 +1603,7 @@ fn search_anchor_upward_wrap_linebreak(
   let target_cursor_line_not_fully_show = line_head_not_show(viewport, target_cursor_line)
     || line_tail_not_show(viewport, buffer, target_cursor_line);
 
-  let start_line = if target_cursor_line <= first_line && !target_cursor_line_not_fully_show {
+  let start_line = if target_cursor_line >= first_line && !target_cursor_line_not_fully_show {
     viewport_start_line
   } else {
     target_cursor_line

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -73,7 +73,7 @@ pub fn sync(
   }
 }
 
-fn end_char_and_prefills(
+fn _end_char_and_prefills(
   buffer: &Buffer,
   bline: &RopeSlice,
   l: usize,
@@ -119,7 +119,7 @@ fn proc_line_nowrap(
 
         let end_width = start_column + window_width as usize;
         let (end_char, end_fills) = match buffer.char_at(current_line, end_width) {
-          Some(c) => end_char_and_prefills(buffer, &bufline, current_line, c, end_width),
+          Some(c) => _end_char_and_prefills(buffer, &bufline, current_line, c, end_width),
           None => {
             // If the char not found, it means the `end_width` is too long than the whole line.
             // So the char next to the line's last char is the end char.
@@ -223,7 +223,7 @@ fn proc_line_wrap_nolinebreak(
         debug_assert!(current_row < window_height);
         while current_row < window_height {
           let (end_char, end_fills_result) = match buffer.char_at(current_line, end_width) {
-            Some(c) => end_char_and_prefills(buffer, &bufline, current_line, c, end_width),
+            Some(c) => _end_char_and_prefills(buffer, &bufline, current_line, c, end_width),
             None => {
               // If the char not found, it means the `end_width` is too long than the whole line.
               // So the char next to the line's last char is the end char.
@@ -309,7 +309,7 @@ fn sync_wrap_nolinebreak(
 ///
 /// Returns the word index which contains this char, and whether the char is the last char in the
 /// word.
-fn find_word_by_char(
+fn _find_word_by_char(
   words: &[&str],
   word_end_chars_index: &HashMap<usize, usize>,
   char_idx: usize,
@@ -348,7 +348,7 @@ fn find_word_by_char(
 
 #[allow(clippy::too_many_arguments)]
 /// Part-1 of the processing algorithm in `_from_top_left_wrap_linebreak`.
-fn part1(
+fn _part1(
   words: &[&str],
   words_end_char_idx: &HashMap<usize, usize>,
   buffer: &Buffer,
@@ -359,7 +359,7 @@ fn part1(
   start_char: usize,
   last_word_is_too_long: &mut Option<(usize, usize, usize, usize)>,
 ) -> (usize, usize) {
-  let (wd_idx, start_c_of_wd, end_c_of_wd) = find_word_by_char(words, words_end_char_idx, c);
+  let (wd_idx, start_c_of_wd, end_c_of_wd) = _find_word_by_char(words, words_end_char_idx, c);
 
   let end_c_width = buffer.width_before(l, end_c_of_wd);
   if end_c_width > end_width {
@@ -379,7 +379,7 @@ fn part1(
       // Part-1.1, simply wrapped this word to next row.
       // Here we actually use the `start_c_of_wd` as the end char for current row.
 
-      end_char_and_prefills(buffer, bline, l, start_c_of_wd - 1, end_width)
+      _end_char_and_prefills(buffer, bline, l, start_c_of_wd - 1, end_width)
     } else {
       // Part-1.2, cut this word and force rendering it ignoring line-break behavior.
       debug_assert_eq!(start_c_of_wd, start_char);
@@ -387,7 +387,7 @@ fn part1(
       *last_word_is_too_long = Some((wd_idx, start_c_of_wd, end_c_of_wd, c));
 
       // If the char `c` width is greater than `end_width`, the `c` itself is the end char.
-      end_char_and_prefills(buffer, bline, l, c, end_width)
+      _end_char_and_prefills(buffer, bline, l, c, end_width)
     }
   } else {
     debug_assert_eq!(c + 1, end_c_of_wd);
@@ -397,7 +397,7 @@ fn part1(
   }
 }
 
-fn cloned_line_max_len(window_height: u16, window_width: u16, start_column: usize) -> usize {
+fn _cloned_line_max_len(window_height: u16, window_width: u16, start_column: usize) -> usize {
   window_height as usize * window_width as usize * 2 + 16 + start_column
 }
 
@@ -425,7 +425,7 @@ fn proc_line_wrap_linebreak(
       .clone_line(
         current_line,
         0,
-        cloned_line_max_len(window_height, window_width, start_column),
+        _cloned_line_max_len(window_height, window_width, start_column),
       )
       .unwrap();
 
@@ -495,12 +495,12 @@ fn proc_line_wrap_linebreak(
 
                         // If the char `c` width is greater than `end_width`, the `c` itself is
                         // the end char.
-                        end_char_and_prefills(buffer, &bufline, current_line, c, end_width)
+                        _end_char_and_prefills(buffer, &bufline, current_line, c, end_width)
                       } else {
                         // Part-2.2, the rest part of the word is not long.
                         // Thus we can go back to *normal* algorithm just like part-1.
 
-                        part1(
+                        _part1(
                           &words,
                           &words_end_char_idx,
                           buffer,
@@ -523,7 +523,7 @@ fn proc_line_wrap_linebreak(
                 }
                 None => {
                   // Part-1
-                  part1(
+                  _part1(
                     &words,
                     &words_end_char_idx,
                     buffer,
@@ -697,7 +697,7 @@ pub fn search_anchor_downward(
 // 1. If target cursor is on the left side of viewport, and we need to adjust/move the viewport to
 //    left.
 // 2. If 1st is true, this is the new "start_column" after adjustments.
-fn adjust_left_nowrap(
+fn _adjust_left_nowrap(
   buffer: &Buffer,
   _window_actual_shape: &U16Rect,
   _viewport_start_line: usize,
@@ -731,7 +731,7 @@ fn adjust_left_nowrap(
 // 1. If target cursor is on the right side of viewport, and we need to adjust/move the viewport to
 //    right.
 // 2. If 1st is true, this is the new "start_column" after adjustments.
-fn adjust_right_nowrap(
+fn _adjust_right_nowrap(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
   _viewport_start_line: usize,
@@ -765,7 +765,7 @@ fn adjust_right_nowrap(
   }
 }
 
-fn adjust_horizontally_nowrap(
+fn _adjust_horizontally_nowrap(
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -776,7 +776,7 @@ fn adjust_horizontally_nowrap(
   let viewport_start_line = viewport.start_line_idx();
   let viewport_start_column = viewport.start_column_idx();
 
-  let (on_left_side, start_column_on_left_side) = adjust_left_nowrap(
+  let (on_left_side, start_column_on_left_side) = _adjust_left_nowrap(
     buffer,
     window_actual_shape,
     viewport_start_line,
@@ -789,7 +789,7 @@ fn adjust_horizontally_nowrap(
     return (start_line, start_column_on_left_side);
   }
 
-  let (on_right_side, start_column_on_right_side) = adjust_right_nowrap(
+  let (on_right_side, start_column_on_right_side) = _adjust_right_nowrap(
     buffer,
     window_actual_shape,
     viewport_start_line,
@@ -865,7 +865,7 @@ fn search_anchor_downward_nowrap(
     current_line as usize
   };
 
-  adjust_horizontally_nowrap(
+  _adjust_horizontally_nowrap(
     viewport,
     buffer,
     window_actual_shape,
@@ -875,7 +875,7 @@ fn search_anchor_downward_nowrap(
   )
 }
 
-fn line_head_not_show(viewport: &Viewport, line_idx: usize) -> bool {
+fn _line_head_not_show(viewport: &Viewport, line_idx: usize) -> bool {
   if viewport.start_line_idx() > line_idx || viewport.end_line_idx() <= line_idx {
     return false;
   }
@@ -887,7 +887,7 @@ fn line_head_not_show(viewport: &Viewport, line_idx: usize) -> bool {
   first_row_viewport.start_char_idx() > 0
 }
 
-fn line_tail_not_show(viewport: &Viewport, buffer: &Buffer, line_idx: usize) -> bool {
+fn _line_tail_not_show(viewport: &Viewport, buffer: &Buffer, line_idx: usize) -> bool {
   if viewport.start_line_idx() > line_idx || viewport.end_line_idx() <= line_idx {
     return false;
   }
@@ -906,7 +906,7 @@ fn line_tail_not_show(viewport: &Viewport, buffer: &Buffer, line_idx: usize) -> 
 }
 
 /// Returns `start_column`
-fn revert_search_line_start_wrap_nolinebreak(
+fn _revert_search_line_start_wrap_nolinebreak(
   buffer: &Buffer,
   line_idx: usize,
   last_char: usize,
@@ -966,7 +966,7 @@ fn revert_search_line_start_wrap_nolinebreak(
 // NOTE: For `wrap=true, linebreak=false`, if there's any head/tail not fully rendered, it means
 // there will be only 1 line shows in current window viewport. Because the `wrap` will force the
 // 2nd line wait to show until the **current** line get fully rendered.
-fn adjust_right_wrap_nolinebreak(
+fn _adjust_right_wrap_nolinebreak(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
   _viewport_start_line: usize,
@@ -986,7 +986,7 @@ fn adjust_right_wrap_nolinebreak(
   let on_right_side = target_cursor_char >= last_row_viewport.end_char_idx();
 
   if on_right_side {
-    let start_column = revert_search_line_start_wrap_nolinebreak(
+    let start_column = _revert_search_line_start_wrap_nolinebreak(
       buffer,
       target_cursor_line,
       target_cursor_char,
@@ -999,7 +999,7 @@ fn adjust_right_wrap_nolinebreak(
   }
 }
 
-fn adjust_horizontally_wrap_nolinebreak(
+fn _adjust_horizontally_wrap_nolinebreak(
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1010,7 +1010,7 @@ fn adjust_horizontally_wrap_nolinebreak(
   let viewport_start_line = viewport.start_line_idx();
   let viewport_start_column = viewport.start_column_idx();
 
-  let (on_left_side, start_column_on_left_side) = adjust_left_nowrap(
+  let (on_left_side, start_column_on_left_side) = _adjust_left_nowrap(
     buffer,
     window_actual_shape,
     viewport_start_line,
@@ -1023,7 +1023,7 @@ fn adjust_horizontally_wrap_nolinebreak(
     return (start_line, start_column_on_left_side);
   }
 
-  let (on_right_side, start_column_on_right_side) = adjust_right_wrap_nolinebreak(
+  let (on_right_side, start_column_on_right_side) = _adjust_right_wrap_nolinebreak(
     buffer,
     window_actual_shape,
     viewport_start_line,
@@ -1039,18 +1039,14 @@ fn adjust_horizontally_wrap_nolinebreak(
   (start_line, viewport_start_column)
 }
 
-fn adjust_current_line(
+fn _adjust_current_line(
   current_line: isize,
   target_cursor_line: usize,
   window_height: u16,
   n: usize,
 ) -> usize {
-  if (current_line as usize) < target_cursor_line {
-    if n > (window_height as usize) {
-      current_line as usize + 1
-    } else {
-      current_line as usize
-    }
+  if (current_line as usize) < target_cursor_line && n > (window_height as usize) {
+    current_line as usize + 1
   } else {
     current_line as usize
   }
@@ -1083,8 +1079,8 @@ fn search_anchor_downward_wrap_nolinebreak(
   debug_assert!(viewport.lines().last_key_value().is_some());
   let (&last_line, _last_line_viewport) = viewport.lines().last_key_value().unwrap();
 
-  let target_cursor_line_not_fully_show = line_head_not_show(viewport, target_cursor_line)
-    || line_tail_not_show(viewport, buffer, target_cursor_line);
+  let target_cursor_line_not_fully_show = _line_head_not_show(viewport, target_cursor_line)
+    || _line_tail_not_show(viewport, buffer, target_cursor_line);
 
   let start_line = if target_cursor_line <= last_line && !target_cursor_line_not_fully_show {
     viewport_start_line
@@ -1105,10 +1101,10 @@ fn search_anchor_downward_wrap_nolinebreak(
       current_line -= 1;
     }
 
-    adjust_current_line(current_line, target_cursor_line, height, n)
+    _adjust_current_line(current_line, target_cursor_line, height, n)
   };
 
-  adjust_horizontally_wrap_nolinebreak(
+  _adjust_horizontally_wrap_nolinebreak(
     viewport,
     buffer,
     window_actual_shape,
@@ -1120,7 +1116,7 @@ fn search_anchor_downward_wrap_nolinebreak(
 
 // For `wrap=true,linebreak=true`, the `start_char` have to start from a valid word
 // beginning, i.e. a unicode segment, not a arbitrary char index.
-fn find_start_char_by_word(
+fn _find_start_char_by_word(
   buffer: &Buffer,
   bufline: &RopeSlice,
   line_idx: usize,
@@ -1176,7 +1172,7 @@ fn find_start_char_by_word(
   }
 }
 
-fn adjust_left_wrap_linebreak(
+fn _adjust_left_wrap_linebreak(
   buffer: &Buffer,
   _window_actual_shape: &U16Rect,
   _viewport_start_line: usize,
@@ -1199,7 +1195,7 @@ fn adjust_left_wrap_linebreak(
     debug_assert!(buffer.get_rope().get_line(target_cursor_line).is_some());
     let bufline = buffer.get_rope().line(target_cursor_line);
     let start_char =
-      find_start_char_by_word(buffer, &bufline, target_cursor_line, target_cursor_char);
+      _find_start_char_by_word(buffer, &bufline, target_cursor_line, target_cursor_char);
     let start_column = buffer.width_before(target_cursor_line, start_char);
     (true, start_column)
   } else {
@@ -1208,7 +1204,7 @@ fn adjust_left_wrap_linebreak(
 }
 
 /// Returns `start_column`
-fn revert_search_line_start_wrap_linebreak(
+fn _revert_search_line_start_wrap_linebreak(
   buffer: &Buffer,
   line_idx: usize,
   last_char: usize,
@@ -1230,7 +1226,7 @@ fn revert_search_line_start_wrap_linebreak(
 
   // For `wrap=true,linebreak=true`, the approximate `start_char` have to start from a valid word
   // beginning, i.e. a unicode segment, not a arbitrary char index.
-  let mut start_char = find_start_char_by_word(buffer, &bufline, line_idx, start_char);
+  let mut start_char = _find_start_char_by_word(buffer, &bufline, line_idx, start_char);
 
   trace!(
     "line_idx:{},last_char:{}({:?}),last_char_width:{},approximate_start_width:{},start_char:{}({:?})",
@@ -1247,7 +1243,7 @@ fn revert_search_line_start_wrap_linebreak(
     .clone_line(
       line_idx,
       start_char,
-      cloned_line_max_len(
+      _cloned_line_max_len(
         window_height,
         window_width,
         buffer.width_before(line_idx, start_char),
@@ -1298,7 +1294,7 @@ fn revert_search_line_start_wrap_linebreak(
   unreachable!()
 }
 
-fn adjust_right_wrap_linebreak(
+fn _adjust_right_wrap_linebreak(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
   _viewport_start_line: usize,
@@ -1318,7 +1314,7 @@ fn adjust_right_wrap_linebreak(
   let on_right_side = target_cursor_char >= last_row_viewport.end_char_idx();
 
   if on_right_side {
-    let start_column = revert_search_line_start_wrap_linebreak(
+    let start_column = _revert_search_line_start_wrap_linebreak(
       buffer,
       target_cursor_line,
       target_cursor_char,
@@ -1331,7 +1327,7 @@ fn adjust_right_wrap_linebreak(
   }
 }
 
-fn adjust_horizontally_wrap_linebreak(
+fn _adjust_horizontally_wrap_linebreak(
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1342,7 +1338,7 @@ fn adjust_horizontally_wrap_linebreak(
   let viewport_start_line = viewport.start_line_idx();
   let viewport_start_column = viewport.start_column_idx();
 
-  let (on_left_side, start_column_on_left_side) = adjust_left_wrap_linebreak(
+  let (on_left_side, start_column_on_left_side) = _adjust_left_wrap_linebreak(
     buffer,
     window_actual_shape,
     viewport_start_line,
@@ -1355,7 +1351,7 @@ fn adjust_horizontally_wrap_linebreak(
     return (start_line, start_column_on_left_side);
   }
 
-  let (on_right_side, start_column_on_right_side) = adjust_right_wrap_linebreak(
+  let (on_right_side, start_column_on_right_side) = _adjust_right_wrap_linebreak(
     buffer,
     window_actual_shape,
     viewport_start_line,
@@ -1398,8 +1394,8 @@ fn search_anchor_downward_wrap_linebreak(
   debug_assert!(viewport.lines().last_key_value().is_some());
   let (&last_line, _last_line_viewport) = viewport.lines().last_key_value().unwrap();
 
-  let target_cursor_line_not_fully_show = line_head_not_show(viewport, target_cursor_line)
-    || line_tail_not_show(viewport, buffer, target_cursor_line);
+  let target_cursor_line_not_fully_show = _line_head_not_show(viewport, target_cursor_line)
+    || _line_tail_not_show(viewport, buffer, target_cursor_line);
 
   let start_line = if target_cursor_line <= last_line && !target_cursor_line_not_fully_show {
     viewport_start_line
@@ -1419,10 +1415,10 @@ fn search_anchor_downward_wrap_linebreak(
       current_line -= 1;
     }
 
-    adjust_current_line(current_line, target_cursor_line, height, n)
+    _adjust_current_line(current_line, target_cursor_line, height, n)
   };
 
-  adjust_horizontally_wrap_linebreak(
+  _adjust_horizontally_wrap_linebreak(
     viewport,
     buffer,
     window_actual_shape,
@@ -1517,7 +1513,7 @@ fn search_anchor_upward_nowrap(
     target_cursor_line
   };
 
-  adjust_horizontally_nowrap(
+  _adjust_horizontally_nowrap(
     viewport,
     buffer,
     window_actual_shape,
@@ -1554,8 +1550,8 @@ fn search_anchor_upward_wrap_nolinebreak(
   debug_assert!(viewport.lines().first_key_value().is_some());
   let (&first_line, _first_line_viewport) = viewport.lines().first_key_value().unwrap();
 
-  let target_cursor_line_not_fully_show = line_head_not_show(viewport, target_cursor_line)
-    || line_tail_not_show(viewport, buffer, target_cursor_line);
+  let target_cursor_line_not_fully_show = _line_head_not_show(viewport, target_cursor_line)
+    || _line_tail_not_show(viewport, buffer, target_cursor_line);
 
   let start_line = if target_cursor_line >= first_line && !target_cursor_line_not_fully_show {
     viewport_start_line
@@ -1563,7 +1559,7 @@ fn search_anchor_upward_wrap_nolinebreak(
     target_cursor_line
   };
 
-  adjust_horizontally_wrap_nolinebreak(
+  _adjust_horizontally_wrap_nolinebreak(
     viewport,
     buffer,
     window_actual_shape,
@@ -1600,8 +1596,8 @@ fn search_anchor_upward_wrap_linebreak(
   debug_assert!(viewport.lines().first_key_value().is_some());
   let (&first_line, _first_line_viewport) = viewport.lines().first_key_value().unwrap();
 
-  let target_cursor_line_not_fully_show = line_head_not_show(viewport, target_cursor_line)
-    || line_tail_not_show(viewport, buffer, target_cursor_line);
+  let target_cursor_line_not_fully_show = _line_head_not_show(viewport, target_cursor_line)
+    || _line_tail_not_show(viewport, buffer, target_cursor_line);
 
   let start_line = if target_cursor_line >= first_line && !target_cursor_line_not_fully_show {
     viewport_start_line
@@ -1609,7 +1605,7 @@ fn search_anchor_upward_wrap_linebreak(
     target_cursor_line
   };
 
-  adjust_horizontally_wrap_linebreak(
+  _adjust_horizontally_wrap_linebreak(
     viewport,
     buffer,
     window_actual_shape,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1018,6 +1018,7 @@ fn _move_more_to_left_wrap_nolinebreak(
     start_column = buffer.width_before(target_cursor_line, target_cursor_char);
   }
 
+  // spellchecker:off
   // If `target_cursor_line` doesn't show its head (i.e. the `target_viewport_start_column` > 0,
   // and the viewport only contains 1 line, and the line is just too lone to fully show), and the
   // `target_cursor_line`'s end char is not at the bottom-right corner of the viewport. For
@@ -1043,6 +1044,7 @@ fn _move_more_to_left_wrap_nolinebreak(
   // ```
   //
   // Which is much better for `wrap=true`.
+  // spellchecker:on
 
   if only_contains_target_cursor_line {
     let last_visible_char = buffer

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1219,7 +1219,6 @@ fn _find_start_char_by_word(
 fn _adjust_left_wrap_linebreak(
   buffer: &Buffer,
   _window_actual_shape: &U16Rect,
-  _viewport_start_line: usize,
   viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
@@ -1227,8 +1226,8 @@ fn _adjust_left_wrap_linebreak(
   let on_left_side = match buffer.char_after(target_cursor_line, viewport_start_column) {
     Some(c) => {
       trace!(
-        "target_cursor_line:{},target_cursor_char:{},viewport_start_line:{},viewport_start_column:{},c:{}",
-        target_cursor_line, target_cursor_char, _viewport_start_line, viewport_start_column, c
+        "target_cursor_line:{},target_cursor_char:{},viewport_start_column:{},c:{}",
+        target_cursor_line, target_cursor_char, viewport_start_column, c
       );
       c > target_cursor_char
     }
@@ -1341,7 +1340,6 @@ fn _revert_search_line_start_wrap_linebreak(
 fn _adjust_right_wrap_linebreak(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
-  _viewport_start_line: usize,
   _viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
@@ -1372,21 +1370,17 @@ fn _adjust_right_wrap_linebreak(
 }
 
 fn _adjust_horizontally_wrap_linebreak(
-  viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
   target_cursor_line: usize,
   target_cursor_char: usize,
   start_line: usize,
+  start_column: usize,
 ) -> (usize, usize) {
-  let viewport_start_line = viewport.start_line_idx();
-  let viewport_start_column = viewport.start_column_idx();
-
   let (on_left_side, start_column_on_left_side) = _adjust_left_wrap_linebreak(
     buffer,
     window_actual_shape,
-    viewport_start_line,
-    viewport_start_column,
+    start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -1398,8 +1392,7 @@ fn _adjust_horizontally_wrap_linebreak(
   let (on_right_side, start_column_on_right_side) = _adjust_right_wrap_linebreak(
     buffer,
     window_actual_shape,
-    viewport_start_line,
-    viewport_start_column,
+    start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -1408,7 +1401,7 @@ fn _adjust_horizontally_wrap_linebreak(
     return (start_line, start_column_on_right_side);
   }
 
-  (start_line, viewport_start_column)
+  (start_line, start_column)
 }
 
 fn search_anchor_downward_wrap_linebreak(
@@ -1463,12 +1456,12 @@ fn search_anchor_downward_wrap_linebreak(
   };
 
   _adjust_horizontally_wrap_linebreak(
-    viewport,
     buffer,
     window_actual_shape,
     target_cursor_line,
     target_cursor_char,
     start_line,
+    viewport.start_column_idx(),
   )
 }
 
@@ -1650,11 +1643,11 @@ fn search_anchor_upward_wrap_linebreak(
   };
 
   _adjust_horizontally_wrap_linebreak(
-    viewport,
     buffer,
     window_actual_shape,
     target_cursor_line,
     target_cursor_char,
     start_line,
+    viewport.start_column_idx(),
   )
 }

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1148,7 +1148,7 @@ fn search_anchor_downward_wrap_nolinebreak(
     if target_cursor_line <= last_line && !target_cursor_line_not_fully_show {
       (viewport_start_line, viewport_start_column)
     } else {
-      // Try fill the viewport with `start_column=0`, and we can know how many rows the
+      // Try to fill the viewport with `start_column=0`, and we can know how many rows the
       // `target_cursor_line` needs to fill into current viewport.
       let (target_cursor_rows, _target_cursor_start_fills, _target_cursor_end_fills, _) =
         proc_line_wrap_nolinebreak(buffer, 0, target_cursor_line, 0_u16, u16::MAX, width);

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -766,15 +766,15 @@ fn _adjust_right_nowrap(
 fn _adjust_horizontally_nowrap(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
-  target_viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
   start_line: usize,
+  start_column: usize,
 ) -> (usize, usize) {
   let (on_left_side, start_column_on_left_side) = _adjust_left_nowrap(
     buffer,
     window_actual_shape,
-    target_viewport_start_column,
+    start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -786,7 +786,7 @@ fn _adjust_horizontally_nowrap(
   let (on_right_side, start_column_on_right_side) = _adjust_right_nowrap(
     buffer,
     window_actual_shape,
-    target_viewport_start_column,
+    start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -795,7 +795,7 @@ fn _adjust_horizontally_nowrap(
     return (start_line, start_column_on_right_side);
   }
 
-  (start_line, target_viewport_start_column)
+  (start_line, start_column)
 }
 
 fn search_anchor_downward_nowrap(
@@ -861,10 +861,10 @@ fn search_anchor_downward_nowrap(
   _adjust_horizontally_nowrap(
     buffer,
     window_actual_shape,
-    viewport.start_column_idx(),
     target_cursor_line,
     target_cursor_char,
     start_line,
+    viewport.start_column_idx(),
   )
 }
 
@@ -1560,10 +1560,10 @@ fn search_anchor_upward_nowrap(
   _adjust_horizontally_nowrap(
     buffer,
     window_actual_shape,
-    viewport.start_column_idx(),
     target_cursor_line,
     target_cursor_char,
     start_line,
+    viewport.start_column_idx(),
   )
 }
 

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1371,56 +1371,61 @@ fn _move_more_to_left_wrap_linebreak(
       target_cursor_line,
       approximate_start_column_diff,
     );
-    let mut result = start_search_char;
+    let mut result_char = start_search_char;
+    let result_column = {
+      let mut col = start_column;
 
-    let cloned_line = buffer
-      .clone_line(
-        target_cursor_line,
-        result,
-        _cloned_line_max_len(
+      let cloned_line = buffer
+        .clone_line(
+          target_cursor_line,
+          result_char,
+          _cloned_line_max_len(
+            window_actual_shape.height(),
+            window_actual_shape.width(),
+            buffer.width_before(target_cursor_line, result_char),
+          ),
+        )
+        .unwrap();
+      let words: Vec<&str> = cloned_line.split_word_bounds().collect();
+      // Word index => its (start char index, end char index)
+      let words_char_idx = words
+        .iter()
+        .enumerate()
+        .scan(result_char, |state, (i, wd)| {
+          let old_state = *state;
+          *state += wd.chars().count();
+          Some((i, (old_state, *state)))
+        })
+        .collect::<HashMap<usize, (usize, usize)>>();
+      let mut word_idx = 0_usize;
+
+      let bufline_len_chars = bufline.len_chars();
+      while result_char < bufline_len_chars {
+        let start_search_column = buffer.width_before(target_cursor_line, result_char);
+        let (rows, _start_fills, _end_fills, _) = proc_line_wrap_linebreak(
+          buffer,
+          start_search_column,
+          target_cursor_line,
+          0_u16,
           window_actual_shape.height(),
           window_actual_shape.width(),
-          buffer.width_before(target_cursor_line, result),
-        ),
-      )
-      .unwrap();
-    let words: Vec<&str> = cloned_line.split_word_bounds().collect();
-    // Word index => its (start char index, end char index)
-    let words_char_idx = words
-      .iter()
-      .enumerate()
-      .scan(result, |state, (i, wd)| {
-        let old_state = *state;
-        *state += wd.chars().count();
-        Some((i, (old_state, *state)))
-      })
-      .collect::<HashMap<usize, (usize, usize)>>();
-    let mut word_idx = 0_usize;
+        );
+        let (_last_row_idx, last_row_viewport) = rows.last_key_value().unwrap();
+        if last_visible_char < last_row_viewport.end_char_idx() {
+          col = start_search_column;
+          break;
+        }
 
-    let bufline_len_chars = bufline.len_chars();
-    while result < bufline_len_chars {
-      let start_search_column = buffer.width_before(target_cursor_line, result);
-      let (rows, _start_fills, _end_fills, _) = proc_line_wrap_linebreak(
-        buffer,
-        start_search_column,
-        target_cursor_line,
-        0_u16,
-        window_actual_shape.height(),
-        window_actual_shape.width(),
-      );
-      let (_last_row_idx, last_row_viewport) = rows.last_key_value().unwrap();
-      if last_visible_char < last_row_viewport.end_char_idx() {
-        start_column = start_search_column;
-        break;
+        word_idx += 1;
+        let (next_word_start_char, _next_word_end_char) = words_char_idx.get(&word_idx).unwrap();
+        result_char = *next_word_start_char;
       }
 
-      word_idx += 1;
-      let (next_word_start_char, _next_word_end_char) = words_char_idx.get(&word_idx).unwrap();
-      result = *next_word_start_char;
-    }
+      col
+    };
 
-    if result < start_column {
-      start_column = result;
+    if result_column < start_column {
+      start_column = result_column;
       on_left_side = true;
     }
   }

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1020,15 +1020,15 @@ fn _adjust_right_wrap_nolinebreak(
 fn _adjust_horizontally_wrap_nolinebreak(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
-  target_viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
   start_line: usize,
+  start_column: usize,
 ) -> (usize, usize) {
   let (on_left_side, start_column_on_left_side) = _adjust_left_wrap_onlinebreak(
     buffer,
     window_actual_shape,
-    target_viewport_start_column,
+    start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -1040,7 +1040,7 @@ fn _adjust_horizontally_wrap_nolinebreak(
   let (on_right_side, start_column_on_right_side) = _adjust_right_wrap_nolinebreak(
     buffer,
     window_actual_shape,
-    target_viewport_start_column,
+    start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -1049,7 +1049,7 @@ fn _adjust_horizontally_wrap_nolinebreak(
     return (start_line, start_column_on_right_side);
   }
 
-  (start_line, target_viewport_start_column)
+  (start_line, start_column)
 }
 
 fn _adjust_current_line(
@@ -1099,58 +1099,62 @@ fn search_anchor_downward_wrap_nolinebreak(
   let target_cursor_line_not_fully_show = _line_head_not_show(viewport, target_cursor_line)
     || _line_tail_not_show(viewport, buffer, target_cursor_line);
 
-  let start_line = if target_cursor_line <= last_line && !target_cursor_line_not_fully_show {
-    viewport_start_line
-  } else {
-    // Try fill the viewport with `start_column=0`, and we can know how many rows the
-    // `target_cursor_line` needs to fill into current viewport.
-    let (target_cursor_rows, _target_cursor_start_fills, _target_cursor_end_fills, _) =
-      proc_line_wrap_nolinebreak(buffer, 0, target_cursor_line, 0_u16, height, width);
-
-    // 1. If the `target_cursor_line` can fully show in current viewport, then we force the
-    // `start_column` to 0.
-    //
-    // 2. Otherwise it means the current viewport can only contains 1 line, i.e. the
-    // `target_cursor_line`, and it is still possible to add some `start_column` if the line is too
-    // long.
-    let target_cursor_line_can_fully_show = target_cursor_rows.len() <= height as usize;
-    let start_column = if target_cursor_line_can_fully_show {
-      0_usize
+  let (start_line, start_column) =
+    if target_cursor_line <= last_line && !target_cursor_line_not_fully_show {
+      (viewport_start_line, viewport_start_column)
     } else {
-      viewport_start_column
-    };
+      // Try fill the viewport with `start_column=0`, and we can know how many rows the
+      // `target_cursor_line` needs to fill into current viewport.
+      let (target_cursor_rows, _target_cursor_start_fills, _target_cursor_end_fills, _) =
+        proc_line_wrap_nolinebreak(buffer, 0, target_cursor_line, 0_u16, height, width);
 
-    let mut n = 0_usize;
-    let mut current_line = target_cursor_line as isize;
+      // 1. If the `target_cursor_line` can fully show in current viewport, then we force the
+      // `start_column` to 0.
+      //
+      // 2. Otherwise it means the current viewport can only contains 1 line, i.e. the
+      // `target_cursor_line`, and it is still possible to add some `start_column` if the line is too
+      // long.
+      let target_cursor_line_can_fully_show = target_cursor_rows.len() <= height as usize;
+      let start_column = if target_cursor_line_can_fully_show {
+        0_usize
+      } else {
+        viewport_start_column
+      };
 
-    while (n < height as usize) && (current_line >= 0) {
-      let (rows, _start_fills, _end_fills, _) = proc_line_wrap_nolinebreak(
-        buffer,
-        start_column,
-        current_line as usize,
-        0_u16,
-        height,
-        width,
-      );
-      n += rows.len();
+      let mut n = 0_usize;
+      let mut current_line = target_cursor_line as isize;
 
-      if current_line == 0 || n >= height as usize {
-        break;
+      while (n < height as usize) && (current_line >= 0) {
+        let (rows, _start_fills, _end_fills, _) = proc_line_wrap_nolinebreak(
+          buffer,
+          start_column,
+          current_line as usize,
+          0_u16,
+          height,
+          width,
+        );
+        n += rows.len();
+
+        if current_line == 0 || n >= height as usize {
+          break;
+        }
+
+        current_line -= 1;
       }
 
-      current_line -= 1;
-    }
-
-    _adjust_current_line(current_line, target_cursor_line, height, n)
-  };
+      (
+        _adjust_current_line(current_line, target_cursor_line, height, n),
+        start_column,
+      )
+    };
 
   _adjust_horizontally_wrap_nolinebreak(
     buffer,
     window_actual_shape,
-    viewport.start_column_idx(),
     target_cursor_line,
     target_cursor_char,
     start_line,
+    start_column,
   )
 }
 
@@ -1602,10 +1606,10 @@ fn search_anchor_upward_wrap_nolinebreak(
   _adjust_horizontally_wrap_nolinebreak(
     buffer,
     window_actual_shape,
-    viewport.start_column_idx(),
     target_cursor_line,
     target_cursor_char,
     start_line,
+    viewport.start_column_idx(),
   )
 }
 

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1137,9 +1137,9 @@ fn search_anchor_downward_wrap_nolinebreak(
   debug_assert!(viewport.lines().last_key_value().is_some());
   let (&last_line, _last_line_viewport) = viewport.lines().last_key_value().unwrap();
 
-  // NOTE: For `wrap=true`, if a line's head/tail not fully rendered, it means there will be only
-  // only 1 line shows in current window viewport. Because the `wrap` will force the 2nd line
-  // wait to show until the **current** line get fully rendered.
+  // NOTE: For `wrap=true`, if a line's head/tail not fully rendered, it means there will be only 1
+  // line shows in current window viewport. Because the `wrap` will force the 2nd line wait to show
+  // until the **current** line get fully rendered.
 
   let target_cursor_line_not_fully_show = _line_head_not_show(viewport, target_cursor_line)
     || _line_tail_not_show(viewport, buffer, target_cursor_line);
@@ -1151,7 +1151,7 @@ fn search_anchor_downward_wrap_nolinebreak(
       // Try fill the viewport with `start_column=0`, and we can know how many rows the
       // `target_cursor_line` needs to fill into current viewport.
       let (target_cursor_rows, _target_cursor_start_fills, _target_cursor_end_fills, _) =
-        proc_line_wrap_nolinebreak(buffer, 0, target_cursor_line, 0_u16, height, width);
+        proc_line_wrap_nolinebreak(buffer, 0, target_cursor_line, 0_u16, u16::MAX, width);
 
       // 1. If the `target_cursor_line` can fully show in current viewport, then we force the
       // `start_column` to 0.

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1190,40 +1190,32 @@ fn search_anchor_downward_wrap_nolinebreak(
   let target_cursor_line_not_fully_show = _line_head_not_show(viewport, target_cursor_line)
     || _line_tail_not_show(viewport, buffer, target_cursor_line);
 
-  let (start_line, start_column, only_contains_target_cursor_line) =
-    if target_cursor_line <= last_line && !target_cursor_line_not_fully_show {
-      (viewport_start_line, viewport_start_column, false)
-    } else {
-      // Try to fill the viewport with `start_column=0`, and we can know how many rows the
-      // `target_cursor_line` needs to fill into current viewport.
-      let (target_cursor_rows, _target_cursor_start_fills, _target_cursor_end_fills, _) =
-        proc_line_wrap_nolinebreak(buffer, 0, target_cursor_line, 0_u16, u16::MAX, width);
+  let (start_line, start_column, only_contains_target_cursor_line) = if target_cursor_line
+    <= last_line
+    && !target_cursor_line_not_fully_show
+  {
+    (viewport_start_line, viewport_start_column, false)
+  } else {
+    // Try to fill the viewport with `start_column=0`, and we can know how many rows the
+    // `target_cursor_line` needs to fill into current viewport.
+    let (target_cursor_rows, _target_cursor_start_fills, _target_cursor_end_fills, _) =
+      proc_line_wrap_nolinebreak(buffer, 0, target_cursor_line, 0_u16, u16::MAX, width);
 
-      // 1. If the `target_cursor_line` can fully show in current viewport, then we force the
-      // `start_column` to 0.
-      //
-      // 2. Otherwise it means the current viewport can only contains 1 line, i.e. the
-      // `target_cursor_line`, and it is still possible to add some `start_column` if the line is too
-      // long.
-      let target_cursor_line_can_fully_show = target_cursor_rows.len() <= height as usize;
-      let (only_contains_target_cursor_line, start_column) = if target_cursor_line_can_fully_show {
-        (true, 0_usize)
-      } else {
-        (false, viewport_start_column)
-      };
-
+    // 1. If the `target_cursor_line` can fully show in current viewport, then we force the
+    // `start_column` to 0.
+    //
+    // 2. Otherwise it means the current viewport can only contains 1 line, i.e. the
+    // `target_cursor_line`, and it is still possible to add some `start_column` if the line is too
+    // long. And in such case, the `start_line` will always be the `target_cursor_line` because
+    // the line is too big to show in current viewport, and we don't need other lines.
+    let target_cursor_line_can_fully_show = target_cursor_rows.len() <= height as usize;
+    if target_cursor_line_can_fully_show {
       let mut n = 0_usize;
       let mut current_line = target_cursor_line as isize;
 
       while (n < height as usize) && (current_line >= 0) {
-        let (rows, _start_fills, _end_fills, _) = proc_line_wrap_nolinebreak(
-          buffer,
-          start_column,
-          current_line as usize,
-          0_u16,
-          height,
-          width,
-        );
+        let (rows, _start_fills, _end_fills, _) =
+          proc_line_wrap_nolinebreak(buffer, 0_usize, current_line as usize, 0_u16, height, width);
         n += rows.len();
 
         if current_line == 0 || n >= height as usize {
@@ -1235,10 +1227,13 @@ fn search_anchor_downward_wrap_nolinebreak(
 
       (
         _adjust_current_line(current_line, target_cursor_line, height, n),
-        start_column,
-        only_contains_target_cursor_line,
+        0_usize,
+        true,
       )
-    };
+    } else {
+      (target_cursor_line, viewport_start_column, false)
+    }
+  };
 
   _adjust_horizontally_wrap_nolinebreak(
     buffer,
@@ -1570,38 +1565,30 @@ fn search_anchor_downward_wrap_linebreak(
         proc_line_wrap_linebreak(buffer, 0, target_cursor_line, 0_u16, u16::MAX, width);
 
       let target_cursor_line_can_fully_show = target_cursor_rows.len() <= height as usize;
-      let (only_contains_target_cursor_line, start_column) = if target_cursor_line_can_fully_show {
-        (true, 0_usize)
-      } else {
-        (false, viewport_start_column)
-      };
+      if target_cursor_line_can_fully_show {
+        let mut n = 0_usize;
+        let mut current_line = target_cursor_line as isize;
 
-      let mut n = 0_usize;
-      let mut current_line = target_cursor_line as isize;
+        while (n < height as usize) && (current_line >= 0) {
+          let (rows, _start_fills, _end_fills, _) =
+            proc_line_wrap_linebreak(buffer, 0_usize, current_line as usize, 0_u16, height, width);
+          n += rows.len();
 
-      while (n < height as usize) && (current_line >= 0) {
-        let (rows, _start_fills, _end_fills, _) = proc_line_wrap_linebreak(
-          buffer,
-          start_column,
-          current_line as usize,
-          0_u16,
-          height,
-          width,
-        );
-        n += rows.len();
+          if current_line == 0 || n >= height as usize {
+            break;
+          }
 
-        if current_line == 0 || n >= height as usize {
-          break;
+          current_line -= 1;
         }
 
-        current_line -= 1;
+        (
+          _adjust_current_line(current_line, target_cursor_line, height, n),
+          0_usize,
+          true,
+        )
+      } else {
+        (target_cursor_line, viewport_start_column, false)
       }
-
-      (
-        _adjust_current_line(current_line, target_cursor_line, height, n),
-        start_column,
-        only_contains_target_cursor_line,
-      )
     };
 
   _adjust_horizontally_wrap_linebreak(

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1388,7 +1388,7 @@ fn search_anchor_downward_wrap_linebreak(
   target_cursor_char: usize,
 ) -> (usize, usize) {
   let viewport_start_line = viewport.start_line_idx();
-  let viewport_start_column = viewport.start_column_idx();
+  let _viewport_start_column = viewport.start_column_idx();
   let height = window_actual_shape.height();
   let width = window_actual_shape.width();
   let buffer_len_lines = buffer.get_rope().len_lines();

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -700,7 +700,6 @@ pub fn search_anchor_downward(
 fn _adjust_left_nowrap(
   buffer: &Buffer,
   _window_actual_shape: &U16Rect,
-  _viewport_start_line: usize,
   viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
@@ -709,8 +708,8 @@ fn _adjust_left_nowrap(
   let on_left_side = match buffer.char_after(target_cursor_line, viewport_start_column) {
     Some(c) => {
       trace!(
-        "target_cursor_line:{},target_cursor_char:{},viewport_start_line:{},viewport_start_column:{},c:{}",
-        target_cursor_line, target_cursor_char, _viewport_start_line, viewport_start_column, c
+        "target_cursor_line:{},target_cursor_char:{},viewport_start_column:{},c:{}",
+        target_cursor_line, target_cursor_char, viewport_start_column, c
       );
       c > target_cursor_char
     }
@@ -779,7 +778,6 @@ fn _adjust_horizontally_nowrap(
   let (on_left_side, start_column_on_left_side) = _adjust_left_nowrap(
     buffer,
     window_actual_shape,
-    viewport_start_line,
     viewport_start_column,
     target_cursor_line,
     target_cursor_char,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -956,7 +956,7 @@ fn _revert_search_line_start_wrap_nolinebreak(
   unreachable!()
 }
 
-fn _adjust_left_wrap_onlinebreak(
+fn _move_more_to_left_wrap_onlinebreak(
   buffer: &Buffer,
   _window_actual_shape: &U16Rect,
   viewport_start_column: usize,
@@ -985,7 +985,7 @@ fn _adjust_left_wrap_onlinebreak(
   (false, 0_usize)
 }
 
-fn _adjust_right_wrap_nolinebreak(
+fn _move_more_to_right_wrap_nolinebreak(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
   _viewport_start_column: usize,
@@ -1025,7 +1025,7 @@ fn _adjust_horizontally_wrap_nolinebreak(
   start_line: usize,
   start_column: usize,
 ) -> (usize, usize) {
-  let (on_left_side, start_column_on_left_side) = _adjust_left_wrap_onlinebreak(
+  let (on_left_side, start_column_on_left_side) = _move_more_to_left_wrap_onlinebreak(
     buffer,
     window_actual_shape,
     start_column,
@@ -1037,7 +1037,7 @@ fn _adjust_horizontally_wrap_nolinebreak(
     return (start_line, start_column_on_left_side);
   }
 
-  let (on_right_side, start_column_on_right_side) = _adjust_right_wrap_nolinebreak(
+  let (on_right_side, start_column_on_right_side) = _move_more_to_right_wrap_nolinebreak(
     buffer,
     window_actual_shape,
     start_column,
@@ -1216,7 +1216,7 @@ fn _find_start_char_by_word(
   }
 }
 
-fn _adjust_left_wrap_linebreak(
+fn _move_more_to_left_wrap_linebreak(
   buffer: &Buffer,
   _window_actual_shape: &U16Rect,
   viewport_start_column: usize,
@@ -1337,7 +1337,7 @@ fn _revert_search_line_start_wrap_linebreak(
   unreachable!()
 }
 
-fn _adjust_right_wrap_linebreak(
+fn _move_more_to_right_wrap_linebreak(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
   _viewport_start_column: usize,
@@ -1377,7 +1377,7 @@ fn _adjust_horizontally_wrap_linebreak(
   start_line: usize,
   start_column: usize,
 ) -> (usize, usize) {
-  let (on_left_side, start_column_on_left_side) = _adjust_left_wrap_linebreak(
+  let (on_left_side, start_column_on_left_side) = _move_more_to_left_wrap_linebreak(
     buffer,
     window_actual_shape,
     start_column,
@@ -1389,7 +1389,7 @@ fn _adjust_horizontally_wrap_linebreak(
     return (start_line, start_column_on_left_side);
   }
 
-  let (on_right_side, start_column_on_right_side) = _adjust_right_wrap_linebreak(
+  let (on_right_side, start_column_on_right_side) = _move_more_to_right_wrap_linebreak(
     buffer,
     window_actual_shape,
     start_column,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1580,8 +1580,14 @@ fn search_anchor_downward_wrap_linebreak(
       let mut current_line = target_cursor_line as isize;
 
       while (n < height as usize) && (current_line >= 0) {
-        let (rows, _start_fills, _end_fills, _) =
-          proc_line_wrap_linebreak(buffer, 0, current_line as usize, 0_u16, height, width);
+        let (rows, _start_fills, _end_fills, _) = proc_line_wrap_linebreak(
+          buffer,
+          start_column,
+          current_line as usize,
+          0_u16,
+          height,
+          width,
+        );
         n += rows.len();
 
         if current_line == 0 || n >= height as usize {

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -73,15 +73,6 @@ pub fn sync(
   }
 }
 
-#[allow(dead_code)]
-fn slice2line(s: &RopeSlice) -> String {
-  let mut builder = String::new();
-  for chunk in s.chunks() {
-    builder.push_str(chunk);
-  }
-  builder
-}
-
 fn end_char_and_prefills(
   buffer: &Buffer,
   bline: &RopeSlice,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -733,7 +733,6 @@ fn _adjust_left_nowrap(
 fn _adjust_right_nowrap(
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
-  _viewport_start_line: usize,
   viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
@@ -745,8 +744,8 @@ fn _adjust_right_nowrap(
   let on_right_side = match buffer.char_at(target_cursor_line, viewport_end_column) {
     Some(c) => {
       trace!(
-        "target_cursor_line:{},target_cursor_char:{},viewport_start_line:{},viewport_start_column:{},c:{}",
-        target_cursor_line, target_cursor_char, _viewport_start_line, viewport_start_column, c
+        "target_cursor_line:{},target_cursor_char:{},viewport_start_column:{},c:{}",
+        target_cursor_line, target_cursor_char, viewport_start_column, c
       );
       c < target_cursor_char
     }
@@ -765,20 +764,17 @@ fn _adjust_right_nowrap(
 }
 
 fn _adjust_horizontally_nowrap(
-  viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
+  target_viewport_start_column: usize,
   target_cursor_line: usize,
   target_cursor_char: usize,
   start_line: usize,
 ) -> (usize, usize) {
-  let viewport_start_line = viewport.start_line_idx();
-  let viewport_start_column = viewport.start_column_idx();
-
   let (on_left_side, start_column_on_left_side) = _adjust_left_nowrap(
     buffer,
     window_actual_shape,
-    viewport_start_column,
+    target_viewport_start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -790,8 +786,7 @@ fn _adjust_horizontally_nowrap(
   let (on_right_side, start_column_on_right_side) = _adjust_right_nowrap(
     buffer,
     window_actual_shape,
-    viewport_start_line,
-    viewport_start_column,
+    target_viewport_start_column,
     target_cursor_line,
     target_cursor_char,
   );
@@ -800,7 +795,7 @@ fn _adjust_horizontally_nowrap(
     return (start_line, start_column_on_right_side);
   }
 
-  (start_line, viewport_start_column)
+  (start_line, target_viewport_start_column)
 }
 
 fn search_anchor_downward_nowrap(
@@ -864,9 +859,9 @@ fn search_anchor_downward_nowrap(
   };
 
   _adjust_horizontally_nowrap(
-    viewport,
     buffer,
     window_actual_shape,
+    viewport.start_column_idx(),
     target_cursor_line,
     target_cursor_char,
     start_line,
@@ -1566,9 +1561,9 @@ fn search_anchor_upward_nowrap(
   };
 
   _adjust_horizontally_nowrap(
-    viewport,
     buffer,
     window_actual_shape,
+    viewport.start_column_idx(),
     target_cursor_line,
     target_cursor_char,
     start_line,


### PR DESCRIPTION
When cursor moves up/down, there are two cases:
1. If the target cursor position is still inside current window, then we simply change the cursor position in the window, which is easy.
2. If the target cursor position is outside of current window (since buffer/file contents can be much bigger than a window and not fully show in the window), then we need to first scroll the buffer to show the target line/char, then update the cursor position.

This PR (and previous #365) helps calculate the new viewport anchor (`start_line`/`start_column`) when scrolling buffer up/down. Also fixes several issues in previous PR.