### PR TITLE
refactor(js): add old "from scratch" constructor back to js runtime

### DIFF
--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -548,11 +548,7 @@ impl JsRuntime {
     };
 
     // When without snapshot, we need to initialize builtin js modules.
-
-    {
-      let scope = &mut runtime.handle_scope();
-      init_builtin_modules(scope);
-    }
+    init_builtin_modules(&mut runtime.handle_scope());
 
     // // Start inspector agent is requested.
     // if let Some(inspector) = runtime.inspector().as_mut() {

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -517,7 +517,8 @@ impl JsRuntime {
     // runtime
   }
 
-  /// Creates a new JsRuntime without snapshot, usually for testing purpose.
+  /// Creates a new JsRuntime from scratch, i.e. without snapshot, usually for
+  /// testing purpose.
   #[allow(clippy::too_many_arguments)]
   pub fn new_without_snapshot(
     options: JsRuntimeOptions,

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -25,7 +25,6 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use std::time::Instant;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::{error, trace};
-use v8::OwnedIsolate;
 
 pub mod binding;
 pub mod err;
@@ -94,7 +93,7 @@ pub fn init_v8_platform(snapshot: bool, user_v8_flags: Option<&[String]>) {
   });
 }
 
-fn init_v8_isolate(isolate: &mut OwnedIsolate) {
+fn init_v8_isolate(isolate: &mut v8::OwnedIsolate) {
   // NOTE: Set microtasks policy to explicit, this requires we invoke `perform_microtask_checkpoint` API on each tick.
   // See: [`run_next_tick_callbacks`].
   isolate.set_microtasks_policy(v8::MicrotasksPolicy::Explicit);

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -106,35 +106,6 @@ fn init_v8_isolate(isolate: &mut OwnedIsolate) {
   );
 }
 
-// Built-in modules {
-
-struct BuiltinRuntimeModule {
-  pub filename: &'static str,
-  pub source: &'static str,
-}
-
-impl BuiltinRuntimeModule {
-  pub fn new(filename: &'static str, source: &'static str) -> Self {
-    Self { filename, source }
-  }
-}
-
-static BUILTIN_RUNTIME_MODULES: Lazy<Vec<BuiltinRuntimeModule>> =
-  Lazy::new(|| {
-    vec![
-      BuiltinRuntimeModule::new(
-        "00__web.js",
-        include_str!("./js/runtime/00__web.js"),
-      ),
-      BuiltinRuntimeModule::new(
-        "01__rsvim.js",
-        include_str!("./js/runtime/01__rsvim.js"),
-      ),
-    ]
-  });
-
-// Built-in modules }
-
 fn _init_builtin_module_impl(
   scope: &mut v8::HandleScope<'_>,
   name: &str,
@@ -186,8 +157,20 @@ fn _init_builtin_module_impl(
 }
 
 fn init_builtin_modules(scope: &mut v8::HandleScope<'_>) {
-  for module in BUILTIN_RUNTIME_MODULES.iter() {
-    _init_builtin_module_impl(scope, module.filename, module.source);
+  static BUILTIN_MODULES: Lazy<
+    Vec<(
+      /* filename */ &'static str,
+      /* source */ &'static str,
+    )>,
+  > = Lazy::new(|| {
+    vec![
+      ("00__web.js", include_str!("./js/runtime/00__web.js")),
+      ("01__rsvim.js", include_str!("./js/runtime/01__rsvim.js")),
+    ]
+  });
+
+  for module in BUILTIN_MODULES.iter() {
+    _init_builtin_module_impl(scope, module.0, module.1);
   }
 }
 

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -17,7 +17,6 @@ use crate::prelude::*;
 use crate::state::StateArc;
 use crate::ui::tree::TreeArc;
 
-use once_cell::sync::Lazy;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Once;
@@ -106,17 +105,10 @@ fn init_v8_isolate(isolate: &mut v8::OwnedIsolate) {
 }
 
 fn init_builtin_modules(scope: &mut v8::HandleScope<'_>) {
-  static BUILTIN_MODULES: Lazy<
-    Vec<(
-      /* filename */ &'static str,
-      /* source */ &'static str,
-    )>,
-  > = Lazy::new(|| {
-    vec![
-      ("00__web.js", include_str!("./js/runtime/00__web.js")),
-      ("01__rsvim.js", include_str!("./js/runtime/01__rsvim.js")),
-    ]
-  });
+  static BUILTIN_MODULES: [(/* filename */ &str, /* source */ &str); 2] = [
+    ("00__web.js", include_str!("./js/runtime/00__web.js")),
+    ("01__rsvim.js", include_str!("./js/runtime/01__rsvim.js")),
+  ];
 
   for module in BUILTIN_MODULES.iter() {
     let filename = module.0;

--- a/rsvim_core/src/js/module.rs
+++ b/rsvim_core/src/js/module.rs
@@ -196,6 +196,8 @@ pub async fn load_import_async(
   load_import(specifier, skip_cache)
 }
 
+/// TODO: Support dependencies resolving for custom snapshot.
+/// Resolves module imports without dependency.
 pub fn fetch_module<'a>(
   scope: &mut v8::HandleScope<'a>,
   filename: &str,

--- a/rsvim_core/src/js/module.rs
+++ b/rsvim_core/src/js/module.rs
@@ -196,8 +196,9 @@ pub async fn load_import_async(
   load_import(specifier, skip_cache)
 }
 
-/// TODO: Support dependencies resolving for custom snapshot.
 /// Resolves module imports without dependency.
+///
+/// TODO: Support dependencies resolving for custom snapshot.
 pub fn fetch_module<'a>(
   scope: &mut v8::HandleScope<'a>,
   filename: &str,

--- a/rsvim_core/src/js/module/module_map.rs
+++ b/rsvim_core/src/js/module/module_map.rs
@@ -184,6 +184,8 @@ impl ModuleMap {
   }
 
   // Returns a specifier by a v8 module.
+  // FIXME: This method has performance issue, make it `O(1)` instead of
+  // `O(N)`.
   pub fn get_path(&self, module: v8::Global<v8::Module>) -> Option<ModulePath> {
     self
       .index

--- a/rsvim_core/src/js/module/module_map.rs
+++ b/rsvim_core/src/js/module/module_map.rs
@@ -154,7 +154,7 @@ impl ModuleMap {
 }
 
 impl ModuleMap {
-  // Creates a new module-map instance.
+  /// Creates a new module-map instance.
   pub fn new() -> ModuleMap {
     Self {
       main: None,
@@ -164,7 +164,7 @@ impl ModuleMap {
     }
   }
 
-  // Inserts a compiled ES module to the map.
+  /// Inserts a compiled ES module to the map.
   pub fn insert(&mut self, path: &str, module: v8::Global<v8::Module>) {
     // No main module has been set, so let's update the value.
     if self.main.is_none() && std::fs::metadata(path).is_ok() {
@@ -178,14 +178,15 @@ impl ModuleMap {
   //   !self.pending.is_empty()
   // }
 
-  // Returns a v8 module reference from me module-map.
+  /// Returns a v8 module reference from me module-map.
   pub fn get(&self, key: &str) -> Option<v8::Global<v8::Module>> {
     self.index.get(key).cloned()
   }
 
-  // Returns a specifier by a v8 module.
-  // FIXME: This method has performance issue, make it `O(1)` instead of
-  // `O(N)`.
+  /// Returns a specifier by a v8 module.
+  ///
+  /// FIXME: This method has performance issue, make it `O(1)` instead of
+  /// `O(N)`.
   pub fn get_path(&self, module: v8::Global<v8::Module>) -> Option<ModulePath> {
     self
       .index

--- a/rsvim_core/src/test.rs
+++ b/rsvim_core/src/test.rs
@@ -7,8 +7,6 @@ pub mod buf;
 #[cfg(test)]
 pub mod constant;
 #[cfg(test)]
-pub mod js;
-#[cfg(test)]
 pub mod log;
 #[cfg(test)]
 pub mod tree;

--- a/rsvim_core/src/test.rs
+++ b/rsvim_core/src/test.rs
@@ -7,6 +7,8 @@ pub mod buf;
 #[cfg(test)]
 pub mod constant;
 #[cfg(test)]
+pub mod js;
+#[cfg(test)]
 pub mod log;
 #[cfg(test)]
 pub mod tree;


### PR DESCRIPTION
This PR adds the old "without snapshot" version constructor back to js runtime.

In previous work #199 , "v8 snapshot" is firstly successful built for the builtin modules (i.e. the `Rsvim` global objects), then in following work #202 and #205 , the "from scratch" version constructor is been replaced with "v8 snapshot" constructor. This is mostly for performance reason, it greatly speed up the `rsvim` cli startup.

But now we want to add unit tests for "js" modules to improve code quality, and need to make js runtime mock for each testing cases. Thus bring the "from scratch" constructor back to js runtime.