### PR TITLE
feat(insert): insert eol when file has no eol at end

### DIFF
--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -6,8 +6,10 @@ use derive_builder::Builder;
 
 // Re-export
 pub use file_encoding::*;
+pub use file_format::*;
 
 pub mod file_encoding;
+pub mod file_format;
 
 #[derive(Debug, Copy, Clone, Builder)]
 /// Local buffer options.
@@ -17,6 +19,9 @@ pub struct BufferLocalOptions {
 
   #[builder(default = defaults::buf::FILE_ENCODING)]
   file_encoding: FileEncodingOption,
+
+  #[builder(default = defaults::buf::FILE_FORMAT)]
+  file_format: FileFormatOption,
 }
 
 impl BufferLocalOptions {
@@ -40,6 +45,22 @@ impl BufferLocalOptions {
 
   pub fn set_file_encoding(&mut self, value: FileEncodingOption) {
     self.file_encoding = value;
+  }
+
+  /// Buffer 'file-format' option.
+  ///
+  /// See: <https://vimhelp.org/options.txt.html#%27fileformat%27>.
+  pub fn file_format(&self) -> FileFormatOption {
+    self.file_format
+  }
+
+  pub fn set_file_format(&mut self, value: FileFormatOption) {
+    self.file_format = value;
+  }
+
+  /// Get 'end-of-line' based on 'file-format' option.
+  pub fn end_of_line(&self) -> EndOfLineOption {
+    self.file_format.into()
   }
 }
 

--- a/rsvim_core/src/buf/opt/file_format.rs
+++ b/rsvim_core/src/buf/opt/file_format.rs
@@ -1,0 +1,49 @@
+//! The "file-format" option for Vim buffer.
+
+use std::fmt::Display;
+use std::string::ToString;
+
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum FileFormatOption {
+  /// CRLF (<CR><NL>)
+  Dos,
+  /// LF (<NL>)
+  Unix,
+  /// CR (<CR>)
+  Mac,
+}
+
+impl Display for FileFormatOption {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      FileFormatOption::Dos => write!(f, "dos"),
+      FileFormatOption::Unix => write!(f, "unix"),
+      FileFormatOption::Mac => write!(f, "mac"),
+    }
+  }
+}
+
+impl TryFrom<&str> for FileFormatOption {
+  type Error = String;
+
+  fn try_from(value: &str) -> Result<Self, Self::Error> {
+    let lower_value = value.to_lowercase();
+    match lower_value.as_str() {
+      "dos" => Ok(FileFormatOption::Dos),
+      "unix" => Ok(FileFormatOption::Unix),
+      "mac" => Ok(FileFormatOption::Mac),
+      _ => Err("Unknown FileFormat value".to_string()),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn display1() {
+    let actual1 = format!("{}", FileFormatOption::Dos);
+    assert_eq!(actual1, "dos");
+  }
+}

--- a/rsvim_core/src/buf/opt/file_format.rs
+++ b/rsvim_core/src/buf/opt/file_format.rs
@@ -11,15 +11,10 @@ pub enum FileFormatOption {
   /// LF (`<NL>`)
   Unix,
 
-  /// LF (`<NL>`)
-  ///
-  /// NOTE: CR (`<CR>`) is deprecated in macos.
-  Mac,
-
   /// CR (`<CR>`)
   ///
-  /// NOTE: CR (`<CR>`) is deprecated in macos.
-  ClassicMac,
+  /// NOTE: This is deprecated and should never used in today's computer.
+  Mac,
 }
 
 impl Display for FileFormatOption {
@@ -28,7 +23,6 @@ impl Display for FileFormatOption {
       FileFormatOption::Dos => write!(f, "dos"),
       FileFormatOption::Unix => write!(f, "unix"),
       FileFormatOption::Mac => write!(f, "mac"),
-      FileFormatOption::ClassicMac => write!(f, "classic_mac"),
     }
   }
 }
@@ -42,7 +36,6 @@ impl TryFrom<&str> for FileFormatOption {
       "dos" => Ok(FileFormatOption::Dos),
       "unix" => Ok(FileFormatOption::Unix),
       "mac" => Ok(FileFormatOption::Mac),
-      "classic_mac" => Ok(FileFormatOption::ClassicMac),
       _ => Err("Unknown FileFormat value".to_string()),
     }
   }
@@ -53,7 +46,7 @@ impl From<EndOfLineOption> for FileFormatOption {
     match value {
       EndOfLineOption::CRLF => FileFormatOption::Dos,
       EndOfLineOption::LF => FileFormatOption::Unix,
-      EndOfLineOption::CR => FileFormatOption::ClassicMac,
+      EndOfLineOption::CR => FileFormatOption::Mac,
     }
   }
 }
@@ -101,8 +94,7 @@ impl From<FileFormatOption> for EndOfLineOption {
     match value {
       FileFormatOption::Dos => EndOfLineOption::CRLF,
       FileFormatOption::Unix => EndOfLineOption::LF,
-      FileFormatOption::Mac => EndOfLineOption::LF,
-      FileFormatOption::ClassicMac => EndOfLineOption::CR,
+      FileFormatOption::Mac => EndOfLineOption::CR,
     }
   }
 }

--- a/rsvim_core/src/buf/opt/file_format.rs
+++ b/rsvim_core/src/buf/opt/file_format.rs
@@ -13,7 +13,8 @@ pub enum FileFormatOption {
 
   /// CR (`<CR>`)
   ///
-  /// NOTE: This is deprecated and should never used in today's computer.
+  /// NOTE: This is deprecated and only been kept for compatibility reason, which should never
+  /// used today.
   Mac,
 }
 

--- a/rsvim_core/src/buf/opt/file_format.rs
+++ b/rsvim_core/src/buf/opt/file_format.rs
@@ -5,20 +5,20 @@ use std::string::ToString;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum FileFormatOption {
-  /// CRLF (<CR><NL>)
+  /// CRLF (`<CR><NL>`)
   Dos,
 
-  /// LF (<NL>)
+  /// LF (`<NL>`)
   Unix,
 
-  /// LF (<NL>)
+  /// LF (`<NL>`)
   ///
-  /// NOTE: CR (<CR>) is deprecated in macos.
+  /// NOTE: CR (`<CR>`) is deprecated in macos.
   Mac,
 
-  /// CR (<CR>)
+  /// CR (`<CR>`)
   ///
-  /// NOTE: CR (<CR>) is deprecated in macos.
+  /// NOTE: CR (`<CR>`) is deprecated in macos.
   ClassicMac,
 }
 

--- a/rsvim_core/src/buf/opt/file_format.rs
+++ b/rsvim_core/src/buf/opt/file_format.rs
@@ -105,6 +105,29 @@ impl TryFrom<&str> for EndOfLineOption {
   }
 }
 
+impl From<FileFormatOption> for EndOfLineOption {
+  fn from(value: FileFormatOption) -> Self {
+    match value {
+      FileFormatOption::Dos => EndOfLineOption::CRLF,
+      FileFormatOption::Unix => EndOfLineOption::LF,
+      FileFormatOption::Mac => EndOfLineOption::LF,
+      FileFormatOption::ClassicMac => EndOfLineOption::CR,
+    }
+  }
+}
+
+impl EndOfLineOption {
+  pub fn to_ascii_str(&self) -> &str {
+    use crate::defaults::ascii::end_of_line as eol;
+
+    match self {
+      EndOfLineOption::CRLF => eol::CRLF,
+      EndOfLineOption::LF => eol::LF,
+      EndOfLineOption::CR => eol::CR,
+    }
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/rsvim_core/src/buf/opt/file_format.rs
+++ b/rsvim_core/src/buf/opt/file_format.rs
@@ -58,17 +58,6 @@ impl From<EndOfLineOption> for FileFormatOption {
   }
 }
 
-impl Into<EndOfLineOption> for FileFormatOption {
-  fn into(self) -> EndOfLineOption {
-    match self {
-      FileFormatOption::Dos => EndOfLineOption::CRLF,
-      FileFormatOption::Unix => EndOfLineOption::LF,
-      FileFormatOption::Mac => EndOfLineOption::LF,
-      FileFormatOption::ClassicMac => EndOfLineOption::CR,
-    }
-  }
-}
-
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum EndOfLineOption {
   /// Windows
@@ -83,10 +72,12 @@ pub enum EndOfLineOption {
 
 impl Display for EndOfLineOption {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    use crate::defaults::ascii::end_of_line as eol;
+
     match self {
-      EndOfLineOption::CRLF => write!(f, "CRLF"),
-      EndOfLineOption::LF => write!(f, "LF"),
-      EndOfLineOption::CR => write!(f, "CR"),
+      EndOfLineOption::CRLF => write!(f, "{}", eol::CRLF),
+      EndOfLineOption::LF => write!(f, "{}", eol::LF),
+      EndOfLineOption::CR => write!(f, "{}", eol::CR),
     }
   }
 }
@@ -112,18 +103,6 @@ impl From<FileFormatOption> for EndOfLineOption {
       FileFormatOption::Unix => EndOfLineOption::LF,
       FileFormatOption::Mac => EndOfLineOption::LF,
       FileFormatOption::ClassicMac => EndOfLineOption::CR,
-    }
-  }
-}
-
-impl EndOfLineOption {
-  pub fn to_ascii_str(&self) -> &str {
-    use crate::defaults::ascii::end_of_line as eol;
-
-    match self {
-      EndOfLineOption::CRLF => eol::CRLF,
-      EndOfLineOption::LF => eol::LF,
-      EndOfLineOption::CR => eol::CR,
     }
   }
 }

