### PR TITLE
fix(viewport): refactor wrap line anchor searching algorithms and fixes edge cases

### DIFF
--- a/rsvim_core/src/ui/widget/window/viewport.rs
+++ b/rsvim_core/src/ui/widget/window/viewport.rs
@@ -5805,7 +5805,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
 
     // Search-2
     {
-      let expect = vec!["\ttoo", "\tlong", "\tto", "\tcompletel", "y\tput:\n"];
+      let expect = vec!["t\t\t", "too\tlong", "\tto", "\tcompletel", "y\tput:\n"];
 
       let actual = {
         let target_cursor_line = 2;
@@ -5823,7 +5823,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 2);
-        assert_eq!(start_column, 29);
+        assert_eq!(start_column, 24);
 
         let viewport = Viewport::view(
           &buf,
@@ -5842,7 +5842,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 4)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 0)].into_iter().collect();
       let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0)].into_iter().collect();
       assert_viewport(
         buf.clone(),
@@ -6684,7 +6684,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
 
     // Search-2
     {
-      let expect = vec!["too\tlong", "\tto", "\t", "completely", "\tput:\n"];
+      let expect = vec!["too\t", "long\tto", "\t", "completely", "\tput:\n"];
 
       let actual = {
         let target_cursor_line = 2;
@@ -6702,7 +6702,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 2);
-        assert_eq!(start_column, 39);
+        assert_eq!(start_column, 35);
 
         let viewport = Viewport::view(
           &buf,
@@ -6715,7 +6715,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 2)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(2, 6)].into_iter().collect();
       let expect_end_fills: BTreeMap<usize, usize> = vec![(2, 0)].into_iter().collect();
       info!("actual:{:?}", actual);
       assert_viewport(
@@ -6732,11 +6732,12 @@ mod tests_search_anchor_downward_wrap_linebreak {
     // Search-3
     {
       let expect = vec![
-        "been truncated if",
+        "are been ",
+        "truncated if",
         "\tboth",
         "\tline-wrap",
         "\tand",
-        "\tword-wrap",
+        // "\tword-wrap",
       ];
 
       let actual = {
@@ -6755,7 +6756,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 3);
-        assert_eq!(start_column, 39);
+        assert_eq!(start_column, 35);
 
         let viewport = Viewport::view(
           &buf,
@@ -6783,7 +6784,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
 
     // Search-4
     {
-      let expect = vec!["split into the", "\tnext", "\trow,", "\tif", "\teither"];
+      let expect = vec!["are split into ", "the\tnext", "\trow,", "\tif", "\teither"];
 
       let actual = {
         let target_cursor_line = 4;
@@ -6801,7 +6802,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 4);
-        assert_eq!(start_column, 39);
+        assert_eq!(start_column, 35);
 
         let viewport = Viewport::view(
           &buf,
@@ -8034,7 +8035,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
 
     // Search-2
     {
-      let expect = vec!["d\tword-wra", "p\toptions", "\tare", "\tnot", "\tset.\n"];
+      let expect = vec!["and\t", "word-wrap\t", "options\tar", "e\tnot", "\tset.\n"];
 
       let actual = {
         let target_cursor_line = 5;
@@ -8052,7 +8053,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 5);
-        assert_eq!(start_column, 95);
+        assert_eq!(start_column, 87);
 
         let viewport = Viewport::view(
           &buf,
@@ -8065,7 +8066,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(5, 6)].into_iter().collect();
       let expect_end_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
       info!("actual:{:?}", actual);
       assert_viewport(
@@ -8973,7 +8974,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
 
     // Search-2
     {
-      let expect = vec!["d\tword-", "wrap\t", "options\t", "are\tnot", "\tset.\n"];
+      let expect = vec!["and\t", "word-wrap\t", "options\t", "are\tnot", "\tset.\n"];
 
       let actual = {
         let target_cursor_line = 5;
@@ -8991,7 +8992,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
           target_cursor_char,
         );
         assert_eq!(start_line, 5);
-        assert_eq!(start_column, 95);
+        assert_eq!(start_column, 87);
 
         let viewport = Viewport::view(
           &buf,
@@ -9004,7 +9005,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
         lock!(window.viewport()).clone()
       };
 
-      let expect_start_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      let expect_start_fills: BTreeMap<usize, usize> = vec![(5, 6)].into_iter().collect();
       let expect_end_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
       info!("actual:{:?}", actual);
       assert_viewport(

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1340,7 +1340,23 @@ fn search_anchor_downward_wrap(
   );
 
   debug_assert!(viewport.lines().last_key_value().is_some());
-  let (&last_line, _last_line_viewport) = viewport.lines().last_key_value().unwrap();
+  let (&last_line, last_line_viewport) = viewport.lines().last_key_value().unwrap();
+
+  // NOTE: Split the algorithm into below use cases:
+  // 1. The viewport cannot fully contain the target cursor line, i.e. the line is too long and
+  //    have to be truncated to place in the viewport.
+  // 2. The viewport can contain the target cursor line, i.e. the line is not too long. And future
+  //    we can split this into below sub cases:
+  //    2.1 The viewport only contains the target cursor line. And we have a very specific edge
+  //      case when considering the empty eol:
+  //        a) The last visible char of target cursor line is at the bottom-right corner of the
+  //        viewport, and thus the empty eol is actually out of viewport.
+  //        b) Otherwise the empty eol of target cursor line is not out of viewport.
+  //    2.2 The viewport not only contains the target cursor line, i.e. it contains at least 2
+  //      lines. And we have a very specific edge case for empty eol:
+  //        a) The target cursor line is the last line in viewport, and its last visible char is at
+  //        the bottom-right corner, and thus the empty eol is out of viewport.
+  //        b) Otherwise the empty eol of target cursor line is not out of viewport.
 
   // NOTE: For `wrap=true`, if a line's head/tail not fully rendered, it means there will be only 1
   // line shows in current window viewport. Because the `wrap` will force the 2nd line wait to show

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -2554,7 +2554,7 @@ fn search_anchor_rightward_wrap(
     let start_line = target_cursor_line;
     let start_column = viewport_start_column;
     wrap_detail::adjust_wrap_1(
-      detail::AdjustOptions::no_rightward(),
+      detail::AdjustOptions::no_leftward(),
       proc,
       buffer,
       window_actual_shape,
@@ -2571,7 +2571,7 @@ fn search_anchor_rightward_wrap(
     let start_line = target_cursor_line;
     let start_column = 0_usize;
     wrap_detail::adjust_wrap_2_1(
-      detail::AdjustOptions::no_rightward(),
+      detail::AdjustOptions::no_leftward(),
       proc,
       buffer,
       window_actual_shape,
@@ -2589,7 +2589,7 @@ fn search_anchor_rightward_wrap(
     let start_line = viewport_start_line;
     let start_column = 0_usize;
     wrap_detail::adjust_wrap_2_2(
-      detail::AdjustOptions::no_rightward(),
+      detail::AdjustOptions::no_leftward(),
       proc,
       buffer,
       window_actual_shape,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -609,6 +609,26 @@ fn sync_wrap_linebreak(
   }
 }
 
+fn _target_is_empty_eol(
+  buffer: &Buffer,
+  target_cursor_line: usize,
+  target_cursor_char: usize,
+) -> bool {
+  match buffer.get_rope().get_line(target_cursor_line) {
+    Some(bufline) => {
+      if target_cursor_char != bufline.len_chars().saturating_sub(1) {
+        false
+      } else {
+        match bufline.get_char(target_cursor_char) {
+          Some(c) => buffer.char_width(c) == 0,
+          None => false,
+        }
+      }
+    }
+    None => false,
+  }
+}
+
 // spellchecker:off
 // When searching the new viewport downward, the target cursor could be not shown in it.
 //

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1146,8 +1146,8 @@ mod wrap_detail {
     target_cursor_line: usize,
     target_cursor_char: usize,
   ) -> Option<usize> {
+    let target_cursor_width = buffer.width_before(target_cursor_line, target_cursor_char);
     if cfg!(debug_assertions) {
-      let target_cursor_width = buffer.width_before(target_cursor_line, target_cursor_char);
       match buffer.char_at(target_cursor_line, target_viewport_start_column) {
         Some(target_viewport_start_char) => trace!(
           "target_cursor_line:{},target_cursor_char:{}({:?}),target_cursor_width:{},viewport_start_column:{},viewport_start_char:{}({:?})",
@@ -1182,7 +1182,9 @@ mod wrap_detail {
       }
     }
 
+    let on_left_side = target_cursor_width < target_viewport_start_column;
     debug_assert_eq!(target_viewport_start_column, 0_usize);
+    debug_assert!(!on_left_side);
     None
   }
 
@@ -1213,18 +1215,8 @@ mod wrap_detail {
     debug_assert!(last_row_viewport.end_char_idx() > last_row_viewport.start_char_idx());
     let on_right_side = target_cursor_char >= last_row_viewport.end_char_idx();
 
-    if on_right_side {
-      let start_column = reverse_search_start_column(
-        proc,
-        buffer,
-        window_actual_shape,
-        target_cursor_line,
-        target_cursor_char,
-      );
-      Some(start_column)
-    } else {
-      None
-    }
+    debug_assert!(!on_right_side);
+    None
   }
 
   // For case-2.1

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -1152,8 +1152,8 @@ mod wrap_detail {
     debug_assert!(preview_target_rows.last_key_value().is_some());
     let (_last_row_idx, last_row_viewport) = preview_target_rows.last_key_value().unwrap();
 
-    debug_assert!(last_row_viewport.end_char_idx() > last_row_viewport.start_char_idx());
-    let on_right_side = target_cursor_char >= last_row_viewport.end_char_idx();
+    let on_right_side = last_row_viewport.end_char_idx() > last_row_viewport.start_char_idx()
+      && target_cursor_char >= last_row_viewport.end_char_idx();
 
     if on_right_side {
       let start_column = reverse_search_start_column(
@@ -1317,8 +1317,8 @@ mod wrap_detail {
     debug_assert!(preview_target_rows.last_key_value().is_some());
     let (_last_row_idx, last_row_viewport) = preview_target_rows.last_key_value().unwrap();
 
-    debug_assert!(last_row_viewport.end_char_idx() > last_row_viewport.start_char_idx());
-    let on_right_side = target_cursor_char >= last_row_viewport.end_char_idx();
+    let on_right_side = last_row_viewport.end_char_idx() > last_row_viewport.start_char_idx()
+      && target_cursor_char >= last_row_viewport.end_char_idx();
 
     debug_assert!(!on_right_side);
     None
@@ -1473,8 +1473,8 @@ mod wrap_detail {
     debug_assert!(preview_target_rows.last_key_value().is_some());
     let (_last_row_idx, last_row_viewport) = preview_target_rows.last_key_value().unwrap();
 
-    debug_assert!(last_row_viewport.end_char_idx() > last_row_viewport.start_char_idx());
-    let on_right_side = target_cursor_char >= last_row_viewport.end_char_idx();
+    let on_right_side = last_row_viewport.end_char_idx() > last_row_viewport.start_char_idx()
+      && target_cursor_char >= last_row_viewport.end_char_idx();
 
     debug_assert!(!on_right_side);
     None

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -2495,46 +2495,6 @@ fn search_anchor_rightward_wrap(
       .unwrap_or(0_usize),
   );
 
-  // debug_assert!(viewport.lines().first_key_value().is_some());
-  // let (&first_line, _first_line_viewport) = viewport.lines().first_key_value().unwrap();
-  //
-  // let target_cursor_line_not_fully_show = _line_head_not_show(viewport, target_cursor_line)
-  //   || _line_tail_not_show(viewport, buffer, target_cursor_line);
-  //
-  // let (start_column, cannot_fully_contains_target_cursor_line) =
-  //   if target_cursor_line >= first_line && !target_cursor_line_not_fully_show {
-  //     (viewport_start_column, false)
-  //   } else {
-  //     let (target_cursor_rows, _target_cursor_start_fills, _target_cursor_end_fills, _) = proc(
-  //       buffer,
-  //       0,
-  //       target_cursor_line,
-  //       0_u16,
-  //       height.saturating_add(10),
-  //       width,
-  //     );
-  //     let cannot_fully_contains_target_cursor_line = target_cursor_rows.len() > height as usize;
-  //     let start_column = if !cannot_fully_contains_target_cursor_line {
-  //       0_usize
-  //     } else {
-  //       viewport_start_column
-  //     };
-  //
-  //     (start_column, cannot_fully_contains_target_cursor_line)
-  //   };
-  //
-  // wrap_detail::adjust_wrap(
-  //   detail::AdjustOptions::no_leftward(),
-  //   proc,
-  //   buffer,
-  //   window_actual_shape,
-  //   cannot_fully_contains_target_cursor_line,
-  //   target_cursor_line,
-  //   target_cursor_char,
-  //   viewport_start_line,
-  //   start_column,
-  // )
-
   let (preview_target_rows, _preview_target_start_fills, _preview_target_end_fills, _) = proc(
     buffer,
     0,

--- a/rsvim_core/src/ui/widget/window/viewport/sync.rs
+++ b/rsvim_core/src/ui/widget/window/viewport/sync.rs
@@ -2056,7 +2056,7 @@ fn search_anchor_upward_wrap(
   target_cursor_line: usize,
   target_cursor_char: usize,
 ) -> (usize, usize) {
-  let viewport_start_line = viewport.start_line_idx();
+  let _viewport_start_line = viewport.start_line_idx();
   let viewport_start_column = viewport.start_column_idx();
   let height = window_actual_shape.height();
   let width = window_actual_shape.width();
@@ -2069,39 +2069,6 @@ fn search_anchor_upward_wrap(
       .last_char_on_line_no_empty_eol(target_cursor_line)
       .unwrap_or(0_usize),
   );
-
-  debug_assert!(viewport.lines().first_key_value().is_some());
-  let (&first_line, _first_line_viewport) = viewport.lines().first_key_value().unwrap();
-
-  let target_cursor_line_not_fully_show = _line_head_not_show(viewport, target_cursor_line)
-    || _line_tail_not_show(viewport, buffer, target_cursor_line);
-
-  let (start_line, start_column, cannot_fully_contains_target_cursor_line) =
-    if target_cursor_line >= first_line && !target_cursor_line_not_fully_show {
-      (viewport_start_line, viewport_start_column, false)
-    } else {
-      let (target_cursor_rows, _target_cursor_start_fills, _target_cursor_end_fills, _) = proc(
-        buffer,
-        0,
-        target_cursor_line,
-        0_u16,
-        height.saturating_add(10),
-        width,
-      );
-
-      let cannot_fully_contains_target_cursor_line = target_cursor_rows.len() > height as usize;
-      let (start_line, start_column) = if !cannot_fully_contains_target_cursor_line {
-        (target_cursor_line, 0_usize)
-      } else {
-        (target_cursor_line, viewport_start_column)
-      };
-
-      (
-        start_line,
-        start_column,
-        cannot_fully_contains_target_cursor_line,
-      )
-    };
 
   let (preview_target_rows, _preview_target_start_fills, _preview_target_end_fills, _) = proc(
     buffer,


### PR DESCRIPTION
After several days of struggling with the anchor search algorithm for 0-width empty eol (end-of-line), I found current implementations has seriously confused 3 scenarios for `wrap=true`:

1. The viewport (window) cannot fully contain the cursor line (the line where cursor is at), i.e. the line is too long and have to be truncated to be put.
2. The viewport can contain the cursor line, i.e. the line is not too long. And further we can split this into more sub cases:
   1. The viewport exactly/only contains the cursor line. And we have a specific edge case when considering the empty eol:
      1. The last visible (non 0-width) char of cursor line is at the bottom-right corner of the viewport, and thus the empty eol is actually out of viewport. (If in insert mode, we need to move viewport to right side for extra 1 column to leave 1 cell if cursor is at empty eol)
      2. Otherwise the empty eol of the cursor line is not out of viewport.
   2. The viewport not only contains the cursor line, i.e. it contains at least 2 lines. And we have a specific edge case when considering empty eol:
      1. The cursor line is the last line in viewport, and its last visible char is at the bottom-right corner, and thus the empty eol is out of viewport. (If in insert mode, we need to move viewport down for extra 1 line to give the next line if cursor is at empty eol)
      2. Otherwise the empty eol of target cursor line is not out of viewport.
