### PR TITLE
refactor(buf): drop unnecessary 'Rc' pointer inside text cache

### DIFF
--- a/rsvim_core/src/buf/text.rs
+++ b/rsvim_core/src/buf/text.rs
@@ -12,7 +12,6 @@ use compact_str::{CompactString, ToCompactString};
 use lru::LruCache;
 use ropey::{Rope, RopeSlice};
 use std::cell::RefCell;
-use std::rc::Rc;
 
 pub mod cidx;
 
@@ -23,7 +22,7 @@ mod cidx_tests;
 /// Text content backend.
 pub struct Text {
   rope: Rope,
-  cached_lines_width: Rc<RefCell<LruCache<usize, ColumnIndex, RandomState>>>,
+  cached_lines_width: RefCell<LruCache<usize, ColumnIndex, RandomState>>,
   options: BufferLocalOptions,
 }
 
@@ -43,10 +42,10 @@ impl Text {
     let cache_size = _cached_size(canvas_size);
     Self {
       rope,
-      cached_lines_width: Rc::new(RefCell::new(LruCache::with_hasher(
+      cached_lines_width: RefCell::new(LruCache::with_hasher(
         cache_size,
         RandomState::new(),
-      ))),
+      )),
       options: opts,
     }
   }

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -17,7 +17,6 @@ use crate::prelude::*;
 use crate::state::StateArc;
 use crate::ui::tree::TreeArc;
 
-use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Once;
 use std::sync::atomic::{AtomicI32, Ordering};

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -336,7 +336,7 @@ pub struct JsRuntime {
 
   /// The state of the runtime.
   #[allow(unused)]
-  pub state: Rc<RefCell<JsRuntimeState>>,
+  pub state: JsRuntimeStateRc,
 }
 
 impl std::fmt::Debug for JsRuntime {


### PR DESCRIPTION
For the 'Text' structure, its inside lines display width cache field 'cached_lines_width' doesn't have to be 'Rc<RefCell<>>', just 'RefCell' works as well.