### PR TITLE
feat(cursor): allow cursor move to end of line '\n' for insert mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,17 @@ jobs:
       - name: MSRV
         run: |
           mkdir ~/.cargo-msrv
-          curl --output ~/.cargo-msrv/cargo-msrv.tgz -fsSL https://github.com/foresterre/cargo-msrv/releases/download/v0.18.4/cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4.tgz
+          CARGO_MSRV_DIR="cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4"
+          curl --output ~/.cargo-msrv/cargo-msrv.tgz -fsSL https://github.com/foresterre/cargo-msrv/releases/download/v0.18.4/$CARGO_MSRV_DIR.tgz
           tar -xvzf ~/.cargo-msrv/cargo-msrv.tgz -C ~/.cargo-msrv
           echo "Info: ~/.cargo-msrv"
           ls -l ~/.cargo-msrv
-          echo "Info: ~/.cargo-msrv/cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4"
-          ls -l ~/.cargo-msrv/cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4
+          echo "Info: ~/.cargo-msrv/$CARGO_MSRV_DIR"
+          ls -l ~/.cargo-msrv/$CARGO_MSRV_DIR
+          mv ~/.cargo-msrv/$CARGO_MSRV_DIR/cargo-msrv ~/.cargo/bin
           chmod 755 ~/.cargo/bin/cargo-msrv
+          echo "Info: ~/.cargo/bin"
+          ls -l ~/.cargo/bin
           # cargo binstall --force --no-confirm cargo-msrv
           echo "Info: cargo msrv --version"
           cargo msrv --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: dtolnay/rust-toolchain@stable
-      - uses: cargo-bins/cargo-binstall@main
+      # - uses: cargo-bins/cargo-binstall@main
       - name: Rustfmt
         run: cargo fmt --check
       - name: Taplo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,9 @@ jobs:
         run: |
           mkdir ~/.cargo-msrv
           curl --output ~/.cargo-msrv/cargo-msrv.tgz -fsSL https://github.com/foresterre/cargo-msrv/releases/download/v0.18.4/cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4.tgz
+          tar -xvzf ~/.cargo-msrv/cargo-msrv.tgz -C ~/.cargo-msrv
           echo "Info: ~/.cargo-msrv"
           ls -l ~/.cargo-msrv
-          tar -xvzf ~/.cargo-msrv/cargo-msrv.tgz -C ~/.cargo/bin
-          echo "Info: ~/.cargo/bin"
-          ls -l ~/.cargo/bin
           chmod 755 ~/.cargo/bin/cargo-msrv
           # cargo binstall --force --no-confirm cargo-msrv
           echo "Info: cargo msrv --version"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,14 @@ jobs:
         run: cargo clippy --all-targets --all-features
       - name: MSRV
         run: |
-          curl -fsSL https://github.com/foresterre/cargo-msrv/releases/download/v0.18.4/cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4.tgz | gzip -d - | install -m 755 /dev/stdin ~/.cargo/bin/cargo-msrv
+          mkdir ~/.cargo-msrv
+          curl --output ~/.cargo-msrv/cargo-msrv.tgz -fsSL https://github.com/foresterre/cargo-msrv/releases/download/v0.18.4/cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4.tgz
+          echo "Info: ~/.cargo-msrv"
+          ls -l ~/.cargo-msrv
+          tar -xvzf ~/.cargo-msrv/cargo-msrv.tgz -C ~/.cargo/bin
+          echo "Info: ~/.cargo/bin"
+          ls -l ~/.cargo/bin
+          chmod 755 ~/.cargo/bin/cargo-msrv
           # cargo binstall --force --no-confirm cargo-msrv
           echo "Info: cargo msrv --version"
           cargo msrv --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           tar -xvzf ~/.cargo-msrv/cargo-msrv.tgz -C ~/.cargo-msrv
           echo "Info: ~/.cargo-msrv"
           ls -l ~/.cargo-msrv
+          echo "Info: ~/.cargo-msrv/cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4"
+          ls -l ~/.cargo-msrv/cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4
           chmod 755 ~/.cargo/bin/cargo-msrv
           # cargo binstall --force --no-confirm cargo-msrv
           echo "Info: cargo msrv --version"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,6 @@ jobs:
           taplo check
           echo "Info: taplo fmt --check"
           taplo fmt --check
-      - name: Clippy
-        env:
-          RUSTC_WRAPPER: "sccache"
-          SCCACHE_GHA_ENABLED: "true"
-        run: cargo clippy --all-targets --all-features
       - name: MSRV
         run: |
           mkdir ~/.cargo-msrv
@@ -93,6 +88,11 @@ jobs:
           cargo msrv verify
           echo "Info: cd SAVED_PWD=${SAVED_PWD}"
           cd "${SAVED_PWD}"
+      - name: Clippy
+        env:
+          RUSTC_WRAPPER: "sccache"
+          SCCACHE_GHA_ENABLED: "true"
+        run: cargo clippy --all-targets --all-features
       - name: Docs
         run: |
           echo "Info: cargo doc --workspace"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
         run: cargo fmt --check
       - name: Taplo
         run: |
-          cargo binstall --force --no-confirm taplo-cli
+          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-linux-x86_64.gz | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
+          # cargo binstall --force --no-confirm taplo-cli
           echo "Info: taplo --version"
           taplo --version
           echo "Info: taplo check"
@@ -71,7 +72,8 @@ jobs:
         run: cargo clippy --all-targets --all-features
       - name: MSRV
         run: |
-          cargo binstall --force --no-confirm cargo-msrv
+          curl -fsSL https://github.com/foresterre/cargo-msrv/releases/download/v0.18.4/cargo-msrv-x86_64-unknown-linux-gnu-v0.18.4.tgz | gzip -d - | install -m 755 /dev/stdin ~/.cargo/bin/cargo-msrv
+          # cargo binstall --force --no-confirm cargo-msrv
           echo "Info: cargo msrv --version"
           cargo msrv --version
           echo "Info: PWD=${PWD}"

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -6,7 +6,9 @@ use crate::state::ops::Operation;
 use crate::state::ops::cursor_ops::{self, CursorMoveDirection};
 use crate::ui::canvas::CursorStyle;
 use crate::ui::tree::*;
-use crate::ui::widget::window::{ViewportArc, ViewportSearchAnchorDirection};
+use crate::ui::widget::window::{
+  ViewportArc, ViewportSearchAnchorDirection, ViewportSearchAnchorOptionsBuilder,
+};
 
 use crossterm::event::{Event, KeyCode, KeyEventKind};
 use tracing::trace;
