### PR TITLE
fix(unicode): fix logic cells canvas drawing for >1 width unicode characters

### DIFF
--- a/rsvim_core/src/ui/canvas.rs
+++ b/rsvim_core/src/ui/canvas.rs
@@ -203,7 +203,7 @@ impl Canvas {
     col_end_at
   }
 
-  pub fn _make_print_shaders(
+  pub fn _make_printable_shaders(
     &self,
     row: u16,
     start_col: u16,
@@ -220,11 +220,11 @@ impl Canvas {
     let new_contents = new_cells
       .iter()
       .map(|c| {
-        if c.symbol().is_empty() {
-          " ".to_compact_string()
-        } else {
-          c.symbol().clone()
-        }
+        // if c.symbol().is_empty() {
+        //   "".to_compact_string()
+        // } else {
+        c.symbol().clone()
+        // }
       })
       .collect::<Vec<_>>()
       .join("");
@@ -269,7 +269,7 @@ impl Canvas {
 
           if col_end_at > col {
             let mut print_shaders =
-              self._make_print_shaders(row, col, col_end_at);
+              self._make_printable_shaders(row, col, col_end_at);
             shaders.append(&mut print_shaders);
             col = col_end_at;
           }
@@ -312,7 +312,7 @@ impl Canvas {
 
             if col_end_at > col {
               let mut print_shaders =
-                self._make_print_shaders(row as u16, col, col_end_at);
+                self._make_printable_shaders(row as u16, col, col_end_at);
               shaders.append(&mut print_shaders);
               col = col_end_at;
             }

--- a/rsvim_core/src/ui/canvas.rs
+++ b/rsvim_core/src/ui/canvas.rs
@@ -7,7 +7,6 @@ pub use frame::cell::*;
 pub use frame::cursor::*;
 pub use frame::*;
 
-use compact_str::ToCompactString;
 use crossterm;
 use geo::point;
 use std::fmt::Debug;

--- a/rsvim_core/src/ui/canvas.rs
+++ b/rsvim_core/src/ui/canvas.rs
@@ -218,13 +218,7 @@ impl Canvas {
     );
     let new_contents = new_cells
       .iter()
-      .map(|c| {
-        // if c.symbol().is_empty() {
-        //   "".to_compact_string()
-        // } else {
-        c.symbol().clone()
-        // }
-      })
+      .map(|c| c.symbol().clone())
       .collect::<Vec<_>>()
       .join("");
     shaders.push(ShaderCommand::CursorMoveTo(crossterm::cursor::MoveTo(

--- a/rsvim_core/src/ui/canvas_tests.rs
+++ b/rsvim_core/src/ui/canvas_tests.rs
@@ -273,7 +273,7 @@ fn _next_same_cell_in_row3() {
 }
 
 #[test]
-fn _make_print_shader1() {
+fn _make_printable_shader1() {
   test_log_init();
   let mut can = Canvas::new(U16Size::new(10, 10));
 
@@ -286,7 +286,7 @@ fn _make_print_shader1() {
   let col = 2;
   let row = 3;
   let col_end_at = can._next_same_cell_in_row(row, col);
-  let shaders = can._make_print_shaders(row, col, col_end_at);
+  let shaders = can._make_printable_shaders(row, col, col_end_at);
   info!("shader:{:?}", shaders);
   assert_eq!(shaders.len(), 2);
   assert!(matches!(

--- a/rsvim_core/src/ui/viewport/draw.rs
+++ b/rsvim_core/src/ui/viewport/draw.rs
@@ -98,22 +98,35 @@ pub fn draw(
             let c = chars_iter.next().unwrap();
             let (unicode_symbol, unicode_width) = text.char_symbol_and_width(c);
 
-            // FIXME: The canvas system is designed with a `M x N` cells.
-            // Ideally each cell should render a 1-width char in terminal.
-            // But in real-world, if a unicode char is 2-width, it will
-            // actually uses 2 cells in terminal, but only 1 cell in our
-            // canvas.
-            // Thus we need to work around this case, by setting the
-            // following cells to empty string `""`.
+            // The canvas system is designed with a `M x N` cells in the
+            // beginning, I was thinking each cell should render a 1-width char
+            // in the terminal.
+            // Then I noticed that, an ASCII control code, ASCII char or a
+            // unicode char can be:
             //
-            // For example we have below 2 cases:
+            // - Use 0-width, for example LF/CR, but actually a widget will
+            //   never render a 0-width char to canvas.
+            // - Use 1-width, most ASCII chars and some special characters.
+            //   This is the happy case.
+            // - Use 2-width, most CJK chars and some special unicodes.
+            // - Use more than 2-width, for example '\t' (Tab) by default uses
+            //   8-width.
             //
-            // - `\t` (Tab), (by default) it is 8-width. We will create 8
-            // cells (because in canvas, 1 cell is for 1-width display),
-            // the 1st cell is the `\t` (Tab) char, the following 7 cells
-            // are `""` empty string.
-            // - `好`, it is 2-width. We will create 2 cells, the 1st cell
-            // is the `好` char, the following 1 cell is `""` empty string.
+            // But in the canvas system, characters are managed by logic "cell"
+            // (a logic cell is a "CompactString"). If a logic cell actually
+            // displays multiple "term cells" in the terminal, then the whole
+            // row in the terminal can be overflow.
+            //
+            // Thus we need to work around this case, by setting the following
+            // cells to empty string `""`.
+            //
+            // For example now we have 2 cases:
+            //
+            // - `\t` (Tab), (by default) it is 8-width. We create 8 logic
+            //   cells, the 1st cell is the `\t` (Tab) char, the following 7
+            //   cells are `""` empty string.
+            // - `好` (CJK), it is 2-width. We create 2 cells, the 1st cell is
+            //   the `好` char, the following 1 cell is `""` empty string.
 
             let cell = Cell::with_symbol(unicode_symbol);
             let cell_upos =

--- a/rsvim_core/src/ui/viewport/draw.rs
+++ b/rsvim_core/src/ui/viewport/draw.rs
@@ -128,12 +128,29 @@ pub fn draw(
             // - `好` (CJK), it is 2-width. We create 2 cells, the 1st cell is
             //   the `好` char, the following 1 cell is `""` empty string.
 
-            let cell = Cell::with_symbol(unicode_symbol);
-            let cell_upos =
-              point!(x: col_idx + upos.x(), y: row_idx + upos.y());
-            canvas.frame_mut().set_cell(cell_upos, cell);
+            if unicode_width > 0 {
+              let cells = if unicode_width > 1 {
+                let cell = Cell::with_symbol(unicode_symbol);
+                // Unicode width > 1
+                let mut v = vec![cell];
+                v.extend(
+                  std::iter::repeat_n(Cell::empty(), unicode_width - 1)
+                    .collect::<Vec<Cell>>(),
+                );
+                v
+              } else {
+                let cell = Cell::with_symbol(unicode_symbol);
+                // Unicode width = 1
+                vec![cell]
+              };
 
-            col_idx += unicode_width as u16;
+              let cell_upos =
+                point!(x: col_idx + upos.x(), y: row_idx + upos.y());
+              canvas.frame_mut().set_cells_at(cell_upos, cells);
+
+              col_idx += unicode_width as u16;
+            }
+
             char_idx += 1;
           }
         }

--- a/rsvim_core/src/ui/viewport/draw.rs
+++ b/rsvim_core/src/ui/viewport/draw.rs
@@ -98,11 +98,11 @@ pub fn draw(
             let c = chars_iter.next().unwrap();
             let (unicode_symbol, unicode_width) = text.char_symbol_and_width(c);
 
-            // The canvas system is designed with a `M x N` cells in the
+            // The canvas system is designed with a `M x N` logic cells in the
             // beginning, I was thinking each cell should render a 1-width char
             // in the terminal.
             // Then I noticed that, an ASCII control code, ASCII char or a
-            // unicode char can be:
+            // unicode char can use different width (cells) in the terminal:
             //
             // - Use 0-width, for example LF/CR, but actually a widget will
             //   never render a 0-width char to canvas.


### PR DESCRIPTION
Fix #534 

Fixes the canvas system by filling the following logic cells with empty string (`""`), when a char displays width > 1. The leading logic cell will store the character itself, while following ones will store empty strings and fill the canvas.

At the beginning, I was simply thinking a terminal is a logic `M * N` cells, each logic cell display a 1-width char in the terminal. But then I noticed, there are multiple kinds of ASCII/unicode characters with various length displayed on the terminal (or say, use different cells in the terminal). This PR fixes this issue.