### PR TITLE
feat(cmdline): initialize default cmdline widget

### DIFF
--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -356,7 +356,6 @@ impl EventLoop {
     let cmdline_id = cmdline.id();
     let cmdline_node = TreeNode::Cmdline(cmdline);
     tree.bounded_insert(tree_root_id, cmdline_node);
-    tree.set_cmdline_id(Some(cmdline_id));
 
     // Initialize cursor.
     let cursor_shape = IRect::new((0, 0), (1, 1));

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -35,7 +35,7 @@ pub mod msg;
 pub mod task;
 pub mod tui;
 
-// #[derive(Debug)]
+#[derive(Debug)]
 /// For slow tasks that are suitable to put in the background, this event loop will spawn them in
 /// tokio's async tasks and let them sync back data once they are done. The event loop controls all
 /// the tasks with [`CancellationToken`] and [`TaskTracker`].

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -353,7 +353,7 @@ impl EventLoop {
       (canvas_size.width() as isize, canvas_size.height() as isize),
     );
     let cmdline = Cmdline::new(cmdline_shape, Arc::downgrade(&self.contents));
-    let cmdline_id = cmdline.id();
+    let _cmdline_id = cmdline.id();
     let cmdline_node = TreeNode::Cmdline(cmdline);
     tree.bounded_insert(tree_root_id, cmdline_node);
 

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -367,6 +367,12 @@ pub struct JsRuntime {
   pub state: Rc<RefCell<JsRuntimeState>>,
 }
 
+impl std::fmt::Debug for JsRuntime {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "JsRuntime")
+  }
+}
+
 impl JsRuntime {
   /// Creates a new JsRuntime based on provided options.
   #[allow(clippy::too_many_arguments)]

--- a/rsvim_core/src/ui/tree.rs
+++ b/rsvim_core/src/ui/tree.rs
@@ -232,8 +232,11 @@ pub struct Tree {
 
   // Cursor and window state {
 
-  // [`cursor`](crate::ui::widget::cursor::Cursor) node ID.
+  // [`Cursor`](crate::ui::widget::cursor::Cursor) node ID.
   cursor_id: Option<TreeNodeId>,
+
+  // [`Cmdline`](crate::ui::widget::cmdline::Cmdline) node ID.
+  cmdline_id: Option<TreeNodeId>,
 
   // All [`Window`](crate::ui::widget::Window) node IDs.
   window_ids: BTreeSet<TreeNodeId>,
@@ -266,6 +269,7 @@ impl Tree {
     Tree {
       base: Itree::new(root_node),
       cursor_id: None,
+      cmdline_id: None,
       window_ids: BTreeSet::new(),
       global_options: WindowGlobalOptionsBuilder::default().build().unwrap(),
       global_local_options: WindowLocalOptionsBuilder::default().build().unwrap(),
@@ -330,6 +334,16 @@ impl Tree {
   /// Set current cursor node ID.
   pub fn set_cursor_id(&mut self, cursor_id: Option<TreeNodeId>) {
     self.cursor_id = cursor_id;
+  }
+
+  /// Get cmdline node ID.
+  pub fn cmdline_id(&self) -> Option<TreeNodeId> {
+    self.cmdline_id
+  }
+
+  /// Set cmdline node ID.
+  pub fn set_cmdline_id(&mut self, cmdline_id: Option<TreeNodeId>) {
+    self.cmdline_id = cmdline_id;
   }
 
   /// Get current window node ID.

--- a/rsvim_core/src/ui/tree.rs
+++ b/rsvim_core/src/ui/tree.rs
@@ -386,6 +386,9 @@ impl Tree {
         }
         self.cursor_id = Some(cursor.id());
       }
+      TreeNode::Cmdline(cmdline) => {
+        self.cmdline_id = Some(cmdline.id());
+      }
       TreeNode::Window(window) => {
         self.window_ids.insert(window.id());
       }

--- a/rsvim_core/src/ui/widget/cmdline.rs
+++ b/rsvim_core/src/ui/widget/cmdline.rs
@@ -6,9 +6,11 @@ use crate::content::TemporaryContentsWk;
 use crate::prelude::*;
 use crate::ui::canvas::Canvas;
 use crate::ui::tree::*;
-use crate::ui::viewport::ViewportWk;
+use crate::ui::viewport::{
+  CursorViewport, CursorViewportArc, Viewport, ViewportArc, ViewportOptions,
+};
 use crate::ui::widget::Widgetable;
-use crate::ui::widget::window::opt::WindowLocalOptions;
+use crate::ui::widget::window::opt::{WindowLocalOptions, WindowLocalOptionsBuilder};
 use crate::{inode_impl, lock};
 
 #[derive(Debug, Clone)]
@@ -16,34 +18,51 @@ use crate::{inode_impl, lock};
 pub struct Cmdline {
   base: InodeBase,
 
-  // Cmdline content temporary content.
+  options: WindowLocalOptions,
+
   contents: TemporaryContentsWk,
 
-  // Cmdline content viewport.
-  viewport: ViewportWk,
+  viewport: ViewportArc,
 
-  options: WindowLocalOptions,
+  cursor_viewport: CursorViewportArc,
 }
 
 impl Cmdline {
-  pub fn new(
-    opts: &WindowLocalOptions,
-    shape: IRect,
-    contents: TemporaryContentsWk,
-    viewport: ViewportWk,
-  ) -> Self {
+  pub fn new(shape: IRect, contents: TemporaryContentsWk) -> Self {
     // Force cmdline window options.
-    let mut options = *opts;
-    options.set_wrap(false);
-    options.set_line_break(false);
-    options.set_scroll_off(0_u16);
+    let options = WindowLocalOptionsBuilder::default()
+      .wrap(false)
+      .line_break(false)
+      .scroll_off(0_u16)
+      .build()
+      .unwrap();
+    let viewport_options = ViewportOptions::from(&options);
 
     let base = InodeBase::new(shape);
+    let cmdline_actual_shape = base.actual_shape();
+
+    let (viewport, cursor_viewport) = {
+      let contents = contents.upgrade().unwrap();
+      let contents = lock!(contents);
+      let viewport = Viewport::view(
+        &viewport_options,
+        contents.cmdline_content(),
+        cmdline_actual_shape,
+        0,
+        0,
+      );
+      let cursor_viewport = CursorViewport::from_top_left(&viewport, contents.cmdline_content());
+      (viewport, cursor_viewport)
+    };
+    let viewport = Viewport::to_arc(viewport);
+    let cursor_viewport = CursorViewport::to_arc(cursor_viewport);
+
     Self {
       base,
-      contents,
       options,
+      contents,
       viewport,
+      cursor_viewport,
     }
   }
 }

--- a/rsvim_core/src/ui/widget/cmdline.rs
+++ b/rsvim_core/src/ui/widget/cmdline.rs
@@ -74,7 +74,7 @@ impl Widgetable for Cmdline {
     let actual_shape = self.actual_shape();
     let contents = self.contents.upgrade().unwrap();
     let contents = lock!(contents);
-    let viewport = self.viewport.upgrade().unwrap();
+    let viewport = self.viewport.clone();
 
     viewport.draw(contents.cmdline_content(), actual_shape, canvas);
   }


### PR DESCRIPTION
TODO: As rsvim add more and more UI widgets, it eventually needs a **layout** framework to provide the ability to help manage all the widgets inside the _screen_ (i.e. the whole terminal).