@@ -115,7 +117,11 @@ impl InsertStateful {
         let new_viewport_arc: Option<ViewportArc> = {
           let viewport = lock!(viewport_arc);
           let (start_line, start_column) = viewport.search_anchor(
-            search_direction,
+            ViewportSearchAnchorOptionsBuilder::default()
+              .allow_line_end(true)
+              .direction(search_direction)
+              .build()
+              .unwrap(),
             &buffer,
             current_window.actual_shape(),
             current_window.options(),

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -7,7 +7,9 @@ use crate::state::ops::Operation;
 use crate::state::ops::cursor_ops::{self, CursorMoveDirection};
 use crate::ui::canvas::CursorStyle;
 use crate::ui::tree::*;
-use crate::ui::widget::window::{ViewportArc, ViewportSearchAnchorDirection};
+use crate::ui::widget::window::{
+  ViewportArc, ViewportSearchAnchorDirection, ViewportSearchAnchorOptionsBuilder,
+};
 
 use crossterm::event::{Event, KeyCode, KeyEventKind};
 use tracing::trace;
@@ -113,7 +115,10 @@ impl NormalStateful {
         let new_viewport_arc: Option<ViewportArc> = {
           let viewport = lock!(viewport_arc);
           let (start_line, start_column) = viewport.search_anchor(
-            search_direction,
+            ViewportSearchAnchorOptionsBuilder::default()
+              .direction(search_direction)
+              .build()
+              .unwrap(),
             &buffer,
             current_window.actual_shape(),
             current_window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -6243,6 +6243,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6350,6 +6351,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6404,6 +6406,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6451,6 +6454,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6503,6 +6507,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6555,6 +6560,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6601,6 +6607,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6698,6 +6705,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6750,6 +6758,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6803,6 +6812,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6849,6 +6859,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6895,6 +6906,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -7014,6 +7026,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -7070,6 +7083,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7120,6 +7134,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7170,6 +7185,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7220,6 +7236,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7276,6 +7293,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7332,6 +7350,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7388,6 +7407,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7495,6 +7515,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -7551,6 +7572,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7601,6 +7623,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7651,6 +7674,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7701,6 +7725,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7757,6 +7782,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7813,6 +7839,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7869,6 +7896,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7990,6 +8018,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -8048,6 +8077,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8100,6 +8130,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8147,6 +8178,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8199,6 +8231,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8251,6 +8284,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8303,6 +8337,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8355,6 +8390,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8458,6 +8494,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -8510,6 +8547,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8562,6 +8600,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8608,6 +8647,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8654,6 +8694,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8706,6 +8747,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8758,6 +8800,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8810,6 +8853,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8929,6 +8973,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -8987,6 +9032,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9039,6 +9085,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9086,6 +9133,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9132,6 +9180,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9184,6 +9233,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9236,6 +9286,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9288,6 +9339,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9391,6 +9443,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -9443,6 +9496,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9495,6 +9549,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9541,6 +9596,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9587,6 +9643,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9639,6 +9696,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9691,6 +9749,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9743,6 +9802,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9870,6 +9930,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -9932,6 +9993,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -9988,6 +10050,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10044,6 +10107,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10100,6 +10164,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10157,6 +10222,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10213,6 +10279,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10269,6 +10336,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10325,6 +10393,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10381,6 +10450,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10437,6 +10507,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10493,6 +10564,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10549,6 +10621,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10605,6 +10678,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10712,6 +10786,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -10768,6 +10843,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10818,6 +10894,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10868,6 +10945,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10918,6 +10996,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10968,6 +11047,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11018,6 +11098,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11068,6 +11149,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11118,6 +11200,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11168,6 +11251,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11218,6 +11302,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11268,6 +11353,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11318,6 +11404,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11368,6 +11455,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11418,6 +11506,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11468,6 +11557,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11518,6 +11608,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11568,6 +11659,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11618,6 +11710,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -4961,297 +4961,6 @@ mod tests_search_anchor_downward_nowrap {
 }
 #[allow(unused_imports)]
 #[cfg(test)]
-mod tests_search_anchor_downward_nowrap_allow_line_end {
-  use super::tests_util::*;
-  use super::*;
-
-  use crate::buf::BufferLocalOptionsBuilder;
-  use crate::lock;
-  use crate::prelude::*;
-  use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
-  use crate::test::log::init as test_log_init;
-  use crate::ui::tree::Inodeable;
-
-  use std::cell::RefCell;
-  use std::rc::Rc;
-
-  #[test]
-  fn new1() {
-    test_log_init();
-
-    let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = make_nowrap();
-
-    let buf = make_buffer_from_lines(
-      terminal_size.height(),
-      buf_opts,
-      vec![
-        "Hello, RSVIM!\n",
-        "This is a quite simple and small test lines.\n",
-        "But still it contains several things we want to test:\n",
-        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
-        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
-        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
-        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
-      ],
-    );
-
-    let window = Rc::new(RefCell::new(make_window(
-      terminal_size,
-      buf.clone(),
-      &win_opts,
-    )));
-
-    // Initialize
-    {
-      let expect = vec![
-        "Hello, RSVIM!\n",
-        "This is a quite s",
-        "But still it cont",
-        "\t1. When",
-        "\t2. When",
-      ];
-
-      let actual = lock!(window.borrow().viewport()).clone();
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        0,
-        5,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-1
-    {
-      let expect = vec![
-        "Hello, RSVIM!\n",
-        "This is a quite s",
-        "But still it cont",
-        "\t1. When",
-        "\t2. When",
-      ];
-
-      let actual = {
-        let target_cursor_line = 2;
-        let target_cursor_char = 15;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 0);
-        assert_eq!(start_column, 0);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
-          &viewport,
-          &buf,
-          target_cursor_line,
-          target_cursor_char,
-        )));
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        0,
-        5,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-2
-    {
-      let expect = vec![
-        "This is a quite s",
-        "But still it cont",
-        "\t1. When",
-        "\t2. When",
-        "\t\t3",
-      ];
-
-      let actual = {
-        let target_cursor_line = 5;
-        let target_cursor_char = 1;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 1);
-        assert_eq!(start_column, 0);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 2), (4, 2), (5, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        1,
-        6,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-3
-    {
-      let expect = vec!["ut still it conta", "1. When", "2. When", "\t3.", "\t4."];
-
-      let actual = {
-        let target_cursor_line = 6;
-        let target_cursor_char = 3;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 2);
-        assert_eq!(start_column, 1);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 7), (4, 7), (5, 7), (6, 7)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 3), (4, 3), (5, 0), (6, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        2,
-        7,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-
-    // Search-4
-    {
-      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
-
-      let actual = {
-        let target_cursor_line = 7;
-        let target_cursor_char = 3;
-
-        let mut window = window.borrow_mut();
-        let old = lock!(window.viewport()).clone();
-        let buf = lock!(buf);
-        let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          target_cursor_line,
-          target_cursor_char,
-        );
-        assert_eq!(start_line, 3);
-        assert_eq!(start_column, 0);
-
-        let viewport = Viewport::view(
-          &buf,
-          window.actual_shape(),
-          window.options(),
-          start_line,
-          start_column,
-        );
-        window.set_viewport(Viewport::to_arc(viewport));
-        lock!(window.viewport()).clone()
-      };
-
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
-        .into_iter()
-        .collect();
-      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport(
-        buf.clone(),
-        &actual,
-        &expect,
-        3,
-        8,
-        &expect_start_fills,
-        &expect_end_fills,
-      );
-    }
-  }
-}
-#[allow(unused_imports)]
-#[cfg(test)]
 mod tests_search_anchor_downward_wrap_nolinebreak {
   use super::tests_util::*;
   use super::*;
@@ -12186,6 +11895,134 @@ mod tests_search_anchor_horizontally_nowrap {
         &expect,
         0,
         5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+  }
+}
+#[allow(unused_imports)]
+#[cfg(test)]
+mod tests_search_anchor_horizontally_nowrap_allow_line_end {
+  use super::tests_util::*;
+  use super::*;
+
+  use crate::buf::BufferLocalOptionsBuilder;
+  use crate::lock;
+  use crate::prelude::*;
+  use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
+  use crate::test::log::init as test_log_init;
+  use crate::ui::tree::Inodeable;
+
+  use std::cell::RefCell;
+  use std::rc::Rc;
+
+  #[test]
+  fn new1() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(17, 4);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let win_opts = make_nowrap();
+
+    let buf = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+
+    let window = Rc::new(RefCell::new(make_window(
+      terminal_size,
+      buf.clone(),
+      &win_opts,
+    )));
+
+    // Initialize
+    {
+      let expect = vec![
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+      ];
+
+      let actual = lock!(window.borrow().viewport()).clone();
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 2), (3, 2)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        4,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec![
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+      ];
+
+      let actual = {
+        let target_cursor_line = 0;
+        let target_cursor_char = 15;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Right,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0), (3, 2)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        4,
         &expect_start_fills,
         &expect_end_fills,
       );

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -732,6 +732,10 @@ mod tests_util {
     ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Down).build().unwrap()
   }
 
+  pub fn search_up() -> ViewportSearchAnchorOptions {
+    ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Up).build().unwrap()
+  }
+
   pub fn search_down_allow_line_end() -> ViewportSearchAnchorOptions {
     ViewportSearchAnchorOptionsBuilder::default()
       .allow_line_end(true)
@@ -5229,7 +5233,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5282,7 +5285,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5329,7 +5331,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5437,7 +5438,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5498,7 +5498,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5546,7 +5545,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5599,7 +5597,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5652,7 +5649,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5699,7 +5695,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5797,7 +5792,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5850,7 +5844,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5980,7 +5973,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6033,7 +6025,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6081,7 +6072,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -13164,7 +13164,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13216,7 +13216,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13268,7 +13268,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13320,7 +13320,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13372,7 +13372,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13424,7 +13424,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13476,7 +13476,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13528,7 +13528,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13580,7 +13580,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13632,7 +13632,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13788,7 +13788,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13834,7 +13834,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13880,7 +13880,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13926,7 +13926,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13972,7 +13972,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14018,7 +14018,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14064,7 +14064,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14110,7 +14110,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14156,7 +14156,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14279,7 +14279,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14339,7 +14339,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14399,7 +14399,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14459,7 +14459,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14519,7 +14519,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14634,7 +14634,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14692,7 +14692,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14750,7 +14750,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14808,7 +14808,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14860,7 +14860,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14912,7 +14912,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -14964,7 +14964,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15016,7 +15016,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15068,7 +15068,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15120,7 +15120,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15172,7 +15172,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15224,7 +15224,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15276,7 +15276,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15328,7 +15328,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15380,7 +15380,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15432,7 +15432,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15484,7 +15484,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15536,7 +15536,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15588,7 +15588,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15640,7 +15640,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15692,7 +15692,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15744,7 +15744,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15840,7 +15840,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -15896,7 +15896,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16848,7 +16848,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -736,7 +736,15 @@ mod tests_util {
     ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Up).build().unwrap()
   }
 
-  pub fn search_down_allow_line_end() -> ViewportSearchAnchorOptions {
+  pub fn search_left() -> ViewportSearchAnchorOptions {
+    ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Left).build().unwrap()
+  }
+
+  pub fn search_right() -> ViewportSearchAnchorOptions {
+    ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Right).build().unwrap()
+  }
+
+  pub fn search_left_allow_line_end() -> ViewportSearchAnchorOptions {
     ViewportSearchAnchorOptionsBuilder::default()
       .allow_line_end(true)
       .direction(ViewportSearchAnchorDirection::Down).build().unwrap()
@@ -6124,7 +6132,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6171,7 +6178,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6218,7 +6224,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6326,7 +6331,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6381,7 +6385,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6429,7 +6432,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6482,7 +6484,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6535,7 +6536,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6582,7 +6582,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6680,7 +6679,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6733,7 +6731,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6787,7 +6784,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6834,7 +6830,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -6881,7 +6876,6 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7001,7 +6995,6 @@ mod tests_search_anchor_upward_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7057,8 +7050,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7108,8 +7100,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7159,8 +7150,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7210,8 +7200,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7267,8 +7256,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7324,8 +7312,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7381,8 +7368,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7490,7 +7476,6 @@ mod tests_search_anchor_upward_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7546,8 +7531,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7597,8 +7581,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7648,8 +7631,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7699,8 +7681,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7756,8 +7737,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7813,8 +7793,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7870,8 +7849,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -7993,7 +7971,6 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8051,8 +8028,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8104,8 +8080,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -11761,6 +11761,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11811,6 +11812,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11861,6 +11863,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11911,6 +11914,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11961,6 +11965,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12011,6 +12016,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12135,6 +12141,7 @@ mod tests_search_anchor_horizontally_nowrap_allow_line_end {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -4683,7 +4683,6 @@ mod tests_search_anchor_downward_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4740,7 +4739,6 @@ mod tests_search_anchor_downward_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4791,7 +4789,6 @@ mod tests_search_anchor_downward_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4842,7 +4839,6 @@ mod tests_search_anchor_downward_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4899,7 +4895,6 @@ mod tests_search_anchor_downward_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4950,7 +4945,6 @@ mod tests_search_anchor_downward_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5078,7 +5072,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5137,7 +5130,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -5185,7 +5177,6 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -16887,12 +16887,7 @@ mod tests_search_anchor_horizontally_nowrap_allow_line_end {
 
     // Search-1
     {
-      let expect = vec![
-        "This is a quite s",
-        "But still it cont",
-        "\t1. When",
-        "\t2. When",
-      ];
+      let expect = vec!["mall test lines.\n", "l things we want ", "line", "\ttoo"];
 
       let actual = {
         let target_cursor_line = 0;
@@ -16910,7 +16905,7 @@ mod tests_search_anchor_horizontally_nowrap_allow_line_end {
           target_cursor_char,
         );
         assert_eq!(start_line, 0);
-        assert_eq!(start_column, 0);
+        assert_eq!(start_column, 28);
 
         let viewport = Viewport::view(
           &buf,
@@ -16930,9 +16925,63 @@ mod tests_search_anchor_horizontally_nowrap_allow_line_end {
       };
 
       let expect_start_fills: BTreeMap<usize, usize> =
-        vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
+        vec![(0, 0), (1, 0), (2, 6), (3, 5)].into_iter().collect();
       let expect_end_fills: BTreeMap<usize, usize> =
-        vec![(0, 0), (1, 0), (2, 2), (3, 2)].into_iter().collect();
+        vec![(0, 0), (1, 0), (2, 7), (3, 1)].into_iter().collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        4,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-2
+    {
+      let expect = vec!["mall test lines.\n", "l things we want ", "line", "\ttoo"];
+
+      let actual = {
+        let target_cursor_line = 0;
+        let target_cursor_char = 45;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          search_right_allow_line_end(),
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 28);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 6), (3, 5)].into_iter().collect();
+      let expect_end_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 7), (3, 1)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -10361,8 +10361,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10418,8 +10417,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10475,8 +10473,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10532,8 +10529,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10589,8 +10585,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10698,7 +10693,6 @@ mod tests_search_anchor_horizontally_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10754,8 +10748,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10805,8 +10798,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10856,8 +10848,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10907,8 +10898,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -4848,6 +4848,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4904,6 +4905,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4954,6 +4956,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -10948,8 +10948,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10999,8 +10998,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11050,8 +11048,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11101,8 +11098,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11152,8 +11148,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -552,6 +552,7 @@ impl Viewport {
   /// Returns `start_line` and `start_column` for new viewport.
   pub fn search_anchor(
     &self,
+    opts: sync::ViewportSearchAnchorOptions,
     direction: ViewportSearchAnchorDirection,
     buffer: &Buffer,
     window_actual_shape: &U16Rect,
@@ -568,6 +569,7 @@ impl Viewport {
 
     match direction {
       ViewportSearchAnchorDirection::Down => sync::search_anchor_downward(
+        opts,
         self,
         buffer,
         window_actual_shape,
@@ -576,6 +578,7 @@ impl Viewport {
         target_cursor_char_idx,
       ),
       ViewportSearchAnchorDirection::Up => sync::search_anchor_upward(
+        opts,
         self,
         buffer,
         window_actual_shape,
@@ -584,6 +587,7 @@ impl Viewport {
         target_cursor_char_idx,
       ),
       ViewportSearchAnchorDirection::Left => sync::search_anchor_leftward(
+        opts,
         self,
         buffer,
         window_actual_shape,
@@ -592,6 +596,7 @@ impl Viewport {
         target_cursor_char_idx,
       ),
       ViewportSearchAnchorDirection::Right => sync::search_anchor_rightward(
+        opts,
         self,
         buffer,
         window_actual_shape,
@@ -704,6 +709,9 @@ mod tests_util {
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Tree;
   use crate::ui::tree::*;
+  use crate::ui::widget::window::viewport::sync::{
+    ViewportSearchAnchorOptions, ViewportSearchAnchorOptionsBuilder,
+  };
   use crate::ui::widget::window::{Window, WindowLocalOptions, WindowLocalOptionsBuilder};
 
   use compact_str::ToCompactString;
@@ -713,6 +721,19 @@ mod tests_util {
   use std::sync::Arc;
   use std::sync::Once;
   use tracing::info;
+
+  pub fn search_opts() -> ViewportSearchAnchorOptions {
+    ViewportSearchAnchorOptionsBuilder::default()
+      .build()
+      .unwrap()
+  }
+
+  pub fn search_opts_allow_line_end() -> ViewportSearchAnchorOptions {
+    ViewportSearchAnchorOptionsBuilder::default()
+      .allow_line_end(true)
+      .build()
+      .unwrap()
+  }
 
   pub fn make_nowrap() -> WindowLocalOptions {
     WindowLocalOptionsBuilder::default()
@@ -4014,6 +4035,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4076,6 +4098,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4126,6 +4149,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4176,6 +4200,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4289,6 +4314,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4345,6 +4371,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4395,6 +4422,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4445,6 +4473,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4495,6 +4524,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4545,6 +4575,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4658,6 +4689,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4714,6 +4746,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4764,6 +4797,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -12016,7 +12016,7 @@ mod tests_search_anchor_horizontally_nowrap_allow_line_end {
       let expect_start_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
       let expect_end_fills: BTreeMap<usize, usize> =
-        vec![(0, 0), (1, 0), (2, 0), (3, 2)].into_iter().collect();
+        vec![(0, 0), (1, 0), (2, 2), (3, 2)].into_iter().collect();
       assert_viewport(
         buf.clone(),
         &actual,

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -11198,8 +11198,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11249,8 +11248,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11300,8 +11298,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11351,8 +11348,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11402,8 +11398,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11453,8 +11448,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11504,8 +11498,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11555,8 +11548,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11606,8 +11598,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11657,8 +11648,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11708,8 +11698,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11759,8 +11748,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11810,8 +11798,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11861,8 +11848,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -11912,8 +11898,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12037,8 +12022,7 @@ mod tests_search_anchor_horizontally_nowrap_allow_line_end {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12170,7 +12154,6 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5,6 +5,7 @@ use crate::buf::Buffer;
 use crate::prelude::*;
 use crate::ui::widget::window::WindowLocalOptions;
 
+use derive_builder::Builder;
 use paste::paste;
 use std::collections::BTreeMap;
 use std::ops::Range;
@@ -512,6 +513,15 @@ pub enum ViewportSearchAnchorDirection {
   Right,
 }
 
+#[derive(Debug, Copy, Clone, Builder)]
+pub struct ViewportSearchAnchorOptions {
+  #[builder]
+  pub direction: ViewportSearchAnchorDirection,
+
+  #[builder(default = false)]
+  pub allow_line_end: bool,
+}
+
 impl Viewport {
   /// Calculate viewport downward, from top to bottom.
   ///
@@ -552,8 +562,7 @@ impl Viewport {
   /// Returns `start_line` and `start_column` for new viewport.
   pub fn search_anchor(
     &self,
-    opts: sync::ViewportSearchAnchorOptions,
-    direction: ViewportSearchAnchorDirection,
+    opts: ViewportSearchAnchorOptions,
     buffer: &Buffer,
     window_actual_shape: &U16Rect,
     window_local_options: &WindowLocalOptions,
@@ -567,7 +576,7 @@ impl Viewport {
       return (0, 0);
     }
 
-    match direction {
+    match opts.direction {
       ViewportSearchAnchorDirection::Down => sync::search_anchor_downward(
         opts,
         self,
@@ -709,9 +718,6 @@ mod tests_util {
   use crate::test::log::init as test_log_init;
   use crate::ui::tree::Tree;
   use crate::ui::tree::*;
-  use crate::ui::widget::window::viewport::sync::{
-    ViewportSearchAnchorOptions, ViewportSearchAnchorOptionsBuilder,
-  };
   use crate::ui::widget::window::{Window, WindowLocalOptions, WindowLocalOptionsBuilder};
 
   use compact_str::ToCompactString;
@@ -722,17 +728,14 @@ mod tests_util {
   use std::sync::Once;
   use tracing::info;
 
-  pub fn search_opts() -> ViewportSearchAnchorOptions {
-    ViewportSearchAnchorOptionsBuilder::default()
-      .build()
-      .unwrap()
+  pub fn search_down() -> ViewportSearchAnchorOptions {
+    ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Down).build().unwrap()
   }
 
-  pub fn search_opts_allow_line_end() -> ViewportSearchAnchorOptions {
+  pub fn search_down_allow_line_end() -> ViewportSearchAnchorOptions {
     ViewportSearchAnchorOptionsBuilder::default()
       .allow_line_end(true)
-      .build()
-      .unwrap()
+      .direction(ViewportSearchAnchorDirection::Down).build().unwrap()
   }
 
   pub fn make_nowrap() -> WindowLocalOptions {
@@ -4035,8 +4038,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4098,8 +4100,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4149,8 +4150,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4200,8 +4200,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4314,8 +4313,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4371,8 +4369,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4422,8 +4419,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4473,8 +4469,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4524,8 +4519,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4575,8 +4569,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -4689,7 +4682,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4746,7 +4739,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4797,7 +4790,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4848,7 +4841,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4905,7 +4898,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -4956,7 +4949,7 @@ mod tests_search_anchor_downward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5084,7 +5077,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5143,7 +5136,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5191,7 +5184,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5244,7 +5237,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5297,7 +5290,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5344,7 +5337,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5452,7 +5445,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5513,7 +5506,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5561,7 +5554,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5614,7 +5607,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5667,7 +5660,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5714,7 +5707,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5812,7 +5805,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5865,7 +5858,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5995,7 +5988,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6048,7 +6041,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6096,7 +6089,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6149,7 +6142,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6196,7 +6189,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6243,7 +6236,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6351,7 +6344,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6406,7 +6399,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6454,7 +6447,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6507,7 +6500,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6560,7 +6553,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6607,7 +6600,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6705,7 +6698,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6758,7 +6751,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6812,7 +6805,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6859,7 +6852,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6906,7 +6899,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -7026,7 +7019,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -7083,7 +7076,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7134,7 +7127,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7185,7 +7178,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7236,7 +7229,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7293,7 +7286,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7350,7 +7343,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7407,7 +7400,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7515,7 +7508,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -7572,7 +7565,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7623,7 +7616,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7674,7 +7667,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7725,7 +7718,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7782,7 +7775,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7839,7 +7832,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -7896,7 +7889,7 @@ mod tests_search_anchor_upward_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8018,7 +8011,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -8077,7 +8070,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8130,7 +8123,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8178,7 +8171,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8231,7 +8224,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8284,7 +8277,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8337,7 +8330,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8390,7 +8383,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8494,7 +8487,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -8547,7 +8540,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8600,7 +8593,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8647,7 +8640,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8694,7 +8687,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8747,7 +8740,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8800,7 +8793,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8853,7 +8846,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -8973,7 +8966,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -9032,7 +9025,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9085,7 +9078,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9133,7 +9126,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9180,7 +9173,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9233,7 +9226,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9286,7 +9279,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9339,7 +9332,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9443,7 +9436,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -9496,7 +9489,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9549,7 +9542,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9596,7 +9589,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9643,7 +9636,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9696,7 +9689,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9749,7 +9742,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9802,7 +9795,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Up,
           &buf,
           window.actual_shape(),
@@ -9930,7 +9923,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -9993,7 +9986,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10050,7 +10043,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10107,7 +10100,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10164,7 +10157,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10222,7 +10215,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10279,7 +10272,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -10336,7 +10329,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10393,7 +10386,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10450,7 +10443,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10507,7 +10500,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10564,7 +10557,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10621,7 +10614,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10678,7 +10671,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10786,7 +10779,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -10843,7 +10836,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10894,7 +10887,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10945,7 +10938,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -10996,7 +10989,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11047,7 +11040,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11098,7 +11091,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11149,7 +11142,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11200,7 +11193,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11251,7 +11244,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11302,7 +11295,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11353,7 +11346,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -11404,7 +11397,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11455,7 +11448,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11506,7 +11499,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11557,7 +11550,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11608,7 +11601,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11659,7 +11652,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11710,7 +11703,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11761,7 +11754,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11812,7 +11805,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11863,7 +11856,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11914,7 +11907,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -11965,7 +11958,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12016,7 +12009,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12141,7 +12134,7 @@ mod tests_search_anchor_horizontally_nowrap_allow_line_end {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_opts(),
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12273,6 +12266,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -12331,6 +12325,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12389,6 +12384,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12441,6 +12437,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12493,6 +12490,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12545,6 +12543,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12597,6 +12596,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12649,6 +12649,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12701,6 +12702,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Right,
           &buf,
           window.actual_shape(),
@@ -12753,6 +12755,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -12805,6 +12808,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down(),
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),
@@ -17010,6 +17014,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_down()
           ViewportSearchAnchorDirection::Left,
           &buf,
           window.actual_shape(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -729,25 +729,39 @@ mod tests_util {
   use tracing::info;
 
   pub fn search_down() -> ViewportSearchAnchorOptions {
-    ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Down).build().unwrap()
+    ViewportSearchAnchorOptionsBuilder::default()
+      .direction(ViewportSearchAnchorDirection::Down)
+      .build()
+      .unwrap()
   }
 
   pub fn search_up() -> ViewportSearchAnchorOptions {
-    ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Up).build().unwrap()
+    ViewportSearchAnchorOptionsBuilder::default()
+      .direction(ViewportSearchAnchorDirection::Up)
+      .build()
+      .unwrap()
   }
 
   pub fn search_left() -> ViewportSearchAnchorOptions {
-    ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Left).build().unwrap()
+    ViewportSearchAnchorOptionsBuilder::default()
+      .direction(ViewportSearchAnchorDirection::Left)
+      .build()
+      .unwrap()
   }
 
   pub fn search_right() -> ViewportSearchAnchorOptions {
-    ViewportSearchAnchorOptionsBuilder::default().direction(ViewportSearchAnchorDirection::Right).build().unwrap()
+    ViewportSearchAnchorOptionsBuilder::default()
+      .direction(ViewportSearchAnchorDirection::Right)
+      .build()
+      .unwrap()
   }
 
   pub fn search_left_allow_line_end() -> ViewportSearchAnchorOptions {
     ViewportSearchAnchorOptionsBuilder::default()
       .allow_line_end(true)
-      .direction(ViewportSearchAnchorDirection::Down).build().unwrap()
+      .direction(ViewportSearchAnchorDirection::Down)
+      .build()
+      .unwrap()
   }
 
   pub fn make_nowrap() -> WindowLocalOptions {
@@ -12211,8 +12225,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12270,8 +12283,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12323,8 +12335,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12376,8 +12387,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12429,8 +12439,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12482,8 +12491,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12535,8 +12543,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12588,8 +12595,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12641,8 +12647,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12694,8 +12699,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12747,7 +12751,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12799,7 +12803,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12851,7 +12855,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12903,7 +12907,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -12955,7 +12959,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13007,7 +13011,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13108,7 +13112,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Down,
+          search_down(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13680,7 +13684,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -13732,7 +13736,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16900,8 +16904,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down()
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5084,6 +5084,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5142,6 +5143,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5189,6 +5191,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5241,6 +5244,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5293,6 +5297,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5339,6 +5344,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5446,6 +5452,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5506,6 +5513,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5553,6 +5561,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5605,6 +5614,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5657,6 +5667,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5703,6 +5714,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5800,6 +5812,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5852,6 +5865,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -5981,6 +5995,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6033,6 +6048,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6080,6 +6096,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6132,6 +6149,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
@@ -6178,6 +6196,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
+          search_opts(),
           ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -8127,8 +8127,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8180,8 +8179,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8233,8 +8231,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8286,8 +8283,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8339,8 +8335,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8444,7 +8439,6 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8496,8 +8490,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8549,8 +8542,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8596,8 +8588,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -8634,8 +8634,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8687,8 +8686,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8740,8 +8738,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8793,8 +8790,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8914,7 +8910,6 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -8972,8 +8967,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9025,8 +9019,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9073,8 +9066,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9120,8 +9112,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9173,8 +9164,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9226,8 +9216,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9279,8 +9268,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9384,7 +9372,6 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9436,8 +9423,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9489,8 +9475,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9536,8 +9521,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9583,8 +9567,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9636,8 +9619,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9689,8 +9671,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9742,8 +9723,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Up,
+          search_up(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9871,7 +9851,6 @@ mod tests_search_anchor_horizontally_nowrap {
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
           search_down(),
-          ViewportSearchAnchorDirection::Down,
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9933,8 +9912,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -9990,8 +9968,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10047,8 +10024,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10104,8 +10080,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10162,8 +10137,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10219,8 +10193,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10276,8 +10249,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -10333,8 +10305,7 @@ mod tests_search_anchor_horizontally_nowrap {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          search_down(),
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -15952,7 +15952,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16008,7 +16008,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16064,7 +16064,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16120,7 +16120,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16176,7 +16176,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16232,7 +16232,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16288,7 +16288,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16344,7 +16344,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16400,7 +16400,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16456,7 +16456,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16512,7 +16512,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Right,
+          search_right(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16568,7 +16568,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16624,7 +16624,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16680,7 +16680,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16736,7 +16736,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),
@@ -16792,7 +16792,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
         let old = lock!(window.viewport()).clone();
         let buf = lock!(buf);
         let (start_line, start_column) = old.search_anchor(
-          ViewportSearchAnchorDirection::Left,
+          search_left(),
           &buf,
           window.actual_shape(),
           window.options(),

--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -4961,6 +4961,297 @@ mod tests_search_anchor_downward_nowrap {
 }
 #[allow(unused_imports)]
 #[cfg(test)]
+mod tests_search_anchor_downward_nowrap_allow_line_end {
+  use super::tests_util::*;
+  use super::*;
+
+  use crate::buf::BufferLocalOptionsBuilder;
+  use crate::lock;
+  use crate::prelude::*;
+  use crate::test::buf::{make_buffer_from_lines, make_empty_buffer};
+  use crate::test::log::init as test_log_init;
+  use crate::ui::tree::Inodeable;
+
+  use std::cell::RefCell;
+  use std::rc::Rc;
+
+  #[test]
+  fn new1() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(17, 5);
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let win_opts = make_nowrap();
+
+    let buf = make_buffer_from_lines(
+      terminal_size.height(),
+      buf_opts,
+      vec![
+        "Hello, RSVIM!\n",
+        "This is a quite simple and small test lines.\n",
+        "But still it contains several things we want to test:\n",
+        "\t1. When\tthe\tline\tis\tsmall\tenough\tto\tcompletely\tput\tinside.\n",
+        "\t2. When\tit\t\ttoo\tlong\tto\tcompletely\tput:\n",
+        "\t\t3. The extra parts are been truncated if\tboth\tline-wrap\tand\tword-wrap\toptions\tare\tnot\tset.\n",
+        "\t\t4. The extra parts are split into the\tnext\trow,\tif\teither\tline-wrap\tor\tword-wrap\toptions\tare\tbeen\tset. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      ],
+    );
+
+    let window = Rc::new(RefCell::new(make_window(
+      terminal_size,
+      buf.clone(),
+      &win_opts,
+    )));
+
+    // Initialize
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+      ];
+
+      let actual = lock!(window.borrow().viewport()).clone();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-1
+    {
+      let expect = vec![
+        "Hello, RSVIM!\n",
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+      ];
+
+      let actual = {
+        let target_cursor_line = 2;
+        let target_cursor_char = 15;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 0);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_cursor_viewport(CursorViewport::to_arc(CursorViewport::from_position(
+          &viewport,
+          &buf,
+          target_cursor_line,
+          target_cursor_char,
+        )));
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0), (2, 0), (3, 2), (4, 2)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        0,
+        5,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-2
+    {
+      let expect = vec![
+        "This is a quite s",
+        "But still it cont",
+        "\t1. When",
+        "\t2. When",
+        "\t\t3",
+      ];
+
+      let actual = {
+        let target_cursor_line = 5;
+        let target_cursor_char = 1;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 1);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(1, 0), (2, 0), (3, 2), (4, 2), (5, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        1,
+        6,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-3
+    {
+      let expect = vec!["ut still it conta", "1. When", "2. When", "\t3.", "\t4."];
+
+      let actual = {
+        let target_cursor_line = 6;
+        let target_cursor_char = 3;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 2);
+        assert_eq!(start_column, 1);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 7), (4, 7), (5, 7), (6, 7)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 3), (4, 3), (5, 0), (6, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        2,
+        7,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+
+    // Search-4
+    {
+      let expect = vec!["\t1. When", "\t2. When", "\t\t3", "\t\t4", ""];
+
+      let actual = {
+        let target_cursor_line = 7;
+        let target_cursor_char = 3;
+
+        let mut window = window.borrow_mut();
+        let old = lock!(window.viewport()).clone();
+        let buf = lock!(buf);
+        let (start_line, start_column) = old.search_anchor(
+          ViewportSearchAnchorDirection::Down,
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          target_cursor_line,
+          target_cursor_char,
+        );
+        assert_eq!(start_line, 3);
+        assert_eq!(start_column, 0);
+
+        let viewport = Viewport::view(
+          &buf,
+          window.actual_shape(),
+          window.options(),
+          start_line,
+          start_column,
+        );
+        window.set_viewport(Viewport::to_arc(viewport));
+        lock!(window.viewport()).clone()
+      };
+
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      let expect_end_fills: BTreeMap<usize, usize> = vec![(3, 2), (4, 2), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport(
+        buf.clone(),
+        &actual,
+        &expect,
+        3,
+        8,
+        &expect_start_fills,
+        &expect_end_fills,
+      );
+    }
+  }
+}
+#[allow(unused_imports)]
+#[cfg(test)]
 mod tests_search_anchor_downward_wrap_nolinebreak {
   use super::tests_util::*;
   use super::*;

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -561,6 +561,14 @@ fn proc_line_wrap_linebreak(
   }
 }
 
+fn _last_x_char_on_line(allow_line_end: bool, buffer: &Buffer, line_idx: usize) -> Option<usize> {
+  if allow_line_end {
+    buffer.last_char_on_line(line_idx)
+  } else {
+    buffer.last_visible_char_on_line(line_idx)
+  }
+}
+
 /// Implements [`sync`] with option `wrap=true` and `line-break=true`.
 fn sync_wrap_linebreak(
   buffer: &Buffer,
@@ -1805,9 +1813,7 @@ fn search_anchor_rightward_nowrap(
   let target_cursor_line = std::cmp::min(target_cursor_line, buffer_len_lines.saturating_sub(1));
   let target_cursor_char = std::cmp::min(
     target_cursor_char,
-    buffer
-      .last_visible_char_on_line(target_cursor_line)
-      .unwrap_or(0_usize),
+    _last_x_char_on_line(opts.allow_line_end, buffer, target_cursor_line).unwrap_or(0_usize),
   );
 
   // adjust horizontally

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1208,11 +1208,18 @@ fn _adjust_current_line(
   }
 }
 
+#[derive(Debug, Copy, Clone, Builder)]
+pub struct ViewportSearchAnchorOptions {
+  #[builder(default = false)]
+  pub allow_line_end: bool,
+}
+
 // Search a new viewport anchor (`start_line`, `start_column`) downward, i.e. when cursor moves
 // down, and possibly scrolling buffer if cursor reaches the window bottom.
 //
 // Returns `start_line`, `start_column` for the new viewport.
 pub fn search_anchor_downward(
+  opts: ViewportSearchAnchorOptions,
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1225,6 +1232,7 @@ pub fn search_anchor_downward(
     window_local_options.line_break(),
   ) {
     (false, _) => search_anchor_downward_nowrap(
+      opts,
       viewport,
       buffer,
       window_actual_shape,
@@ -1232,6 +1240,7 @@ pub fn search_anchor_downward(
       target_cursor_char,
     ),
     (true, false) => search_anchor_downward_wrap(
+      opts,
       proc_line_wrap_nolinebreak,
       viewport,
       buffer,
@@ -1240,6 +1249,7 @@ pub fn search_anchor_downward(
       target_cursor_char,
     ),
     (true, true) => search_anchor_downward_wrap(
+      opts,
       proc_line_wrap_linebreak,
       viewport,
       buffer,
@@ -1251,6 +1261,7 @@ pub fn search_anchor_downward(
 }
 
 fn search_anchor_downward_nowrap(
+  opts: ViewportSearchAnchorOptions,
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1308,7 +1319,10 @@ fn search_anchor_downward_nowrap(
   };
 
   _adjust_horizontally_nowrap(
-    AdjustHorizontallyOptionsBuilder::default().build().unwrap(),
+    AdjustHorizontallyOptionsBuilder::default()
+      .allow_line_end(opts.allow_line_end)
+      .build()
+      .unwrap(),
     buffer,
     window_actual_shape,
     target_cursor_line,
@@ -1319,6 +1333,7 @@ fn search_anchor_downward_nowrap(
 }
 
 fn search_anchor_downward_wrap(
+  opts: ViewportSearchAnchorOptions,
   proc: ProcessLineFn,
   viewport: &Viewport,
   buffer: &Buffer,
@@ -1405,7 +1420,10 @@ fn search_anchor_downward_wrap(
     };
 
   _adjust_horizontally_wrap(
-    AdjustHorizontallyOptionsBuilder::default().build().unwrap(),
+    AdjustHorizontallyOptionsBuilder::default()
+      .allow_line_end(opts.allow_line_end)
+      .build()
+      .unwrap(),
     proc,
     buffer,
     window_actual_shape,
@@ -1422,6 +1440,7 @@ fn search_anchor_downward_wrap(
 //
 // Returns `start_line`, `start_column` for the new viewport.
 pub fn search_anchor_upward(
+  opts: ViewportSearchAnchorOptions,
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1434,6 +1453,7 @@ pub fn search_anchor_upward(
     window_local_options.line_break(),
   ) {
     (false, _) => search_anchor_upward_nowrap(
+      opts,
       viewport,
       buffer,
       window_actual_shape,
@@ -1441,6 +1461,7 @@ pub fn search_anchor_upward(
       target_cursor_char,
     ),
     (true, false) => search_anchor_upward_wrap(
+      opts,
       proc_line_wrap_nolinebreak,
       viewport,
       buffer,
@@ -1449,6 +1470,7 @@ pub fn search_anchor_upward(
       target_cursor_char,
     ),
     (true, true) => search_anchor_upward_wrap(
+      opts,
       proc_line_wrap_linebreak,
       viewport,
       buffer,
@@ -1460,6 +1482,7 @@ pub fn search_anchor_upward(
 }
 
 fn search_anchor_upward_nowrap(
+  opts: ViewportSearchAnchorOptions,
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1493,7 +1516,10 @@ fn search_anchor_upward_nowrap(
   };
 
   _adjust_horizontally_nowrap(
-    AdjustHorizontallyOptionsBuilder::default().build().unwrap(),
+    AdjustHorizontallyOptionsBuilder::default()
+      .allow_line_end(opts.allow_line_end)
+      .build()
+      .unwrap(),
     buffer,
     window_actual_shape,
     target_cursor_line,
@@ -1504,6 +1530,7 @@ fn search_anchor_upward_nowrap(
 }
 
 fn search_anchor_upward_wrap(
+  opts: ViewportSearchAnchorOptions,
   proc: ProcessLineFn,
   viewport: &Viewport,
   buffer: &Buffer,
@@ -1559,7 +1586,10 @@ fn search_anchor_upward_wrap(
     };
 
   _adjust_horizontally_wrap(
-    AdjustHorizontallyOptionsBuilder::default().build().unwrap(),
+    AdjustHorizontallyOptionsBuilder::default()
+      .allow_line_end(opts.allow_line_end)
+      .build()
+      .unwrap(),
     proc,
     buffer,
     window_actual_shape,
@@ -1576,6 +1606,7 @@ fn search_anchor_upward_wrap(
 //
 // Returns `start_line`, `start_column` for the new viewport.
 pub fn search_anchor_leftward(
+  opts: ViewportSearchAnchorOptions,
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1588,6 +1619,7 @@ pub fn search_anchor_leftward(
     window_local_options.line_break(),
   ) {
     (false, _) => search_anchor_leftward_nowrap(
+      opts,
       viewport,
       buffer,
       window_actual_shape,
@@ -1595,6 +1627,7 @@ pub fn search_anchor_leftward(
       target_cursor_char,
     ),
     (true, false) => search_anchor_leftward_wrap(
+      opts,
       proc_line_wrap_nolinebreak,
       viewport,
       buffer,
@@ -1603,6 +1636,7 @@ pub fn search_anchor_leftward(
       target_cursor_char,
     ),
     (true, true) => search_anchor_leftward_wrap(
+      opts,
       proc_line_wrap_linebreak,
       viewport,
       buffer,
@@ -1614,6 +1648,7 @@ pub fn search_anchor_leftward(
 }
 
 fn search_anchor_leftward_nowrap(
+  opts: ViewportSearchAnchorOptions,
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1636,6 +1671,7 @@ fn search_anchor_leftward_nowrap(
 
   _adjust_horizontally_nowrap(
     AdjustHorizontallyOptionsBuilder::default()
+      .allow_line_end(opts.allow_line_end)
       .disable_detect_rightward(true)
       .build()
       .unwrap(),
@@ -1649,6 +1685,7 @@ fn search_anchor_leftward_nowrap(
 }
 
 fn search_anchor_leftward_wrap(
+  opts: ViewportSearchAnchorOptions,
   proc: ProcessLineFn,
   viewport: &Viewport,
   buffer: &Buffer,
@@ -1700,6 +1737,7 @@ fn search_anchor_leftward_wrap(
 
   _adjust_horizontally_wrap(
     AdjustHorizontallyOptionsBuilder::default()
+      .allow_line_end(opts.allow_line_end)
       .disable_detect_rightward(true)
       .build()
       .unwrap(),
@@ -1719,6 +1757,7 @@ fn search_anchor_leftward_wrap(
 //
 // Returns `start_line`, `start_column` for the new viewport.
 pub fn search_anchor_rightward(
+  opts: ViewportSearchAnchorOptions,
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1731,6 +1770,7 @@ pub fn search_anchor_rightward(
     window_local_options.line_break(),
   ) {
     (false, _) => search_anchor_rightward_nowrap(
+      opts,
       viewport,
       buffer,
       window_actual_shape,
@@ -1738,6 +1778,7 @@ pub fn search_anchor_rightward(
       target_cursor_char,
     ),
     (true, false) => search_anchor_rightward_wrap(
+      opts,
       proc_line_wrap_nolinebreak,
       viewport,
       buffer,
@@ -1746,6 +1787,7 @@ pub fn search_anchor_rightward(
       target_cursor_char,
     ),
     (true, true) => search_anchor_rightward_wrap(
+      opts,
       proc_line_wrap_linebreak,
       viewport,
       buffer,
@@ -1757,6 +1799,7 @@ pub fn search_anchor_rightward(
 }
 
 fn search_anchor_rightward_nowrap(
+  opts: ViewportSearchAnchorOptions,
   viewport: &Viewport,
   buffer: &Buffer,
   window_actual_shape: &U16Rect,
@@ -1779,6 +1822,7 @@ fn search_anchor_rightward_nowrap(
 
   _adjust_horizontally_nowrap(
     AdjustHorizontallyOptionsBuilder::default()
+      .allow_line_end(opts.allow_line_end)
       .disable_detect_leftward(true)
       .build()
       .unwrap(),
@@ -1792,6 +1836,7 @@ fn search_anchor_rightward_nowrap(
 }
 
 fn search_anchor_rightward_wrap(
+  opts: ViewportSearchAnchorOptions,
   proc: ProcessLineFn,
   viewport: &Viewport,
   buffer: &Buffer,
@@ -1844,6 +1889,7 @@ fn search_anchor_rightward_wrap(
   // adjust horizontally
   _adjust_horizontally_wrap(
     AdjustHorizontallyOptionsBuilder::default()
+      .allow_line_end(opts.allow_line_end)
       .disable_detect_leftward(true)
       .build()
       .unwrap(),

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -15,7 +15,7 @@ use std::ops::Range;
 use tracing::trace;
 use unicode_segmentation::UnicodeSegmentation;
 
-use super::Viewport;
+use super::{Viewport, ViewportSearchAnchorOptions};
 
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 /// Lines index inside the viewport.
@@ -1206,12 +1206,6 @@ fn _adjust_current_line(
   } else {
     current_line as usize
   }
-}
-
-#[derive(Debug, Copy, Clone, Builder)]
-pub struct ViewportSearchAnchorOptions {
-  #[builder(default = false)]
-  pub allow_line_end: bool,
 }
 
 // Search a new viewport anchor (`start_line`, `start_column`) downward, i.e. when cursor moves


### PR DESCRIPTION
Close #394 .

In normal mode cursor is not allowed to move onto end of line, while in insert mode it is allowed.