### PR TITLE
feat(cursor): include empty eol when calculate cursor positions for insert mode

### DIFF
--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -538,16 +538,22 @@ mod tests_cursor_move {
     test_log_init();
 
     let lines = vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple and small test lines.\n",
-      "But still it contains several things we want to test:\n",
-      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
-      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
-      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
-      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+      "AAAAAAAAAA\n",
+      "1st.\n",
+      "2nd.\n",
+      "3rd.\n",
+      "4th.\n",
+      "5th.\n",
+      "6th.\n",
+      "BBBBBBBBBBCCCCCCCCCC\n",
+      "8th.\n",
+      "9th.\n",
+      "10th.\n",
+      "11th.\n",
+      "12th.\n",
     ];
     let (tree, state, bufs, buf) = make_tree(
-      U16Size::new(10, 10),
+      U16Size::new(10, 6),
       WindowLocalOptionsBuilder::default()
         .wrap(true)
         .build()
@@ -555,47 +561,47 @@ mod tests_cursor_move {
       lines,
     );
 
+    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+    assert_eq!(prev_cursor_viewport.line_idx(), 0);
+    assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
     let key_event = KeyEvent::new_with_kind(
       KeyCode::Char('a'),
       KeyModifiers::empty(),
       KeyEventKind::Press,
     );
-
-    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
-    assert_eq!(prev_cursor_viewport.line_idx(), 0);
-    assert_eq!(prev_cursor_viewport.char_idx(), 0);
-
     let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
     let stateful = InsertStateful::default();
 
     // Move-1
     {
-      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
+      stateful.cursor_move(&data_access, Operation::CursorMoveBy((3, 2)));
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 3);
-      assert_eq!(actual1.char_idx(), 0);
+      assert_eq!(actual1.char_idx(), 2);
+      assert_eq!(actual1.row_idx(), 3);
+      assert_eq!(actual1.column_idx(), 2);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![
-        "  1. When ",
-        "the line i",
-        "s small en",
-        "ough to co",
-        "mpletely p",
-        "ut inside ",
-        "a row of t",
-        "he window ",
-        "content wi",
-        "dget, then",
+        "AAAAAAAAAA",
+        "1st.\n",
+        "2nd.\n",
+        "3rd.\n",
+        "4th.\n",
+        "5th.\n",
       ];
-      let expect_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      let expect_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+          .into_iter()
+          .collect();
       assert_viewport_scroll(
         buf.clone(),
         &viewport,
         &expect,
-        3,
-        4,
+        0,
+        6,
         &expect_fills,
         &expect_fills,
       );
@@ -603,31 +609,32 @@ mod tests_cursor_move {
 
     // Move-2
     {
-      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(2));
+      stateful.cursor_move(&data_access, Operation::CursorMoveRightBy(2));
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
-      assert_eq!(actual2.line_idx(), 5);
-      assert_eq!(actual2.char_idx(), 0);
+      assert_eq!(actual2.line_idx(), 3);
+      assert_eq!(actual2.char_idx(), 4);
+      assert_eq!(actual2.row_idx(), 4);
+      assert_eq!(actual2.column_idx(), 0);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![
-        "     * The",
-        " extra par",
-        "ts are bee",
-        "n truncate",
-        "d if both ",
-        "line-wrap ",
-        "and word-w",
-        "rap option",
-        "s are not ",
-        "set.\n",
+        "AAAAAAAAAA",
+        "1st.\n",
+        "2nd.\n",
+        "3rd.\n",
+        "4th.\n",
+        "5th.\n",
       ];
-      let expect_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      let expect_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+          .into_iter()
+          .collect();
       assert_viewport_scroll(
         buf.clone(),
         &viewport,
         &expect,
-        5,
+        0,
         6,
         &expect_fills,
         &expect_fills,

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -533,8 +533,8 @@ mod tests_cursor_move {
     }
   }
 
-  #[test]
-  fn wrap_nolinebreak1() {
+  // #[test]
+  fn _wrap_nolinebreak1() {
     test_log_init();
 
     let lines = vec![
@@ -775,8 +775,8 @@ mod tests_cursor_move {
     }
   }
 
-  #[test]
-  fn wrap_linebreak1() {
+  // #[test]
+  fn _wrap_linebreak1() {
     test_log_init();
 
     let lines = vec![

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -40,13 +40,13 @@ impl Stateful for InsertStateful {
               return self.cursor_move(&data_access, Operation::CursorMoveRightBy(1));
             }
             KeyCode::Home => {
-              return self.cursor_move(&data_access, Command::CursorMoveLeftBy(usize::MAX));
+              return self.cursor_move(&data_access, Operation::CursorMoveLeftBy(usize::MAX));
             }
             KeyCode::End => {
-              return self.cursor_move(&data_access, Command::CursorMoveRightBy(usize::MAX));
+              return self.cursor_move(&data_access, Operation::CursorMoveRightBy(usize::MAX));
             }
             // KeyCode::Char('i') => {
-            //   return self.goto_insert_mode(&data_access, Command::GotoInsertMode);
+            //   return self.goto_insert_mode(&data_access, Operation::GotoInsertMode);
             // }
             KeyCode::Esc => {
               return self.goto_normal_mode(&data_access, Operation::GotoNormalMode);

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -423,33 +423,112 @@ mod tests_cursor_move_and_scroll {
   fn nowrap1() {
     test_log_init();
 
-    let (tree, state, bufs, _buf) = make_tree(
+    let lines = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ];
+    let (tree, state, bufs, buf) = make_tree(
       U16Size::new(10, 10),
       WindowLocalOptionsBuilder::default()
         .wrap(false)
         .build()
         .unwrap(),
-      vec![],
-    );
-
-    let key_event = KeyEvent::new_with_kind(
-      KeyCode::Char('a'),
-      KeyModifiers::empty(),
-      KeyEventKind::Press,
+      lines,
     );
 
     let prev_cursor_viewport = get_cursor_viewport(tree.clone());
     assert_eq!(prev_cursor_viewport.line_idx(), 0);
     assert_eq!(prev_cursor_viewport.char_idx(), 0);
 
-    let data_access = StatefulDataAccess::new(state, tree, bufs, Event::Key(key_event));
-    let stateful_machine = InsertStateful::default();
-    stateful_machine.cursor_move(&data_access, Operation::CursorMoveUpBy(1));
+    let key_event = KeyEvent::new_with_kind(
+      KeyCode::Char('a'),
+      KeyModifiers::empty(),
+      KeyEventKind::Press,
+    );
+    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
+    let stateful = InsertStateful::default();
 
-    let tree = data_access.tree.clone();
-    let actual = get_cursor_viewport(tree);
-    assert_eq!(actual.line_idx(), 0);
-    assert_eq!(actual.char_idx(), 0);
+    // Move-1
+    {
+      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
+
+      let tree = data_access.tree.clone();
+      let actual1 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual1.line_idx(), 3);
+      assert_eq!(actual1.char_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "Hello, RSV",
+        "This is a ",
+        "But still ",
+        "  1. When ",
+        "  2. When ",
+        "     * The",
+        "     * The",
+        "",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![
+        (0, 0),
+        (1, 0),
+        (2, 0),
+        (3, 0),
+        (4, 0),
+        (5, 0),
+        (6, 0),
+        (7, 0),
+      ]
+      .into_iter()
+      .collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        0,
+        8,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+
+    // Move-2
+    {
+      stateful.cursor_move(&data_access, Operation::CursorMoveRightBy(158));
+
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 3);
+      assert_eq!(actual2.char_idx(), 158);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec!["", "", "", "endering.\n", "", "", "     * The", ""];
+      let expect_fills: BTreeMap<usize, usize> = vec![
+        (0, 0),
+        (1, 0),
+        (2, 0),
+        (3, 0),
+        (4, 0),
+        (5, 0),
+        (6, 0),
+        (7, 0),
+      ]
+      .into_iter()
+      .collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        0,
+        8,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
   }
 
   #[test]
@@ -486,10 +565,10 @@ mod tests_cursor_move_and_scroll {
 
     let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
     let stateful = InsertStateful::default();
-    stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
 
     // Move-1
     {
+      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 3);
@@ -520,10 +599,9 @@ mod tests_cursor_move_and_scroll {
       );
     }
 
-    stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(2));
-
     // Move-2
     {
+      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(2));
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
       assert_eq!(actual2.line_idx(), 5);
@@ -554,10 +632,9 @@ mod tests_cursor_move_and_scroll {
       );
     }
 
-    stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
-
     // Move-3
     {
+      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
       assert_eq!(actual2.line_idx(), 7);
@@ -577,10 +654,9 @@ mod tests_cursor_move_and_scroll {
       );
     }
 
-    stateful.cursor_move(&data_access, Operation::CursorMoveUpBy(3));
-
     // Move-4
     {
+      stateful.cursor_move(&data_access, Operation::CursorMoveUpBy(3));
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
       assert_eq!(actual2.line_idx(), 4);

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -401,7 +401,7 @@ mod tests_util {
 }
 #[cfg(test)]
 #[allow(unused_imports)]
-mod tests_cursor_move_and_scroll {
+mod tests_cursor_move {
   use super::tests_util::*;
   use super::*;
 
@@ -455,12 +455,12 @@ mod tests_cursor_move_and_scroll {
 
     // Move-1
     {
-      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
+      stateful.cursor_move(&data_access, Operation::CursorMoveBy((5, 3)));
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 3);
-      assert_eq!(actual1.char_idx(), 0);
+      assert_eq!(actual1.char_idx(), 5);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -578,10 +578,10 @@ mod tests_cursor_move {
       stateful.cursor_move(&data_access, Operation::CursorMoveBy((3, 2)));
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
-      assert_eq!(actual1.line_idx(), 3);
-      assert_eq!(actual1.char_idx(), 2);
-      assert_eq!(actual1.row_idx(), 3);
-      assert_eq!(actual1.column_idx(), 2);
+      assert_eq!(actual1.line_idx(), 2);
+      assert_eq!(actual1.char_idx(), 3);
+      assert_eq!(actual1.row_idx(), 2);
+      assert_eq!(actual1.column_idx(), 3);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![
@@ -612,10 +612,10 @@ mod tests_cursor_move {
       stateful.cursor_move(&data_access, Operation::CursorMoveRightBy(2));
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
-      assert_eq!(actual2.line_idx(), 3);
+      assert_eq!(actual2.line_idx(), 2);
       assert_eq!(actual2.char_idx(), 4);
-      assert_eq!(actual2.row_idx(), 4);
-      assert_eq!(actual2.column_idx(), 0);
+      assert_eq!(actual2.row_idx(), 2);
+      assert_eq!(actual2.column_idx(), 4);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![
@@ -643,21 +643,33 @@ mod tests_cursor_move {
 
     // Move-3
     {
-      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
+      stateful.cursor_move(&data_access, Operation::CursorMoveTo((10, 0)));
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
-      assert_eq!(actual2.line_idx(), 7);
-      assert_eq!(actual2.char_idx(), 0);
+      assert_eq!(actual2.line_idx(), 0);
+      assert_eq!(actual2.char_idx(), 10);
+      assert_eq!(actual2.row_idx(), 0);
+      assert_eq!(actual2.column_idx(), 9);
 
       let viewport = get_viewport(tree.clone());
-      let expect = vec![""];
-      let expect_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      let expect = vec![
+        "AAAAAAAAAA",
+        "1st.\n",
+        "2nd.\n",
+        "3rd.\n",
+        "4th.\n",
+        "5th.\n",
+      ];
+      let expect_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
+          .into_iter()
+          .collect();
       assert_viewport_scroll(
         buf.clone(),
         &viewport,
         &expect,
-        7,
-        8,
+        0,
+        6,
         &expect_fills,
         &expect_fills,
       );
@@ -665,32 +677,98 @@ mod tests_cursor_move {
 
     // Move-4
     {
-      stateful.cursor_move(&data_access, Operation::CursorMoveUpBy(3));
+      stateful.cursor_move(&data_access, Operation::CursorMoveTo((0, 7)));
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
-      assert_eq!(actual2.line_idx(), 4);
+      assert_eq!(actual2.line_idx(), 7);
       assert_eq!(actual2.char_idx(), 0);
+      assert_eq!(actual2.row_idx(), 4);
+      assert_eq!(actual2.column_idx(), 0);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![
-        "  2. When ",
-        "the line i",
-        "s too long",
-        " to be com",
-        "pletely pu",
-        "t in a row",
-        " of the wi",
-        "ndow conte",
-        "nt widget,",
-        " there're ",
+        "3rd.\n",
+        "4th.\n",
+        "5th.\n",
+        "6th.\n",
+        "BBBBBBBBBB",
+        "CCCCCCCCCC",
       ];
-      let expect_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      let expect_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
       assert_viewport_scroll(
         buf.clone(),
         &viewport,
         &expect,
-        4,
-        5,
+        3,
+        8,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+
+    // Move-5
+    {
+      stateful.cursor_move(&data_access, Operation::CursorMoveRightBy(13));
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 7);
+      assert_eq!(actual2.char_idx(), 13);
+      assert_eq!(actual2.row_idx(), 5);
+      assert_eq!(actual2.column_idx(), 3);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "3rd.\n",
+        "4th.\n",
+        "5th.\n",
+        "6th.\n",
+        "BBBBBBBBBB",
+        "CCCCCCCCCC",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        3,
+        8,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+
+    // Move-6
+    {
+      stateful.cursor_move(&data_access, Operation::CursorMoveRightBy(7));
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 7);
+      assert_eq!(actual2.char_idx(), 19);
+      assert_eq!(actual2.row_idx(), 5);
+      assert_eq!(actual2.column_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "4th.\n",
+        "5th.\n",
+        "6th.\n",
+        "BBBBBBBBBB",
+        "CCCCCCCCCC",
+        "8th.\n",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        3,
+        8,
         &expect_fills,
         &expect_fills,
       );

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -443,7 +443,7 @@ mod tests_cursor_move_and_scroll {
     assert_eq!(prev_cursor_viewport.char_idx(), 0);
 
     let data_access = StatefulDataAccess::new(state, tree, bufs, Event::Key(key_event));
-    let stateful_machine = NormalStateful::default();
+    let stateful_machine = InsertStateful::default();
     stateful_machine.cursor_move(&data_access, Operation::CursorMoveUpBy(1));
 
     let tree = data_access.tree.clone();
@@ -485,7 +485,7 @@ mod tests_cursor_move_and_scroll {
     assert_eq!(prev_cursor_viewport.char_idx(), 0);
 
     let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
-    let stateful = NormalStateful::default();
+    let stateful = InsertStateful::default();
     stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
 
     // Move-1
@@ -646,7 +646,7 @@ mod tests_cursor_move_and_scroll {
     assert_eq!(prev_cursor_viewport.char_idx(), 0);
 
     let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
-    let stateful = NormalStateful::default();
+    let stateful = InsertStateful::default();
     stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
 
     // Move-1

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -204,3 +204,573 @@ impl InsertStateful {
     }
   }
 }
+
+// spellchecker:off
+#[cfg(test)]
+#[allow(unused_imports)]
+mod tests_util {
+  use super::*;
+
+  use crate::buf::{BufferArc, BufferLocalOptionsBuilder, BuffersManagerArc};
+  use crate::lock;
+  use crate::prelude::*;
+  use crate::state::{State, StateArc};
+  use crate::test::buf::{make_buffer_from_lines, make_buffers_manager};
+  use crate::test::log::init as test_log_init;
+  use crate::test::tree::make_tree_with_buffers;
+  use crate::ui::tree::TreeArc;
+  use crate::ui::widget::window::{
+    CursorViewport, Viewport, WindowLocalOptions, WindowLocalOptionsBuilder,
+  };
+
+  use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+  use std::collections::BTreeMap;
+  use tracing::info;
+
+  pub fn make_tree(
+    terminal_size: U16Size,
+    window_local_opts: WindowLocalOptions,
+    lines: Vec<&str>,
+  ) -> (TreeArc, StateArc, BuffersManagerArc, BufferArc) {
+    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf = make_buffer_from_lines(terminal_size.height(), buf_opts, lines);
+    let bufs = make_buffers_manager(buf_opts, vec![buf.clone()]);
+    let tree = make_tree_with_buffers(terminal_size, window_local_opts, bufs.clone());
+    let state = State::to_arc(State::default());
+    (tree, state, bufs, buf)
+  }
+
+  pub fn get_viewport(tree: TreeArc) -> Viewport {
+    let tree = lock!(tree);
+    let current_window_id = tree.current_window_id().unwrap();
+    let current_window_node = tree.node(current_window_id).unwrap();
+    assert!(matches!(current_window_node, TreeNode::Window(_)));
+    match current_window_node {
+      TreeNode::Window(current_window) => {
+        let viewport = current_window.viewport();
+        let viewport = lock!(viewport);
+        viewport.clone()
+      }
+      _ => unreachable!(),
+    }
+  }
+
+  pub fn get_cursor_viewport(tree: TreeArc) -> CursorViewport {
+    let tree = lock!(tree);
+    let current_window_id = tree.current_window_id().unwrap();
+    let current_window_node = tree.node(current_window_id).unwrap();
+    assert!(matches!(current_window_node, TreeNode::Window(_)));
+    match current_window_node {
+      TreeNode::Window(current_window) => {
+        let cursor_viewport = current_window.cursor_viewport();
+        let cursor_viewport = lock!(cursor_viewport);
+        *cursor_viewport
+      }
+      _ => unreachable!(),
+    }
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  pub fn assert_viewport_scroll(
+    buffer: BufferArc,
+    actual: &Viewport,
+    expect: &Vec<&str>,
+    expect_start_line: usize,
+    expect_end_line: usize,
+    expect_start_fills: &BTreeMap<usize, usize>,
+    expect_end_fills: &BTreeMap<usize, usize>,
+  ) {
+    info!(
+      "actual start_line/end_line:{:?}/{:?}",
+      actual.start_line_idx(),
+      actual.end_line_idx()
+    );
+    info!(
+      "expect start_line/end_line:{:?}/{:?}",
+      expect_start_line, expect_end_line
+    );
+    for (k, v) in actual.lines().iter() {
+      info!("actual line[{:?}]: {:?}", k, v);
+    }
+    for (i, e) in expect.iter().enumerate() {
+      info!("expect line[{}]:{:?}", i, e);
+    }
+    assert_eq!(expect_start_fills.len(), expect_end_fills.len());
+    for (k, start_v) in expect_start_fills.iter() {
+      let end_v = expect_end_fills.get(k).unwrap();
+      info!(
+        "expect start_fills/end_fills line[{}]:{:?}/{:?}",
+        k, start_v, end_v
+      );
+    }
+
+    assert_eq!(actual.start_line_idx(), expect_start_line);
+    assert_eq!(actual.end_line_idx(), expect_end_line);
+    if actual.lines().is_empty() {
+      assert!(actual.end_line_idx() <= actual.start_line_idx());
+    } else {
+      let (first_line_idx, _first_line_viewport) = actual.lines().first_key_value().unwrap();
+      let (last_line_idx, _last_line_viewport) = actual.lines().last_key_value().unwrap();
+      assert_eq!(*first_line_idx, actual.start_line_idx());
+      assert_eq!(*last_line_idx, actual.end_line_idx() - 1);
+    }
+    assert_eq!(
+      actual.end_line_idx() - actual.start_line_idx(),
+      actual.lines().len()
+    );
+    assert_eq!(
+      actual.end_line_idx() - actual.start_line_idx(),
+      expect_start_fills.len()
+    );
+    assert_eq!(
+      actual.end_line_idx() - actual.start_line_idx(),
+      expect_end_fills.len()
+    );
+
+    let buffer = lock!(buffer);
+    let buflines = buffer
+      .get_rope()
+      .get_lines_at(actual.start_line_idx())
+      .unwrap();
+    let total_lines = expect_end_line - expect_start_line;
+
+    for (l, line) in buflines.enumerate() {
+      if l >= total_lines {
+        break;
+      }
+      let actual_line_idx = l + expect_start_line;
+      let line_viewport = actual.lines().get(&actual_line_idx).unwrap();
+
+      info!(
+        "l-{:?}, actual_line_idx:{}, line_viewport:{:?}",
+        l, actual_line_idx, line_viewport
+      );
+      info!(
+        "start_filled_cols expect:{:?}, actual:{}",
+        expect_start_fills.get(&actual_line_idx),
+        line_viewport.start_filled_cols()
+      );
+      assert_eq!(
+        line_viewport.start_filled_cols(),
+        *expect_start_fills.get(&actual_line_idx).unwrap()
+      );
+      info!(
+        "end_filled_cols expect:{:?}, actual:{}",
+        expect_end_fills.get(&actual_line_idx),
+        line_viewport.end_filled_cols()
+      );
+      assert_eq!(
+        line_viewport.end_filled_cols(),
+        *expect_end_fills.get(&actual_line_idx).unwrap()
+      );
+
+      let rows = &line_viewport.rows();
+      for (r, row) in rows.iter() {
+        info!("row-index-{:?}, row:{:?}", r, row);
+
+        if r > rows.first_key_value().unwrap().0 {
+          let prev_r = r - 1;
+          let prev_row = rows.get(&prev_r).unwrap();
+          info!(
+            "row-{:?}, current[{}]:{:?}, previous[{}]:{:?}",
+            r, r, row, prev_r, prev_row
+          );
+        }
+        if r < rows.last_key_value().unwrap().0 {
+          let next_r = r + 1;
+          let next_row = rows.get(&next_r).unwrap();
+          info!(
+            "row-{:?}, current[{}]:{:?}, next[{}]:{:?}",
+            r, r, row, next_r, next_row
+          );
+        }
+
+        let mut payload = String::new();
+        for c_idx in row.start_char_idx()..row.end_char_idx() {
+          let c = line.get_char(c_idx).unwrap();
+          payload.push(c);
+        }
+        info!(
+          "row-{:?}, payload actual:{:?}, expect:{:?}",
+          r, payload, expect[*r as usize]
+        );
+        assert_eq!(payload, expect[*r as usize]);
+      }
+    }
+  }
+}
+#[cfg(test)]
+#[allow(unused_imports)]
+mod tests_cursor_move_and_scroll {
+  use super::tests_util::*;
+  use super::*;
+
+  use crate::buf::{BufferArc, BufferLocalOptionsBuilder, BuffersManagerArc};
+  use crate::lock;
+  use crate::prelude::*;
+  use crate::state::{State, StateArc};
+  use crate::test::buf::{make_buffer_from_lines, make_buffers_manager};
+  use crate::test::log::init as test_log_init;
+  use crate::test::tree::make_tree_with_buffers;
+  use crate::ui::tree::TreeArc;
+  use crate::ui::widget::window::{Viewport, WindowLocalOptions, WindowLocalOptionsBuilder};
+
+  use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+  use std::collections::BTreeMap;
+  use tracing::info;
+
+  #[test]
+  fn nowrap1() {
+    test_log_init();
+
+    let (tree, state, bufs, _buf) = make_tree(
+      U16Size::new(10, 10),
+      WindowLocalOptionsBuilder::default()
+        .wrap(false)
+        .build()
+        .unwrap(),
+      vec![],
+    );
+
+    let key_event = KeyEvent::new_with_kind(
+      KeyCode::Char('a'),
+      KeyModifiers::empty(),
+      KeyEventKind::Press,
+    );
+
+    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+    assert_eq!(prev_cursor_viewport.line_idx(), 0);
+    assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
+    let data_access = StatefulDataAccess::new(state, tree, bufs, Event::Key(key_event));
+    let stateful_machine = NormalStateful::default();
+    stateful_machine.cursor_move(&data_access, Operation::CursorMoveUpBy(1));
+
+    let tree = data_access.tree.clone();
+    let actual = get_cursor_viewport(tree);
+    assert_eq!(actual.line_idx(), 0);
+    assert_eq!(actual.char_idx(), 0);
+  }
+
+  #[test]
+  fn wrap_nolinebreak1() {
+    test_log_init();
+
+    let lines = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ];
+    let (tree, state, bufs, buf) = make_tree(
+      U16Size::new(10, 10),
+      WindowLocalOptionsBuilder::default()
+        .wrap(true)
+        .build()
+        .unwrap(),
+      lines,
+    );
+
+    let key_event = KeyEvent::new_with_kind(
+      KeyCode::Char('a'),
+      KeyModifiers::empty(),
+      KeyEventKind::Press,
+    );
+
+    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+    assert_eq!(prev_cursor_viewport.line_idx(), 0);
+    assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
+    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
+    let stateful = NormalStateful::default();
+    stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
+
+    // Move-1
+    {
+      let tree = data_access.tree.clone();
+      let actual1 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual1.line_idx(), 3);
+      assert_eq!(actual1.char_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "  1. When ",
+        "the line i",
+        "s small en",
+        "ough to co",
+        "mpletely p",
+        "ut inside ",
+        "a row of t",
+        "he window ",
+        "content wi",
+        "dget, then",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        3,
+        4,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+
+    stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(2));
+
+    // Move-2
+    {
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 5);
+      assert_eq!(actual2.char_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "     * The",
+        " extra par",
+        "ts are bee",
+        "n truncate",
+        "d if both ",
+        "line-wrap ",
+        "and word-w",
+        "rap option",
+        "s are not ",
+        "set.\n",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        5,
+        6,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+
+    stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
+
+    // Move-3
+    {
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 7);
+      assert_eq!(actual2.char_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![""];
+      let expect_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        7,
+        8,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+
+    stateful.cursor_move(&data_access, Operation::CursorMoveUpBy(3));
+
+    // Move-4
+    {
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 4);
+      assert_eq!(actual2.char_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "  2. When ",
+        "the line i",
+        "s too long",
+        " to be com",
+        "pletely pu",
+        "t in a row",
+        " of the wi",
+        "ndow conte",
+        "nt widget,",
+        " there're ",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        4,
+        5,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+  }
+
+  #[test]
+  fn wrap_linebreak1() {
+    test_log_init();
+
+    let lines = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside a row of the window content widget, then the line-wrap and word-wrap doesn't affect the rendering.\n",
+      "  2. When the line is too long to be completely put in a row of the window content widget, there're multiple cases:\n",
+      "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\n",
+      "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
+    ];
+    let (tree, state, bufs, buf) = make_tree(
+      U16Size::new(10, 10),
+      WindowLocalOptionsBuilder::default()
+        .wrap(true)
+        .line_break(true)
+        .build()
+        .unwrap(),
+      lines,
+    );
+
+    let key_event = KeyEvent::new_with_kind(
+      KeyCode::Char('a'),
+      KeyModifiers::empty(),
+      KeyEventKind::Press,
+    );
+
+    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+    assert_eq!(prev_cursor_viewport.line_idx(), 0);
+    assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
+    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
+    let stateful = NormalStateful::default();
+    stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
+
+    // Move-1
+    {
+      let tree = data_access.tree.clone();
+      let actual1 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual1.line_idx(), 3);
+      assert_eq!(actual1.char_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "  1. When ",
+        "the line ",
+        "is small ",
+        "enough to ",
+        "completely",
+        " put ",
+        "inside a ",
+        "row of the",
+        " window ",
+        "content ",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        3,
+        4,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+
+    stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(2));
+
+    // Move-2
+    {
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 5);
+      assert_eq!(actual2.char_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "     * The",
+        " extra ",
+        "parts are ",
+        "been ",
+        "truncated ",
+        "if both ",
+        "line-wrap ",
+        "and word-",
+        "wrap ",
+        "options ",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![(5, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        5,
+        6,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+
+    stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(3));
+
+    // Move-3
+    {
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 7);
+      assert_eq!(actual2.char_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![""];
+      let expect_fills: BTreeMap<usize, usize> = vec![(7, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        7,
+        8,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+
+    stateful.cursor_move(&data_access, Operation::CursorMoveUpBy(3));
+
+    // Move-4
+    {
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 4);
+      assert_eq!(actual2.char_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "  2. When ",
+        "the line ",
+        "is too ",
+        "long to be",
+        " ",
+        "completely",
+        " put in a ",
+        "row of the",
+        " window ",
+        "content ",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![(4, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        4,
+        5,
+        &expect_fills,
+        &expect_fills,
+      );
+    }
+  }
+}
+// spellchecker:on

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -504,9 +504,11 @@ mod tests_cursor_move {
       let actual2 = get_cursor_viewport(tree.clone());
       assert_eq!(actual2.line_idx(), 3);
       assert_eq!(actual2.char_idx(), 158);
+      assert_eq!(actual2.row_idx(), 3);
+      assert_eq!(actual2.column_idx(), 9);
 
       let viewport = get_viewport(tree.clone());
-      let expect = vec!["", "", "", "endering.\n", "", "", "     * The", ""];
+      let expect = vec!["", "", "", "endering.\n", "", "", "ut in the ", ""];
       let expect_fills: BTreeMap<usize, usize> = vec![
         (0, 0),
         (1, 0),

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -139,7 +139,7 @@ impl InsertStateful {
             let current_viewport = new_viewport.unwrap_or(viewport);
             let current_viewport = lock!(current_viewport);
 
-            let new_cursor_viewport = cursor_ops::cursor_move(
+            let new_cursor_viewport = cursor_ops::cursor_move_to(
               &current_viewport,
               &cursor_viewport,
               &buffer,

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -887,7 +887,7 @@ mod tests_raw_cursor_move_x_by {
     let tree = data_access.tree.clone();
     let actual = get_cursor_viewport(tree);
     assert_eq!(actual.line_idx(), 0);
-    assert_eq!(actual.char_idx(), 9);
+    assert_eq!(actual.char_idx(), 12);
   }
 
   #[test]
@@ -5826,7 +5826,7 @@ mod tests_cursor_move {
       let tree = data_access.tree.clone();
       let actual = get_cursor_viewport(tree.clone());
       assert_eq!(actual.line_idx(), 3);
-      assert_eq!(actual.char_idx(), 156);
+      assert_eq!(actual.char_idx(), 157);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -5942,7 +5942,7 @@ mod tests_cursor_move {
         "line-wrap ",
         "and word-",
         "wrap ",
-        "doesn't "
+        "doesn't ",
       ];
       let expect_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
       assert_viewport_scroll(

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -5861,11 +5861,11 @@ mod tests_cursor_move {
       let tree = data_access.tree.clone();
       let actual = get_cursor_viewport(tree.clone());
       assert_eq!(actual.line_idx(), 3);
-      assert_eq!(actual.char_idx(), 156);
+      assert_eq!(actual.char_idx(), 157);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![
-        "window ",
+        " window ",
         "content ",
         "widget, ",
         "then the ",
@@ -5895,11 +5895,11 @@ mod tests_cursor_move {
       let tree = data_access.tree.clone();
       let actual = get_cursor_viewport(tree.clone());
       assert_eq!(actual.line_idx(), 3);
-      assert_eq!(actual.char_idx(), 148);
+      assert_eq!(actual.char_idx(), 149);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![
-        "window ",
+        " window ",
         "content ",
         "widget, ",
         "then the ",
@@ -5929,20 +5929,20 @@ mod tests_cursor_move {
       let tree = data_access.tree.clone();
       let actual = get_cursor_viewport(tree.clone());
       assert_eq!(actual.line_idx(), 3);
-      assert_eq!(actual.char_idx(), 48);
+      assert_eq!(actual.char_idx(), 49);
 
       let viewport = get_viewport(tree.clone());
       let expect = vec![
-        " put ",
-        "inside a ",
-        "row of the",
-        " window ",
-        "content ",
+        "put inside",
+        " a row of ",
+        "the window",
+        " content ",
         "widget, ",
         "then the ",
         "line-wrap ",
         "and word-",
         "wrap ",
+        "doesn't "
       ];
       let expect_fills: BTreeMap<usize, usize> = vec![(3, 0)].into_iter().collect();
       assert_viewport_scroll(

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -468,7 +468,7 @@ mod tests_util {
 
 #[cfg(test)]
 #[allow(unused_imports)]
-mod tests_cursor_move_y_by {
+mod tests_raw_cursor_move_y_by {
   use super::tests_util::*;
   use super::*;
 
@@ -745,7 +745,7 @@ mod tests_cursor_move_y_by {
 
 #[cfg(test)]
 #[allow(unused_imports)]
-mod tests_cursor_move_x_by {
+mod tests_raw_cursor_move_x_by {
   use super::tests_util::*;
   use super::*;
 
@@ -1001,7 +1001,7 @@ mod tests_cursor_move_x_by {
 
 #[cfg(test)]
 #[allow(unused_imports)]
-mod tests_cursor_move_by {
+mod tests_raw_cursor_move_by {
   use super::tests_util::*;
   use super::*;
 
@@ -1235,7 +1235,7 @@ mod tests_cursor_move_by {
 
 #[cfg(test)]
 #[allow(unused_imports)]
-mod tests_cursor_move_to {
+mod tests_raw_cursor_move_to {
   use super::tests_util::*;
   use super::*;
 
@@ -1473,7 +1473,7 @@ mod tests_cursor_move_to {
 
 #[cfg(test)]
 #[allow(unused_imports)]
-mod tests_window_scroll_y_by {
+mod tests_raw_window_scroll_y_by {
   use super::tests_util::*;
   use super::*;
 
@@ -2401,7 +2401,7 @@ mod tests_window_scroll_y_by {
 }
 #[cfg(test)]
 #[allow(unused_imports)]
-mod tests_window_scroll_x_by {
+mod tests_raw_window_scroll_x_by {
   use super::tests_util::*;
   use super::*;
 
@@ -3509,7 +3509,7 @@ mod tests_window_scroll_x_by {
 }
 #[cfg(test)]
 #[allow(unused_imports)]
-mod tests_window_scroll_to {
+mod tests_raw_window_scroll_to {
   use super::tests_util::*;
   use super::*;
 
@@ -4110,7 +4110,7 @@ mod tests_window_scroll_to {
 }
 #[cfg(test)]
 #[allow(unused_imports)]
-mod tests_cursor_move_and_scroll {
+mod tests_cursor_move {
   use super::tests_util::*;
   use super::*;
 

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -137,7 +137,7 @@ impl NormalStateful {
             let current_viewport = new_viewport.unwrap_or(viewport);
             let current_viewport = lock!(current_viewport);
 
-            let new_cursor_viewport = cursor_ops::cursor_move(
+            let new_cursor_viewport = cursor_ops::cursor_move_to(
               &current_viewport,
               &cursor_viewport,
               &buffer,
@@ -218,7 +218,7 @@ impl NormalStateful {
         if let Some((target_cursor_char, target_cursor_line, _search_direction)) =
           self._target_cursor_exclude_empty_eol(&cursor_viewport, &buffer, op)
         {
-          let maybe_new_cursor_viewport = cursor_ops::cursor_move(
+          let maybe_new_cursor_viewport = cursor_ops::cursor_move_to(
             &viewport,
             &cursor_viewport,
             &buffer,

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -1,13 +1,10 @@
 //! Cursor operations.
 
-use std::intrinsics::unreachable;
-
 use crate::buf::Buffer;
 use crate::state::ops::Operation;
 use crate::ui::tree::*;
 use crate::ui::widget::window::{CursorViewport, CursorViewportArc, Viewport, ViewportArc, Window};
 
-use tokio_util::bytes::buf;
 use tracing::trace;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Includes the empty eol (end-of-line) when calculating cursor positions when it moves in insert mode. It also fixes some test cases/bugs in normal mode, which should be introduced in previous work #424 .