--- a/rsvim_core/src/buf/opt/file_format.rs
+++ b/rsvim_core/src/buf/opt/file_format.rs
@@ -7,10 +7,19 @@ use std::string::ToString;
 pub enum FileFormatOption {
   /// CRLF (<CR><NL>)
   Dos,
+
   /// LF (<NL>)
   Unix,
-  /// CR (<CR>)
+
+  /// LF (<NL>)
+  ///
+  /// NOTE: CR (<CR>) is deprecated in macos.
   Mac,
+
+  /// CR (<CR>)
+  ///
+  /// NOTE: CR (<CR>) is deprecated in macos.
+  ClassicMac,
 }
 
 impl Display for FileFormatOption {
@@ -19,6 +28,7 @@ impl Display for FileFormatOption {
       FileFormatOption::Dos => write!(f, "dos"),
       FileFormatOption::Unix => write!(f, "unix"),
       FileFormatOption::Mac => write!(f, "mac"),
+      FileFormatOption::ClassicMac => write!(f, "classic_mac"),
     }
   }
 }
@@ -32,7 +42,65 @@ impl TryFrom<&str> for FileFormatOption {
       "dos" => Ok(FileFormatOption::Dos),
       "unix" => Ok(FileFormatOption::Unix),
       "mac" => Ok(FileFormatOption::Mac),
+      "classic_mac" => Ok(FileFormatOption::ClassicMac),
       _ => Err("Unknown FileFormat value".to_string()),
+    }
+  }
+}
+
+impl From<EndOfLineOption> for FileFormatOption {
+  fn from(value: EndOfLineOption) -> Self {
+    match value {
+      EndOfLineOption::CRLF => FileFormatOption::Dos,
+      EndOfLineOption::LF => FileFormatOption::Unix,
+      EndOfLineOption::CR => FileFormatOption::ClassicMac,
+    }
+  }
+}
+
+impl Into<EndOfLineOption> for FileFormatOption {
+  fn into(self) -> EndOfLineOption {
+    match self {
+      FileFormatOption::Dos => EndOfLineOption::CRLF,
+      FileFormatOption::Unix => EndOfLineOption::LF,
+      FileFormatOption::Mac => EndOfLineOption::LF,
+      FileFormatOption::ClassicMac => EndOfLineOption::CR,
+    }
+  }
+}
+
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum EndOfLineOption {
+  /// Windows
+  CRLF,
+
+  /// Unix
+  LF,
+
+  /// Classic Mac, not used today
+  CR,
+}
+
+impl Display for EndOfLineOption {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      EndOfLineOption::CRLF => write!(f, "CRLF"),
+      EndOfLineOption::LF => write!(f, "LF"),
+      EndOfLineOption::CR => write!(f, "CR"),
+    }
+  }
+}
+
+impl TryFrom<&str> for EndOfLineOption {
+  type Error = String;
+
+  fn try_from(value: &str) -> Result<Self, Self::Error> {
+    let lower_value = value.to_lowercase();
+    match lower_value.as_str() {
+      "CRLF" => Ok(EndOfLineOption::CRLF),
+      "LF" => Ok(EndOfLineOption::LF),
+      "CR" => Ok(EndOfLineOption::CR),
+      _ => Err("Unknown EndOfLine value".to_string()),
     }
   }
 }

--- a/rsvim_core/src/defaults/ascii.rs
+++ b/rsvim_core/src/defaults/ascii.rs
@@ -3,6 +3,8 @@
 use ascii::AsciiChar;
 use std::fmt;
 
+pub mod end_of_line;
+
 /// The formatter for ASCII control code in [`AsciiChar`], helps implement the `Debug`/`Display` trait.
 pub struct AsciiControlCodeFormatter {
   value: AsciiChar,

--- a/rsvim_core/src/defaults/ascii/end_of_line.rs
+++ b/rsvim_core/src/defaults/ascii/end_of_line.rs
@@ -1,0 +1,5 @@
+//! End of line.
+
+pub const CRLF: &str = "\r\n";
+pub const LF: &str = "\n";
+pub const CR: &str = "\r";

--- a/rsvim_core/src/defaults/buf.rs
+++ b/rsvim_core/src/defaults/buf.rs
@@ -16,4 +16,4 @@ pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Dos;
 pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Mac;
 
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Dos;
+pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Unix;

--- a/rsvim_core/src/defaults/buf.rs
+++ b/rsvim_core/src/defaults/buf.rs
@@ -3,7 +3,17 @@
 //! See: [`crate::buf::BufferLocalOptions`].
 
 use crate::buf::FileEncodingOption;
+use crate::buf::FileFormatOption;
 
 pub const TAB_STOP: u16 = 8;
 
 pub const FILE_ENCODING: FileEncodingOption = FileEncodingOption::Utf8;
+
+#[cfg(target_os = "windows")]
+pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Dos;
+
+#[cfg(target_os = "macos")]
+pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Mac;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Dos;

--- a/rsvim_core/src/defaults/buf.rs
+++ b/rsvim_core/src/defaults/buf.rs
@@ -12,8 +12,5 @@ pub const FILE_ENCODING: FileEncodingOption = FileEncodingOption::Utf8;
 #[cfg(target_os = "windows")]
 pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Dos;
 
-#[cfg(target_os = "macos")]
-pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Mac;
-
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(not(target_os = "windows"))]
 pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Unix;

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -135,8 +135,7 @@ impl InsertStateful {
           if cursor_line_idx == buffer.get_rope().len_lines().saturating_sub(1) {
             use crate::defaults::ascii::end_of_line as eol;
 
-            let buf_ff = buffer.options().file_format();
-            let buf_eol = EndOfLineOption::from(buf_ff);
+            let buf_eol = buffer.options().end_of_line();
             let bufline = buffer.get_rope().line(cursor_line_idx);
             let bufline_len_chars = bufline.len_chars();
 

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -129,20 +129,21 @@ impl InsertStateful {
             use crate::defaults::ascii::end_of_line as eol;
 
             let buf_ff = buffer.options().file_format();
+            let buf_eol = EndOfLineOption::from(buf_ff);
             let bufline = buffer.get_rope().line(cursor_line_idx);
             let bufline_len_chars = bufline.len_chars();
 
             if bufline_len_chars == 0 {
               buffer
                 .get_rope_mut()
-                .insert(0_usize, buf_ff.into().to_ascii_str());
+                .insert(0_usize, buf_eol.to_compact_string().as_str());
               buffer.remove_cached_line(cursor_line_idx);
             } else {
               let last1 = bufline.char(bufline_len_chars - 1);
-              if last1.to_string() != eol::CR || last1.to_string() != eol::LF {
+              if last1.to_compact_string() != eol::CR || last1.to_compact_string() != eol::LF {
                 buffer
                   .get_rope_mut()
-                  .insert(bufline_len_chars, buf_ff.into().to_ascii_str());
+                  .insert(bufline_len_chars, buf_eol.to_compact_string().as_str());
                 buffer.truncate_cached_line_since_char(
                   cursor_line_idx,
                   bufline_len_chars.saturating_sub(1),
@@ -152,7 +153,7 @@ impl InsertStateful {
                 if last2 != eol::CRLF {
                   buffer
                     .get_rope_mut()
-                    .insert(bufline_len_chars, buf_ff.into().to_ascii_str());
+                    .insert(bufline_len_chars, buf_eol.to_compact_string().as_str());
                   buffer.truncate_cached_line_since_char(
                     cursor_line_idx,
                     bufline_len_chars.saturating_sub(1),

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -1657,6 +1657,7 @@ mod tests_insert_text {
       assert_eq!(actual2.column_idx(), 1);
 
       let viewport = get_viewport(tree.clone());
+      let a = format!("a{}", lock!(buf.clone()).options().end_of_line());
       let expect = vec![
         "Hello, RSV",
         "This is a ",
@@ -1664,7 +1665,7 @@ mod tests_insert_text {
         "  1. When ",
         "  2. When ",
         "  3. Is th",
-        "a\n",
+        a.as_str(),
         "",
       ];
       let expect_fills: BTreeMap<usize, usize> = vec![
@@ -1706,7 +1707,6 @@ mod tests_insert_text {
     }
   }
 
-  #[cfg(not(target_os = "windows"))]
   #[test]
   fn nowrap3() {
     test_log_init();
@@ -2225,7 +2225,6 @@ mod tests_insert_text {
     }
   }
 
-  #[cfg(not(target_os = "windows"))]
   #[test]
   fn wrap_nolinebreak2() {
     test_log_init();
@@ -2291,7 +2290,6 @@ mod tests_insert_text {
     }
   }
 
-  #[cfg(not(target_os = "windows"))]
   #[test]
   fn wrap_nolinebreak3() {
     test_log_init();
@@ -2332,71 +2330,6 @@ mod tests_insert_text {
 
       let viewport = get_viewport(tree.clone());
       let expect = vec!["b\n", ""];
-      let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
-        buf.clone(),
-        &viewport,
-        &expect,
-        0,
-        2,
-        &expect_fills,
-        &expect_fills,
-      );
-
-      let expect_canvas = vec![
-        "b         ",
-        "          ",
-        "          ",
-        "          ",
-        "          ",
-        "          ",
-      ];
-      let actual_canvas = make_canvas(terminal_size, window_options, buf.clone(), viewport);
-      assert_canvas(&actual_canvas, &expect_canvas);
-    }
-  }
-
-  #[cfg(target_os = "windows")]
-  #[test]
-  fn wrap_nolinebreak3() {
-    test_log_init();
-
-    let terminal_size = U16Size::new(10, 6);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .line_break(false)
-      .build()
-      .unwrap();
-    let lines = vec![""];
-    let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
-
-    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
-    assert_eq!(prev_cursor_viewport.line_idx(), 0);
-    assert_eq!(prev_cursor_viewport.char_idx(), 0);
-
-    let key_event = KeyEvent::new_with_kind(
-      KeyCode::Char('a'),
-      KeyModifiers::empty(),
-      KeyEventKind::Press,
-    );
-    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
-    let stateful = InsertStateful::default();
-
-    // Insert-1
-    {
-      stateful.insert_text(
-        &data_access,
-        Operation::InsertLineWiseTextAtCursor(CompactString::new("b")),
-      );
-      let tree = data_access.tree.clone();
-      let actual1 = get_cursor_viewport(tree.clone());
-      assert_eq!(actual1.line_idx(), 0);
-      assert_eq!(actual1.char_idx(), 1);
-      assert_eq!(actual1.row_idx(), 0);
-      assert_eq!(actual1.column_idx(), 1);
-
-      let viewport = get_viewport(tree.clone());
-      let expect = vec!["b\r\n", ""];
       let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
       assert_viewport_scroll(
         buf.clone(),

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -1790,10 +1790,7 @@ mod tests_insert_text {
       assert_eq!(actual2.column_idx(), 1);
 
       let viewport = get_viewport(tree.clone());
-      let a = format!(
-        "a{}",
-        lock!(buf.clone()).options().end_of_line().to_string()
-      );
+      let a = format!("a{}", lock!(buf.clone()).options().end_of_line());
       let expect = vec![
         "But still ",
         "  1. When ",
@@ -2268,10 +2265,7 @@ mod tests_insert_text {
       assert_eq!(actual1.column_idx(), 1);
 
       let viewport = get_viewport(tree.clone());
-      let a = format!(
-        "a{}",
-        lock!(buf.clone()).options().end_of_line().to_string()
-      );
+      let a = format!("a{}", lock!(buf.clone()).options().end_of_line());
       let expect = vec![a.as_str(), ""];
       let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
       assert_viewport_scroll(

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -1829,9 +1829,9 @@ mod tests_insert_text {
 
     let terminal_size = U16Size::new(10, 5);
     let window_option = WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap();
+      .wrap(false)
+      .build()
+      .unwrap();
     let lines = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and small test lines.\n",
@@ -1868,8 +1868,8 @@ mod tests_insert_text {
       let viewport = get_viewport(tree.clone());
       let expect = vec!["But still ", "  1. When ", "  2. When ", "  3. Is th", ""];
       let expect_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
-          .into_iter()
-          .collect();
+        .into_iter()
+        .collect();
       assert_viewport_scroll(
         buf.clone(),
         &viewport,
@@ -1914,8 +1914,8 @@ mod tests_insert_text {
         "a\r\n",
       ];
       let expect_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
-          .into_iter()
-          .collect();
+        .into_iter()
+        .collect();
       assert_viewport_scroll(
         buf.clone(),
         &viewport,
@@ -2412,10 +2412,10 @@ mod tests_insert_text {
 
     let terminal_size = U16Size::new(10, 6);
     let window_options = WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .line_break(false)
-        .build()
-        .unwrap();
+      .wrap(true)
+      .line_break(false)
+      .build()
+      .unwrap();
     let lines = vec![];
     let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
 
@@ -2542,10 +2542,10 @@ mod tests_insert_text {
 
     let terminal_size = U16Size::new(10, 6);
     let window_options = WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .line_break(false)
-        .build()
-        .unwrap();
+      .wrap(true)
+      .line_break(false)
+      .build()
+      .unwrap();
     let lines = vec![""];
     let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
 

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -105,7 +105,7 @@ impl InsertStateful {
     let mut buffer = lock!(buffer);
 
     let dbg_print_details =
-      |dbg_buffer: &Buffer, dbg_line_idx: usize, dbg_char_idx: usize, msg: &str| -> () {
+      |dbg_buffer: &Buffer, dbg_line_idx: usize, dbg_char_idx: usize, msg: &str| {
         if cfg!(debug_assertions) {
           use crate::test::buf::{print_buffer, print_bufline_and_focus_char};
 
@@ -115,7 +115,7 @@ impl InsertStateful {
       };
 
     let dbg_print_details_on_line =
-      |dbg_buffer: &Buffer, dbg_line_idx: usize, dbg_char_idx: usize, msg: &str| -> () {
+      |dbg_buffer: &Buffer, dbg_line_idx: usize, dbg_char_idx: usize, msg: &str| {
         if cfg!(debug_assertions) {
           use crate::test::buf::{print_buffer, print_bufline_and_focus_char_on_line};
 

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -1,6 +1,6 @@
 //! The insert mode.
 
-use crate::buf::{Buffer, BufferWk, EndOfLineOption};
+use crate::buf::{Buffer, BufferWk};
 use crate::lock;
 use crate::state::fsm::{Stateful, StatefulDataAccess, StatefulValue};
 use crate::state::ops::Operation;

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -116,10 +116,34 @@ impl InsertStateful {
           let before_insert_char_idx = start_char_pos_of_line + cursor_char_idx;
           if cfg!(debug_assertions) {
             use crate::test::buf::bufline_to_string;
+
+            let b = before_insert_char_idx;
+            let b1 = before_insert_char_idx.saturating_sub(1);
+            let b2 = before_insert_char_idx.saturating_add(1);
             trace!(
-              "Before buffer inserted(line:{cursor_line_idx},char:{before_insert_char_idx}):{:?}",
-              bufline_to_string(&buffer.get_rope().line(cursor_line_idx))
+              "Before buffer inserted, cursor_line_idx:{cursor_line_idx},before_insert_char_idx({b}):{:?}, before({b1}):{:?}, after({b2}):{:?}",
+              buffer
+                .get_rope()
+                .get_char(b)
+                .map(|c| c.to_string())
+                .unwrap_or("null?".to_string()),
+              buffer
+                .get_rope()
+                .get_char(b1)
+                .map(|c| c.to_string())
+                .unwrap_or("null?".to_string()),
+              buffer
+                .get_rope()
+                .get_char(b2)
+                .map(|c| c.to_string())
+                .unwrap_or("null?".to_string()),
             );
+            for i in 0..buffer.get_rope().len_lines() {
+              trace!(
+                "line:{i}:{:?}",
+                bufline_to_string(&buffer.get_rope().line(i))
+              );
+            }
           }
 
           buffer
@@ -144,26 +168,125 @@ impl InsertStateful {
                 .get_rope_mut()
                 .insert(0_usize, buf_eol.to_compact_string().as_str());
               buffer.remove_cached_line(cursor_line_idx);
+
+              if cfg!(debug_assertions) {
+                use crate::test::buf::bufline_to_string;
+
+                let b = before_insert_char_idx;
+                let b1 = before_insert_char_idx.saturating_sub(1);
+                let b2 = before_insert_char_idx.saturating_add(1);
+                trace!(
+                  "Eol inserted (line=0), cursor_line_idx:{cursor_line_idx},before_insert_char_idx({b}):{:?}, before({b1}):{:?}, after({b2}):{:?}",
+                  buffer
+                    .get_rope()
+                    .get_char(b)
+                    .map(|c| c.to_string())
+                    .unwrap_or("null?".to_string()),
+                  buffer
+                    .get_rope()
+                    .get_char(b1)
+                    .map(|c| c.to_string())
+                    .unwrap_or("null?".to_string()),
+                  buffer
+                    .get_rope()
+                    .get_char(b2)
+                    .map(|c| c.to_string())
+                    .unwrap_or("null?".to_string()),
+                );
+                for i in 0..buffer.get_rope().len_lines() {
+                  trace!(
+                    "line:{i}:{:?}",
+                    bufline_to_string(&buffer.get_rope().line(i))
+                  );
+                }
+              }
             } else {
+              let bufline_start_char_pos = buffer.get_rope().line_to_char(cursor_line_idx);
+              let bufline_insert_char_pos = bufline_start_char_pos + bufline_len_chars;
+
               let last1 = bufline.char(bufline_len_chars - 1);
               if last1.to_compact_string() != eol::CR || last1.to_compact_string() != eol::LF {
-                buffer
-                  .get_rope_mut()
-                  .insert(bufline_len_chars, buf_eol.to_compact_string().as_str());
+                buffer.get_rope_mut().insert(
+                  bufline_insert_char_pos,
+                  buf_eol.to_compact_string().as_str(),
+                );
                 buffer.truncate_cached_line_since_char(
                   cursor_line_idx,
                   bufline_len_chars.saturating_sub(1),
                 );
+                if cfg!(debug_assertions) {
+                  use crate::test::buf::bufline_to_string;
+
+                  let b = before_insert_char_idx;
+                  let b1 = before_insert_char_idx.saturating_sub(1);
+                  let b2 = before_insert_char_idx.saturating_add(1);
+                  trace!(
+                    "Eol inserted (last=1), cursor_line_idx:{cursor_line_idx},before_insert_char_idx({b}):{:?}, before({b1}):{:?}, after({b2}):{:?}",
+                    buffer
+                      .get_rope()
+                      .get_char(b)
+                      .map(|c| c.to_string())
+                      .unwrap_or("null?".to_string()),
+                    buffer
+                      .get_rope()
+                      .get_char(b1)
+                      .map(|c| c.to_string())
+                      .unwrap_or("null?".to_string()),
+                    buffer
+                      .get_rope()
+                      .get_char(b2)
+                      .map(|c| c.to_string())
+                      .unwrap_or("null?".to_string()),
+                  );
+                  for i in 0..buffer.get_rope().len_lines() {
+                    trace!(
+                      "line:{i}:{:?}",
+                      bufline_to_string(&buffer.get_rope().line(i))
+                    );
+                  }
+                }
               } else if bufline_len_chars >= 2 {
                 let last2 = format!("{}{}", bufline.char(bufline_len_chars - 2), last1);
                 if last2 != eol::CRLF {
-                  buffer
-                    .get_rope_mut()
-                    .insert(bufline_len_chars, buf_eol.to_compact_string().as_str());
+                  buffer.get_rope_mut().insert(
+                    bufline_insert_char_pos,
+                    buf_eol.to_compact_string().as_str(),
+                  );
                   buffer.truncate_cached_line_since_char(
                     cursor_line_idx,
                     bufline_len_chars.saturating_sub(1),
                   );
+                  if cfg!(debug_assertions) {
+                    use crate::test::buf::bufline_to_string;
+
+                    let b = before_insert_char_idx;
+                    let b1 = before_insert_char_idx.saturating_sub(1);
+                    let b2 = before_insert_char_idx.saturating_add(1);
+                    trace!(
+                      "Eol inserted (last=2), cursor_line_idx:{cursor_line_idx},before_insert_char_idx({b}):{:?}, before({b1}):{:?}, after({b2}):{:?}",
+                      buffer
+                        .get_rope()
+                        .get_char(b)
+                        .map(|c| c.to_string())
+                        .unwrap_or("null?".to_string()),
+                      buffer
+                        .get_rope()
+                        .get_char(b1)
+                        .map(|c| c.to_string())
+                        .unwrap_or("null?".to_string()),
+                      buffer
+                        .get_rope()
+                        .get_char(b2)
+                        .map(|c| c.to_string())
+                        .unwrap_or("null?".to_string()),
+                    );
+                    for i in 0..buffer.get_rope().len_lines() {
+                      trace!(
+                        "line:{i}:{:?}",
+                        bufline_to_string(&buffer.get_rope().line(i))
+                      );
+                    }
+                  }
                 }
               }
             }
@@ -171,10 +294,36 @@ impl InsertStateful {
 
           if cfg!(debug_assertions) {
             use crate::test::buf::bufline_to_string;
-            trace!(
-              "After buffer inserted(line:{cursor_line_idx},char:{after_inserted_char_idx}):{:?}",
-              bufline_to_string(&buffer.get_rope().line(cursor_line_idx))
-            );
+
+            let a = after_inserted_char_idx;
+            let a1 = a.saturating_sub(1);
+            let a2 = a.saturating_add(1);
+            match buffer.get_rope().get_line(cursor_line_idx) {
+              Some(line) => trace!(
+                "After buffer inserted, cursor_line_idx:{cursor_line_idx},after_inserted_char_idx({a}):{:?}, before({a1}):{:?}, after({a2}):{:?}",
+                line
+                  .get_char(a)
+                  .map(|c| c.to_string())
+                  .unwrap_or("null-c?".to_string()),
+                line
+                  .get_char(a1)
+                  .map(|c| c.to_string())
+                  .unwrap_or("null-c?".to_string()),
+                line
+                  .get_char(a2)
+                  .map(|c| c.to_string())
+                  .unwrap_or("null-c?".to_string()),
+              ),
+              None => trace!(
+                "After buffer inserted, cursor_line_idx:{cursor_line_idx}:null-l,after_inserted_char_idx({a}), before({a1}), after({a2})"
+              ),
+            }
+            for i in 0..buffer.get_rope().len_lines() {
+              trace!(
+                "line:{i}:{:?}",
+                bufline_to_string(&buffer.get_rope().line(i))
+              );
+            }
           }
           (cursor_line_idx, after_inserted_char_idx)
         } else {
@@ -1516,6 +1665,267 @@ mod tests_insert_text {
   }
 
   #[test]
+  fn nowrap2() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(10, 10);
+    let window_option = WindowLocalOptionsBuilder::default()
+      .wrap(false)
+      .build()
+      .unwrap();
+    let lines = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside.\n",
+      "  2. When the line is too long to be completely put in.\n",
+      "  3. Is there any other cases?\n",
+    ];
+    let (tree, state, bufs, buf) = make_tree(terminal_size, window_option, lines);
+
+    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+    assert_eq!(prev_cursor_viewport.line_idx(), 0);
+    assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
+    let key_event = KeyEvent::new_with_kind(
+      KeyCode::Char('a'),
+      KeyModifiers::empty(),
+      KeyEventKind::Press,
+    );
+    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
+    let stateful = InsertStateful::default();
+
+    // Move-1
+    {
+      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(6));
+
+      let tree = data_access.tree.clone();
+      let actual1 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual1.line_idx(), 6);
+      assert_eq!(actual1.char_idx(), 0);
+      assert_eq!(actual1.row_idx(), 6);
+      assert_eq!(actual1.column_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "Hello, RSV",
+        "This is a ",
+        "But still ",
+        "  1. When ",
+        "  2. When ",
+        "  3. Is th",
+        "",
+      ];
+      let expect_fills: BTreeMap<usize, usize> =
+        vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
+          .into_iter()
+          .collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        0,
+        7,
+        &expect_fills,
+        &expect_fills,
+      );
+
+      let expect_canvas = vec![
+        "Hello, RSV",
+        "This is a ",
+        "But still ",
+        "  1. When ",
+        "  2. When ",
+        "  3. Is th",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+      ];
+      let actual_canvas = make_canvas(terminal_size, window_option, buf.clone(), viewport);
+      assert_canvas(&actual_canvas, &expect_canvas);
+    }
+
+    // Insert-2
+    {
+      stateful.insert_text(
+        &data_access,
+        Operation::InsertLineWiseTextAtCursor(CompactString::new("a")),
+      );
+
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 6);
+      assert_eq!(actual2.char_idx(), 1);
+      assert_eq!(actual2.row_idx(), 6);
+      assert_eq!(actual2.column_idx(), 1);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "Hello, RSV",
+        "This is a ",
+        "But still ",
+        "  1. When ",
+        "  2. When ",
+        "  3. Is th",
+        "a\n",
+        "",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![
+        (0, 0),
+        (1, 0),
+        (2, 0),
+        (3, 0),
+        (4, 0),
+        (5, 0),
+        (6, 0),
+        (7, 0),
+      ]
+      .into_iter()
+      .collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        0,
+        8,
+        &expect_fills,
+        &expect_fills,
+      );
+
+      let expect_canvas = vec![
+        "Hello, RSV",
+        "This is a ",
+        "But still ",
+        "  1. When ",
+        "  2. When ",
+        "  3. Is th",
+        "a         ",
+        "          ",
+        "          ",
+        "          ",
+      ];
+      let actual_canvas = make_canvas(terminal_size, window_option, buf.clone(), viewport);
+      assert_canvas(&actual_canvas, &expect_canvas);
+    }
+  }
+
+  #[test]
+  fn nowrap3() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(10, 5);
+    let window_option = WindowLocalOptionsBuilder::default()
+      .wrap(false)
+      .build()
+      .unwrap();
+    let lines = vec![
+      "Hello, RSVIM!\n",
+      "This is a quite simple and small test lines.\n",
+      "But still it contains several things we want to test:\n",
+      "  1. When the line is small enough to completely put inside.\n",
+      "  2. When the line is too long to be completely put in.\n",
+      "  3. Is there any other cases?\n",
+    ];
+    let (tree, state, bufs, buf) = make_tree(terminal_size, window_option, lines);
+
+    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+    assert_eq!(prev_cursor_viewport.line_idx(), 0);
+    assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
+    let key_event = KeyEvent::new_with_kind(
+      KeyCode::Char('a'),
+      KeyModifiers::empty(),
+      KeyEventKind::Press,
+    );
+    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
+    let stateful = InsertStateful::default();
+
+    // Move-1
+    {
+      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(6));
+
+      let tree = data_access.tree.clone();
+      let actual1 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual1.line_idx(), 6);
+      assert_eq!(actual1.char_idx(), 0);
+      assert_eq!(actual1.row_idx(), 4);
+      assert_eq!(actual1.column_idx(), 0);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec!["But still ", "  1. When ", "  2. When ", "  3. Is th", ""];
+      let expect_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        2,
+        7,
+        &expect_fills,
+        &expect_fills,
+      );
+
+      let expect_canvas = vec![
+        "But still ",
+        "  1. When ",
+        "  2. When ",
+        "  3. Is th",
+        "          ",
+      ];
+      let actual_canvas = make_canvas(terminal_size, window_option, buf.clone(), viewport);
+      assert_canvas(&actual_canvas, &expect_canvas);
+    }
+
+    // Insert-2
+    {
+      stateful.insert_text(
+        &data_access,
+        Operation::InsertLineWiseTextAtCursor(CompactString::new("a")),
+      );
+
+      let tree = data_access.tree.clone();
+      let actual2 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual2.line_idx(), 6);
+      assert_eq!(actual2.char_idx(), 1);
+      assert_eq!(actual2.row_idx(), 4);
+      assert_eq!(actual2.column_idx(), 1);
+
+      let viewport = get_viewport(tree.clone());
+      let expect = vec![
+        "But still ",
+        "  1. When ",
+        "  2. When ",
+        "  3. Is th",
+        "a\n",
+      ];
+      let expect_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
+        .into_iter()
+        .collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        2,
+        7,
+        &expect_fills,
+        &expect_fills,
+      );
+
+      let expect_canvas = vec![
+        "But still ",
+        "  1. When ",
+        "  2. When ",
+        "  3. Is th",
+        "a         ",
+      ];
+      let actual_canvas = make_canvas(terminal_size, window_option, buf.clone(), viewport);
+      assert_canvas(&actual_canvas, &expect_canvas);
+    }
+  }
+
+  #[test]
   fn wrap_nolinebreak1() {
     test_log_init();
 
@@ -1921,128 +2331,127 @@ mod tests_insert_text {
   fn wrap_nolinebreak2() {
     test_log_init();
 
-    // Case-1
+    let terminal_size = U16Size::new(10, 6);
+    let window_options = WindowLocalOptionsBuilder::default()
+      .wrap(true)
+      .line_break(false)
+      .build()
+      .unwrap();
+    let lines = vec![];
+    let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
+
+    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+    assert_eq!(prev_cursor_viewport.line_idx(), 0);
+    assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
+    let key_event = KeyEvent::new_with_kind(
+      KeyCode::Char('a'),
+      KeyModifiers::empty(),
+      KeyEventKind::Press,
+    );
+    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
+    let stateful = InsertStateful::default();
+
+    // Insert-1
     {
-      let terminal_size = U16Size::new(10, 6);
-      let window_options = WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .line_break(false)
-        .build()
-        .unwrap();
-      let lines = vec![];
-      let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
-
-      let prev_cursor_viewport = get_cursor_viewport(tree.clone());
-      assert_eq!(prev_cursor_viewport.line_idx(), 0);
-      assert_eq!(prev_cursor_viewport.char_idx(), 0);
-
-      let key_event = KeyEvent::new_with_kind(
-        KeyCode::Char('a'),
-        KeyModifiers::empty(),
-        KeyEventKind::Press,
+      stateful.insert_text(
+        &data_access,
+        Operation::InsertLineWiseTextAtCursor(CompactString::new("a")),
       );
-      let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
-      let stateful = InsertStateful::default();
+      let tree = data_access.tree.clone();
+      let actual1 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual1.line_idx(), 0);
+      assert_eq!(actual1.char_idx(), 1);
+      assert_eq!(actual1.row_idx(), 0);
+      assert_eq!(actual1.column_idx(), 1);
 
-      // Insert-1
-      {
-        stateful.insert_text(
-          &data_access,
-          Operation::InsertLineWiseTextAtCursor(CompactString::new("a")),
-        );
-        let tree = data_access.tree.clone();
-        let actual1 = get_cursor_viewport(tree.clone());
-        assert_eq!(actual1.line_idx(), 0);
-        assert_eq!(actual1.char_idx(), 1);
-        assert_eq!(actual1.row_idx(), 0);
-        assert_eq!(actual1.column_idx(), 1);
+      let viewport = get_viewport(tree.clone());
+      let expect = vec!["a\n", ""];
+      let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        0,
+        2,
+        &expect_fills,
+        &expect_fills,
+      );
 
-        let viewport = get_viewport(tree.clone());
-        let expect = vec!["a\n", ""];
-        let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
-        assert_viewport_scroll(
-          buf.clone(),
-          &viewport,
-          &expect,
-          0,
-          2,
-          &expect_fills,
-          &expect_fills,
-        );
-
-        let expect_canvas = vec![
-          "a         ",
-          "          ",
-          "          ",
-          "          ",
-          "          ",
-          "          ",
-        ];
-        let actual_canvas = make_canvas(terminal_size, window_options, buf.clone(), viewport);
-        assert_canvas(&actual_canvas, &expect_canvas);
-      }
+      let expect_canvas = vec![
+        "a         ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+      ];
+      let actual_canvas = make_canvas(terminal_size, window_options, buf.clone(), viewport);
+      assert_canvas(&actual_canvas, &expect_canvas);
     }
+  }
 
-    // Case-2
+  #[test]
+  fn wrap_nolinebreak3() {
+    test_log_init();
+
+    let terminal_size = U16Size::new(10, 6);
+    let window_options = WindowLocalOptionsBuilder::default()
+      .wrap(true)
+      .line_break(false)
+      .build()
+      .unwrap();
+    let lines = vec![""];
+    let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
+
+    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+    assert_eq!(prev_cursor_viewport.line_idx(), 0);
+    assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
+    let key_event = KeyEvent::new_with_kind(
+      KeyCode::Char('a'),
+      KeyModifiers::empty(),
+      KeyEventKind::Press,
+    );
+    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
+    let stateful = InsertStateful::default();
+
+    // Insert-1
     {
-      let terminal_size = U16Size::new(10, 6);
-      let window_options = WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .line_break(false)
-        .build()
-        .unwrap();
-      let lines = vec![""];
-      let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
-
-      let prev_cursor_viewport = get_cursor_viewport(tree.clone());
-      assert_eq!(prev_cursor_viewport.line_idx(), 0);
-      assert_eq!(prev_cursor_viewport.char_idx(), 0);
-
-      let key_event = KeyEvent::new_with_kind(
-        KeyCode::Char('a'),
-        KeyModifiers::empty(),
-        KeyEventKind::Press,
+      stateful.insert_text(
+        &data_access,
+        Operation::InsertLineWiseTextAtCursor(CompactString::new("b")),
       );
-      let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
-      let stateful = InsertStateful::default();
+      let tree = data_access.tree.clone();
+      let actual1 = get_cursor_viewport(tree.clone());
+      assert_eq!(actual1.line_idx(), 0);
+      assert_eq!(actual1.char_idx(), 1);
+      assert_eq!(actual1.row_idx(), 0);
+      assert_eq!(actual1.column_idx(), 1);
 
-      // Insert-1
-      {
-        stateful.insert_text(
-          &data_access,
-          Operation::InsertLineWiseTextAtCursor(CompactString::new("b")),
-        );
-        let tree = data_access.tree.clone();
-        let actual1 = get_cursor_viewport(tree.clone());
-        assert_eq!(actual1.line_idx(), 0);
-        assert_eq!(actual1.char_idx(), 1);
-        assert_eq!(actual1.row_idx(), 0);
-        assert_eq!(actual1.column_idx(), 1);
+      let viewport = get_viewport(tree.clone());
+      let expect = vec!["b\n", ""];
+      let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
+      assert_viewport_scroll(
+        buf.clone(),
+        &viewport,
+        &expect,
+        0,
+        2,
+        &expect_fills,
+        &expect_fills,
+      );
 
-        let viewport = get_viewport(tree.clone());
-        let expect = vec!["b\n", ""];
-        let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
-        assert_viewport_scroll(
-          buf.clone(),
-          &viewport,
-          &expect,
-          0,
-          2,
-          &expect_fills,
-          &expect_fills,
-        );
-
-        let expect_canvas = vec![
-          "b         ",
-          "          ",
-          "          ",
-          "          ",
-          "          ",
-          "          ",
-        ];
-        let actual_canvas = make_canvas(terminal_size, window_options, buf.clone(), viewport);
-        assert_canvas(&actual_canvas, &expect_canvas);
-      }
+      let expect_canvas = vec![
+        "b         ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+      ];
+      let actual_canvas = make_canvas(terminal_size, window_options, buf.clone(), viewport);
+      assert_canvas(&actual_canvas, &expect_canvas);
     }
   }
 

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -122,16 +122,19 @@ impl InsertStateful {
             );
           }
 
+          // For text mode (different from the 'binary' mode, i.e. bin/hex mode), the editor have
+          // to always keep an eol (end-of-line) at the end of text file. It helps the cursor
+          // motion.
+          if cursor_line_idx == buffer.get_rope().len_lines().saturating_sub(1) {
+            // if buffer
+          }
+
           buffer
             .get_rope_mut()
             .insert(before_insert_char_idx, text.as_str());
           buffer
             .truncate_cached_line_since_char(cursor_line_idx, cursor_char_idx.saturating_sub(1));
           let after_inserted_char_idx = cursor_char_idx + text.len();
-
-          // For text mode (different from the 'binary' mode, i.e. bin/hex mode), the editor have
-          // to always keep an eol (end-of-line) at the end of text file. It helps the cursor
-          // motion.
 
           if cfg!(debug_assertions) {
             use crate::test::buf::bufline_to_string;

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -121,12 +121,18 @@ impl InsertStateful {
               bufline_to_string(&buffer.get_rope().line(cursor_line_idx))
             );
           }
+
           buffer
             .get_rope_mut()
             .insert(before_insert_char_idx, text.as_str());
           buffer
             .truncate_cached_line_since_char(cursor_line_idx, cursor_char_idx.saturating_sub(1));
           let after_inserted_char_idx = cursor_char_idx + text.len();
+
+          // For text mode (different from the 'binary' mode, i.e. bin/hex mode), the editor have
+          // to always keep an eol (end-of-line) at the end of text file. It helps the cursor
+          // motion.
+
           if cfg!(debug_assertions) {
             use crate::test::buf::bufline_to_string;
             trace!(

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -2329,7 +2329,8 @@ mod tests_insert_text {
       assert_eq!(actual1.column_idx(), 1);
 
       let viewport = get_viewport(tree.clone());
-      let expect = vec!["b\n", ""];
+      let b = format!("b{}", lock!(buf.clone()).options().end_of_line());
+      let expect = vec![b.as_str(), ""];
       let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
       assert_viewport_scroll(
         buf.clone(),

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -1790,128 +1790,16 @@ mod tests_insert_text {
       assert_eq!(actual2.column_idx(), 1);
 
       let viewport = get_viewport(tree.clone());
+      let a = format!(
+        "a{}",
+        lock!(buf.clone()).options().end_of_line().to_string()
+      );
       let expect = vec![
         "But still ",
         "  1. When ",
         "  2. When ",
         "  3. Is th",
-        "a\n",
-      ];
-      let expect_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport_scroll(
-        buf.clone(),
-        &viewport,
-        &expect,
-        2,
-        7,
-        &expect_fills,
-        &expect_fills,
-      );
-
-      let expect_canvas = vec![
-        "But still ",
-        "  1. When ",
-        "  2. When ",
-        "  3. Is th",
-        "a         ",
-      ];
-      let actual_canvas = make_canvas(terminal_size, window_option, buf.clone(), viewport);
-      assert_canvas(&actual_canvas, &expect_canvas);
-    }
-  }
-
-  #[cfg(target_os = "windows")]
-  #[test]
-  fn nowrap3_win() {
-    test_log_init();
-
-    let terminal_size = U16Size::new(10, 5);
-    let window_option = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
-    let lines = vec![
-      "Hello, RSVIM!\n",
-      "This is a quite simple and small test lines.\n",
-      "But still it contains several things we want to test:\n",
-      "  1. When the line is small enough to completely put inside.\n",
-      "  2. When the line is too long to be completely put in.\n",
-      "  3. Is there any other cases?\n",
-    ];
-    let (tree, state, bufs, buf) = make_tree(terminal_size, window_option, lines);
-
-    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
-    assert_eq!(prev_cursor_viewport.line_idx(), 0);
-    assert_eq!(prev_cursor_viewport.char_idx(), 0);
-
-    let key_event = KeyEvent::new_with_kind(
-      KeyCode::Char('a'),
-      KeyModifiers::empty(),
-      KeyEventKind::Press,
-    );
-    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
-    let stateful = InsertStateful::default();
-
-    // Move-1
-    {
-      stateful.cursor_move(&data_access, Operation::CursorMoveDownBy(6));
-
-      let tree = data_access.tree.clone();
-      let actual1 = get_cursor_viewport(tree.clone());
-      assert_eq!(actual1.line_idx(), 6);
-      assert_eq!(actual1.char_idx(), 0);
-      assert_eq!(actual1.row_idx(), 4);
-      assert_eq!(actual1.column_idx(), 0);
-
-      let viewport = get_viewport(tree.clone());
-      let expect = vec!["But still ", "  1. When ", "  2. When ", "  3. Is th", ""];
-      let expect_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
-        .into_iter()
-        .collect();
-      assert_viewport_scroll(
-        buf.clone(),
-        &viewport,
-        &expect,
-        2,
-        7,
-        &expect_fills,
-        &expect_fills,
-      );
-
-      let expect_canvas = vec![
-        "But still ",
-        "  1. When ",
-        "  2. When ",
-        "  3. Is th",
-        "          ",
-      ];
-      let actual_canvas = make_canvas(terminal_size, window_option, buf.clone(), viewport);
-      assert_canvas(&actual_canvas, &expect_canvas);
-    }
-
-    // Insert-2
-    {
-      stateful.insert_text(
-        &data_access,
-        Operation::InsertLineWiseTextAtCursor(CompactString::new("a")),
-      );
-
-      let tree = data_access.tree.clone();
-      let actual2 = get_cursor_viewport(tree.clone());
-      assert_eq!(actual2.line_idx(), 6);
-      assert_eq!(actual2.char_idx(), 1);
-      assert_eq!(actual2.row_idx(), 4);
-      assert_eq!(actual2.column_idx(), 1);
-
-      let viewport = get_viewport(tree.clone());
-      let expect = vec![
-        "But still ",
-        "  1. When ",
-        "  2. When ",
-        "  3. Is th",
-        "a\r\n",
+        a.as_str(),
       ];
       let expect_fills: BTreeMap<usize, usize> = vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
         .into_iter()
@@ -2380,72 +2268,11 @@ mod tests_insert_text {
       assert_eq!(actual1.column_idx(), 1);
 
       let viewport = get_viewport(tree.clone());
-      let expect = vec!["a\n", ""];
-      let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
-        buf.clone(),
-        &viewport,
-        &expect,
-        0,
-        2,
-        &expect_fills,
-        &expect_fills,
+      let a = format!(
+        "a{}",
+        lock!(buf.clone()).options().end_of_line().to_string()
       );
-
-      let expect_canvas = vec![
-        "a         ",
-        "          ",
-        "          ",
-        "          ",
-        "          ",
-        "          ",
-      ];
-      let actual_canvas = make_canvas(terminal_size, window_options, buf.clone(), viewport);
-      assert_canvas(&actual_canvas, &expect_canvas);
-    }
-  }
-
-  #[cfg(target_os = "windows")]
-  #[test]
-  fn wrap_nolinebreak2_win() {
-    test_log_init();
-
-    let terminal_size = U16Size::new(10, 6);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .line_break(false)
-      .build()
-      .unwrap();
-    let lines = vec![];
-    let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
-
-    let prev_cursor_viewport = get_cursor_viewport(tree.clone());
-    assert_eq!(prev_cursor_viewport.line_idx(), 0);
-    assert_eq!(prev_cursor_viewport.char_idx(), 0);
-
-    let key_event = KeyEvent::new_with_kind(
-      KeyCode::Char('a'),
-      KeyModifiers::empty(),
-      KeyEventKind::Press,
-    );
-    let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
-    let stateful = InsertStateful::default();
-
-    // Insert-1
-    {
-      stateful.insert_text(
-        &data_access,
-        Operation::InsertLineWiseTextAtCursor(CompactString::new("a")),
-      );
-      let tree = data_access.tree.clone();
-      let actual1 = get_cursor_viewport(tree.clone());
-      assert_eq!(actual1.line_idx(), 0);
-      assert_eq!(actual1.char_idx(), 1);
-      assert_eq!(actual1.row_idx(), 0);
-      assert_eq!(actual1.column_idx(), 1);
-
-      let viewport = get_viewport(tree.clone());
-      let expect = vec!["a\r\n", ""];
+      let expect = vec![a.as_str(), ""];
       let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
       assert_viewport_scroll(
         buf.clone(),

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -122,6 +122,13 @@ impl InsertStateful {
             );
           }
 
+          buffer
+            .get_rope_mut()
+            .insert(before_insert_char_idx, text.as_str());
+          buffer
+            .truncate_cached_line_since_char(cursor_line_idx, cursor_char_idx.saturating_sub(1));
+          let after_inserted_char_idx = cursor_char_idx + text.len();
+
           // For text mode (different from the 'binary' mode, i.e. bin/hex mode), the editor have
           // to always keep an eol (end-of-line) at the end of text file. It helps the cursor
           // motion.
@@ -162,13 +169,6 @@ impl InsertStateful {
               }
             }
           }
-
-          buffer
-            .get_rope_mut()
-            .insert(before_insert_char_idx, text.as_str());
-          buffer
-            .truncate_cached_line_since_char(cursor_line_idx, cursor_char_idx.saturating_sub(1));
-          let after_inserted_char_idx = cursor_char_idx + text.len();
 
           if cfg!(debug_assertions) {
             use crate::test::buf::bufline_to_string;

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -1919,6 +1919,135 @@ mod tests_insert_text {
   }
 
   #[test]
+  fn wrap_nolinebreak2() {
+    test_log_init();
+
+    // Case-1
+    {
+      let terminal_size = U16Size::new(10, 6);
+      let window_options = WindowLocalOptionsBuilder::default()
+        .wrap(true)
+        .line_break(false)
+        .build()
+        .unwrap();
+      let lines = vec![];
+      let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
+
+      let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+      assert_eq!(prev_cursor_viewport.line_idx(), 0);
+      assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
+      let key_event = KeyEvent::new_with_kind(
+        KeyCode::Char('a'),
+        KeyModifiers::empty(),
+        KeyEventKind::Press,
+      );
+      let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
+      let stateful = InsertStateful::default();
+
+      // Insert-1
+      {
+        stateful.insert_text(
+          &data_access,
+          Operation::InsertLineWiseTextAtCursor(CompactString::new("a")),
+        );
+        let tree = data_access.tree.clone();
+        let actual1 = get_cursor_viewport(tree.clone());
+        assert_eq!(actual1.line_idx(), 0);
+        assert_eq!(actual1.char_idx(), 1);
+        assert_eq!(actual1.row_idx(), 0);
+        assert_eq!(actual1.column_idx(), 1);
+
+        let viewport = get_viewport(tree.clone());
+        let expect = vec!["a\n", ""];
+        let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
+        assert_viewport_scroll(
+          buf.clone(),
+          &viewport,
+          &expect,
+          0,
+          2,
+          &expect_fills,
+          &expect_fills,
+        );
+
+        let expect_canvas = vec![
+          "a         ",
+          "          ",
+          "          ",
+          "          ",
+          "          ",
+          "          ",
+        ];
+        let actual_canvas = make_canvas(terminal_size, window_options, buf.clone(), viewport);
+        assert_canvas(&actual_canvas, &expect_canvas);
+      }
+    }
+
+    // Case-2
+    {
+      let terminal_size = U16Size::new(10, 6);
+      let window_options = WindowLocalOptionsBuilder::default()
+        .wrap(true)
+        .line_break(false)
+        .build()
+        .unwrap();
+      let lines = vec![""];
+      let (tree, state, bufs, buf) = make_tree(terminal_size, window_options, lines);
+
+      let prev_cursor_viewport = get_cursor_viewport(tree.clone());
+      assert_eq!(prev_cursor_viewport.line_idx(), 0);
+      assert_eq!(prev_cursor_viewport.char_idx(), 0);
+
+      let key_event = KeyEvent::new_with_kind(
+        KeyCode::Char('a'),
+        KeyModifiers::empty(),
+        KeyEventKind::Press,
+      );
+      let data_access = StatefulDataAccess::new(state, tree.clone(), bufs, Event::Key(key_event));
+      let stateful = InsertStateful::default();
+
+      // Insert-1
+      {
+        stateful.insert_text(
+          &data_access,
+          Operation::InsertLineWiseTextAtCursor(CompactString::new("b")),
+        );
+        let tree = data_access.tree.clone();
+        let actual1 = get_cursor_viewport(tree.clone());
+        assert_eq!(actual1.line_idx(), 0);
+        assert_eq!(actual1.char_idx(), 1);
+        assert_eq!(actual1.row_idx(), 0);
+        assert_eq!(actual1.column_idx(), 1);
+
+        let viewport = get_viewport(tree.clone());
+        let expect = vec!["b\n", ""];
+        let expect_fills: BTreeMap<usize, usize> = vec![(0, 0), (1, 0)].into_iter().collect();
+        assert_viewport_scroll(
+          buf.clone(),
+          &viewport,
+          &expect,
+          0,
+          2,
+          &expect_fills,
+          &expect_fills,
+        );
+
+        let expect_canvas = vec![
+          "b         ",
+          "          ",
+          "          ",
+          "          ",
+          "          ",
+          "          ",
+        ];
+        let actual_canvas = make_canvas(terminal_size, window_options, buf.clone(), viewport);
+        assert_canvas(&actual_canvas, &expect_canvas);
+      }
+    }
+  }
+
+  #[test]
   fn wrap_linebreak1() {
     test_log_init();
 

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -104,7 +104,7 @@ impl InsertStateful {
     let buffer = buffer.upgrade().unwrap();
     let mut buffer = lock!(buffer);
 
-    let dbg_print_details =
+    let _dbg_print_details =
       |dbg_buffer: &Buffer, dbg_line_idx: usize, dbg_char_idx: usize, msg: &str| {
         if cfg!(debug_assertions) {
           use crate::test::buf::{print_buffer, print_bufline_and_focus_char};
@@ -114,7 +114,7 @@ impl InsertStateful {
         }
       };
 
-    let dbg_print_details_on_line =
+    let _dbg_print_details_on_line =
       |dbg_buffer: &Buffer, dbg_line_idx: usize, dbg_char_idx: usize, msg: &str| {
         if cfg!(debug_assertions) {
           use crate::test::buf::{print_buffer, print_bufline_and_focus_char_on_line};
@@ -135,7 +135,7 @@ impl InsertStateful {
           let start_char_pos_of_line = buffer.get_rope().line_to_char(cursor_line_idx);
           let before_insert_char_idx = start_char_pos_of_line + cursor_char_idx;
 
-          dbg_print_details(
+          _dbg_print_details(
             &buffer,
             cursor_line_idx,
             before_insert_char_idx,
@@ -165,7 +165,7 @@ impl InsertStateful {
                 .insert(0_usize, buf_eol.to_compact_string().as_str());
               buffer.remove_cached_line(cursor_line_idx);
 
-              dbg_print_details(
+              _dbg_print_details(
                 &buffer,
                 cursor_line_idx,
                 before_insert_char_idx,
@@ -186,7 +186,7 @@ impl InsertStateful {
                   bufline_len_chars.saturating_sub(1),
                 );
 
-                dbg_print_details(
+                _dbg_print_details(
                   &buffer,
                   cursor_line_idx,
                   before_insert_char_idx,
@@ -203,7 +203,7 @@ impl InsertStateful {
                     cursor_line_idx,
                     bufline_len_chars.saturating_sub(1),
                   );
-                  dbg_print_details(
+                  _dbg_print_details(
                     &buffer,
                     cursor_line_idx,
                     before_insert_char_idx,
@@ -214,7 +214,7 @@ impl InsertStateful {
             }
           }
 
-          dbg_print_details_on_line(
+          _dbg_print_details_on_line(
             &buffer,
             cursor_line_idx,
             after_inserted_char_idx,

--- a/rsvim_core/src/test/buf.rs
+++ b/rsvim_core/src/test/buf.rs
@@ -243,9 +243,7 @@ pub fn print_bufline_and_focus_char_on_line(
         if w > 0 {
           builder1.push(c);
         }
-        let s: String = std::iter::repeat(if i == char_idx { '^' } else { ' ' })
-          .take(w)
-          .collect();
+        let s: String = std::iter::repeat_n(if i == char_idx { '^' } else { ' ' }, w).collect();
         builder2.push_str(s.as_str());
       }
       trace!("-{}-", builder1);
@@ -277,12 +275,14 @@ pub fn print_bufline_and_focus_char(buffer: &Buffer, line_idx: usize, char_idx: 
         if w > 0 {
           builder1.push(c);
         }
-        let s: String = std::iter::repeat(if i + start_char_on_line == char_idx {
-          '^'
-        } else {
-          ' '
-        })
-        .take(w)
+        let s: String = std::iter::repeat_n(
+          if i + start_char_on_line == char_idx {
+            '^'
+          } else {
+            ' '
+          },
+          w,
+        )
         .collect();
         builder2.push_str(s.as_str());
       }

--- a/rsvim_core/src/test/buf.rs
+++ b/rsvim_core/src/test/buf.rs
@@ -10,7 +10,7 @@ use ropey::{Rope, RopeBuilder, RopeSlice};
 use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::BufReader;
-use tracing::{self, info};
+use tracing::{self, info, trace};
 use tracing_appender::non_blocking::DEFAULT_BUFFERED_LINES_LIMIT;
 
 /// Create rope from filename.
@@ -215,9 +215,9 @@ pub fn bufline_to_string(bufline: &RopeSlice) -> String {
 }
 
 pub fn print_buffer(buf: &Buffer, msg: &str) {
-  info!("{} whole buffer:", msg);
+  trace!("{} whole buffer:", msg);
   for i in 0..buf.get_rope().len_lines() {
-    info!("{i}:{:?}", bufline_to_string(&buf.get_rope().line(i)));
+    trace!("{i}:{:?}", bufline_to_string(&buf.get_rope().line(i)));
   }
 }
 
@@ -229,7 +229,7 @@ pub fn print_bufline_and_focus_char_on_line(
 ) {
   match buffer.get_rope().get_line(line_idx) {
     Some(bufline) => {
-      info!(
+      trace!(
         "{} line:{}, len_chars:{}, focus char:{}",
         msg,
         line_idx,
@@ -248,10 +248,10 @@ pub fn print_bufline_and_focus_char_on_line(
           .collect();
         builder2.push_str(s.as_str());
       }
-      info!("-{}-", builder1);
-      info!("-{}-", builder2);
+      trace!("-{}-", builder1);
+      trace!("-{}-", builder2);
     }
-    None => info!(
+    None => trace!(
       "{} line:{}, focus char:{}, not exist",
       msg, line_idx, char_idx
     ),
@@ -261,7 +261,7 @@ pub fn print_bufline_and_focus_char_on_line(
 pub fn print_bufline_and_focus_char(buffer: &Buffer, line_idx: usize, char_idx: usize, msg: &str) {
   match buffer.get_rope().get_line(line_idx) {
     Some(bufline) => {
-      info!(
+      trace!(
         "{} line:{}, len_chars:{}, focus char:{}",
         msg,
         line_idx,
@@ -286,10 +286,10 @@ pub fn print_bufline_and_focus_char(buffer: &Buffer, line_idx: usize, char_idx: 
         .collect();
         builder2.push_str(s.as_str());
       }
-      info!("-{}-", builder1);
-      info!("-{}-", builder2);
+      trace!("-{}-", builder1);
+      trace!("-{}-", builder2);
     }
-    None => info!(
+    None => trace!(
       "{} line:{}, focus char:{}, not exist",
       msg, line_idx, char_idx
     ),

--- a/rsvim_core/src/test/buf.rs
+++ b/rsvim_core/src/test/buf.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::BufReader;
 use tracing::{self, info};
+use tracing_appender::non_blocking::DEFAULT_BUFFERED_LINES_LIMIT;
 
 /// Create rope from filename.
 pub fn make_rope_from_file(filename: String) -> Rope {
@@ -211,4 +212,86 @@ pub fn bufline_to_string(bufline: &RopeSlice) -> String {
     builder.push(c);
   }
   builder
+}
+
+pub fn print_buffer(buf: &Buffer, msg: &str) {
+  info!("{} whole buffer:", msg);
+  for i in 0..buf.get_rope().len_lines() {
+    info!("{i}:{:?}", bufline_to_string(&buf.get_rope().line(i)));
+  }
+}
+
+pub fn print_bufline_and_focus_char_on_line(
+  buffer: &Buffer,
+  line_idx: usize,
+  char_idx: usize,
+  msg: &str,
+) {
+  match buffer.get_rope().get_line(line_idx) {
+    Some(bufline) => {
+      info!(
+        "{} line:{}, len_chars:{}, focus char:{}",
+        msg,
+        line_idx,
+        bufline.len_chars(),
+        char_idx
+      );
+      let mut builder1 = String::new();
+      let mut builder2 = String::new();
+      for (i, c) in bufline.chars().enumerate() {
+        let w = buffer.char_width(c);
+        if w > 0 {
+          builder1.push(c);
+        }
+        let s: String = std::iter::repeat(if i == char_idx { '^' } else { ' ' })
+          .take(w)
+          .collect();
+        builder2.push_str(s.as_str());
+      }
+      info!("-{}-", builder1);
+      info!("-{}-", builder2);
+    }
+    None => info!(
+      "{} line:{}, focus char:{}, not exist",
+      msg, line_idx, char_idx
+    ),
+  }
+}
+
+pub fn print_bufline_and_focus_char(buffer: &Buffer, line_idx: usize, char_idx: usize, msg: &str) {
+  match buffer.get_rope().get_line(line_idx) {
+    Some(bufline) => {
+      info!(
+        "{} line:{}, len_chars:{}, focus char:{}",
+        msg,
+        line_idx,
+        bufline.len_chars(),
+        char_idx
+      );
+      let start_char_on_line = buffer.get_rope().line_to_char(line_idx);
+
+      let mut builder1 = String::new();
+      let mut builder2 = String::new();
+      for (i, c) in bufline.chars().enumerate() {
+        let w = buffer.char_width(c);
+        if w > 0 {
+          builder1.push(c);
+        }
+        let s: String = std::iter::repeat(if i + start_char_on_line == char_idx {
+          '^'
+        } else {
+          ' '
+        })
+        .take(w)
+        .collect();
+        builder2.push_str(s.as_str());
+      }
+      info!("-{}-", builder1);
+      info!("-{}-", builder2);
+    }
+    None => info!(
+      "{} line:{}, focus char:{}, not exist",
+      msg, line_idx, char_idx
+    ),
+  }
 }


### PR DESCRIPTION
This PR inserts an an extra eol char at the file end (only when the file doesn't have it), also adds the [fileformat](https://vimhelp.org/options.txt.html#%27fileformat%27) option. The 'fileformat' option is still internal, not exposed to js script yet.