### PR TITLE
fix(loader): fix module fs loader and add tests for "fetch_module_tree"

### DIFF
--- a/rsvim_core/src/cli.rs
+++ b/rsvim_core/src/cli.rs
@@ -85,41 +85,9 @@ impl CliOpt {
   // pub fn debug(&self) -> bool {
   //   self.debug
   // }
-}
 
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn cli_opt1() {
-    let input = [
-      vec!["rsvim".to_string()],
-      vec!["rsvim".to_string(), "--version".to_string()],
-      vec!["rsvim".to_string(), "README.md".to_string()],
-    ];
-
-    let expect = [
-      CliOpt {
-        file: vec![],
-        version: false,
-      },
-      CliOpt {
-        file: vec![],
-        version: true,
-      },
-      CliOpt {
-        file: vec!["README.md".to_string()],
-        version: false,
-      },
-    ];
-
-    assert_eq!(input.len(), expect.len());
-    let n = input.len();
-    for i in 0..n {
-      let actual = CliOpt::parse_from(&input[i]);
-      assert_eq!(actual.file, expect[i].file);
-      assert_eq!(actual.version(), expect[i].version());
-    }
+  #[cfg(test)]
+  pub fn new(version: bool, file: Vec<String>) -> Self {
+    Self { version, file }
   }
 }

--- a/rsvim_core/src/cli_tests.rs
+++ b/rsvim_core/src/cli_tests.rs
@@ -1,0 +1,26 @@
+use super::cli::*;
+
+use clap::Parser;
+
+#[test]
+fn cli_opt1() {
+  let input = [
+    vec!["rsvim".to_string()],
+    vec!["rsvim".to_string(), "--version".to_string()],
+    vec!["rsvim".to_string(), "README.md".to_string()],
+  ];
+
+  let expect = [
+    CliOpt::new(false, vec![]),
+    CliOpt::new(true, vec![]),
+    CliOpt::new(false, vec!["README.md".to_string()]),
+  ];
+
+  assert_eq!(input.len(), expect.len());
+  let n = input.len();
+  for i in 0..n {
+    let actual = CliOpt::parse_from(&input[i]);
+    assert_eq!(actual.file(), expect[i].file());
+    assert_eq!(actual.version(), expect[i].version());
+  }
+}

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -33,6 +33,9 @@ pub mod module;
 pub mod msg;
 pub mod transpiler;
 
+#[cfg(test)]
+mod module_tests;
+
 pub fn v8_version() -> &'static str {
   v8::VERSION_STRING
 }

--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -790,8 +790,8 @@ impl JsRuntime {
     {
       let state = state_rc.borrow();
 
-      let mut seen_modules = state.module_map.seen_mut();
-      let mut pending_graphs = state.module_map.pending_mut();
+      let mut seen_modules = state.module_map.seen().borrow_mut();
+      let mut pending_graphs = state.module_map.pending().borrow_mut();
 
       pending_graphs.retain(|graph_rc| {
         // Get a usable ref to graph's root module.
@@ -908,7 +908,13 @@ impl JsRuntime {
 
   /// Returns if we have imports in pending state.
   pub fn has_pending_imports(&mut self) -> bool {
-    !self.get_state().borrow().module_map.pending().is_empty()
+    !self
+      .get_state()
+      .borrow()
+      .module_map
+      .pending()
+      .borrow()
+      .is_empty()
   }
 
   // /// Returns if we have scheduled any next-tick callbacks.

--- a/rsvim_core/src/js/loader/fs_loader.rs
+++ b/rsvim_core/src/js/loader/fs_loader.rs
@@ -13,7 +13,6 @@ use crate::prelude::*;
 // use sha::utils::DigestExt;
 use path_absolutize::Absolutize;
 use std::fs;
-use std::ops::Deref;
 use std::path::Path;
 use std::path::PathBuf;
 // use url::Url;

--- a/rsvim_core/src/js/module.rs
+++ b/rsvim_core/src/js/module.rs
@@ -236,7 +236,13 @@ pub fn fetch_module_tree<'a>(
   filename: &str,
   source: Option<&str>,
 ) -> Option<v8::Local<'a, v8::Module>> {
-  let module = fetch_module(scope, filename, source).unwrap();
+  let module = match fetch_module(scope, filename, source) {
+    Some(module) => module,
+    None => {
+      // Early returns `None`
+      return None;
+    }
+  };
 
   let state = JsRuntime::state(scope);
 

--- a/rsvim_core/src/js/module.rs
+++ b/rsvim_core/src/js/module.rs
@@ -213,15 +213,15 @@ pub fn fetch_module<'a>(
     None => load_import(filename, true).unwrap(),
   };
 
-  trace!(
-    "Fetch module, filename: {:?}, source: {:?}",
-    filename,
-    if source.as_str().len() > 50 {
-      String::from(&source.as_str()[..50]) + "..."
+  if cfg!(debug_assertions) {
+    const MAX_SRC_LEN: usize = 100;
+    let src = if source.as_str().len() > MAX_SRC_LEN {
+      String::from(&source.as_str()[..MAX_SRC_LEN]) + "..."
     } else {
       String::from(source.as_str())
-    }
-  );
+    };
+    trace!("Fetch module, filename: {:?}, source: {:?}", filename, src);
+  }
 
   let source = v8::String::new(scope, &source).unwrap();
   let mut source = v8::script_compiler::Source::new(source, Some(&origin));

--- a/rsvim_core/src/js/module.rs
+++ b/rsvim_core/src/js/module.rs
@@ -220,7 +220,7 @@ pub fn fetch_module<'a>(
     } else {
       String::from(source.as_str())
     };
-    trace!("Fetch module, filename: {:?}, source: {:?}", filename, src);
+    trace!("Fetch module, filename:{:?}, source:{:?}", filename, src);
   }
 
   let source = v8::String::new(scope, &source).unwrap();

--- a/rsvim_core/src/js/module.rs
+++ b/rsvim_core/src/js/module.rs
@@ -226,9 +226,7 @@ pub fn fetch_module<'a>(
   let source = v8::String::new(scope, &source).unwrap();
   let mut source = v8::script_compiler::Source::new(source, Some(&origin));
 
-  let module = v8::script_compiler::compile_module(scope, &mut source)?;
-
-  Some(module)
+  v8::script_compiler::compile_module(scope, &mut source)
 }
 
 /// Resolves module imports synchronously.

--- a/rsvim_core/src/js/module/module_map.rs
+++ b/rsvim_core/src/js/module/module_map.rs
@@ -40,7 +40,7 @@ use crate::js::module::es_module::*;
 use crate::js::module::{ModulePath, ModuleStatus};
 use crate::prelude::*;
 
-use std::cell::{Ref, RefCell, RefMut};
+use std::cell::RefCell;
 use std::collections::LinkedList;
 
 #[derive(Debug, Clone)]
@@ -136,21 +136,21 @@ impl ModuleMap {
     &self.index
   }
 
-  pub fn seen(&self) -> Ref<'_, HashMap<ModulePath, ModuleStatus>> {
-    self.seen.borrow()
+  pub fn seen(&self) -> &RefCell<HashMap<ModulePath, ModuleStatus>> {
+    &self.seen
   }
 
-  pub fn seen_mut(&self) -> RefMut<'_, HashMap<ModulePath, ModuleStatus>> {
-    self.seen.borrow_mut()
+  // pub fn seen_mut(&self) -> RefMut<'_, HashMap<ModulePath, ModuleStatus>> {
+  //   self.seen.borrow_mut()
+  // }
+
+  pub fn pending(&self) -> &RefCell<Vec<ModuleGraphRc>> {
+    &self.pending
   }
 
-  pub fn pending(&self) -> Ref<'_, Vec<ModuleGraphRc>> {
-    self.pending.borrow()
-  }
-
-  pub fn pending_mut(&self) -> RefMut<'_, Vec<ModuleGraphRc>> {
-    self.pending.borrow_mut()
-  }
+  // pub fn pending_mut(&self) -> RefMut<'_, Vec<ModuleGraphRc>> {
+  //   self.pending.borrow_mut()
+  // }
 }
 
 impl ModuleMap {

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -1,8 +1,13 @@
 use super::module::*;
 
-use crate::test::log as test_log_init;
+use crate::js::JsRuntime;
+use crate::test::js::make_js_runtime;
+use crate::test::log::init as test_log_init;
 
 #[test]
-fn fetch_module1() {
+fn test_fetch1() {
   test_log_init();
+  let mut jsrt = make_js_runtime();
+  let scope = jsrt.handle_scope();
+  // let module = fetch_module(&mut scope, filename, source);
 }

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -1,5 +1,6 @@
 use super::module::*;
 
+use crate::prelude::*;
 use crate::test::constant::acquire_sequential_guard;
 use crate::test::js::make_js_runtime;
 use crate::test::log::init as test_log_init;
@@ -39,6 +40,11 @@ fn test_fetch1() {
     fetch_module(&mut scope, fetch1.as_os_str().to_str().unwrap(), None);
   assert!(actual1.is_some());
   let actual1 = actual1.unwrap();
+  info!(
+    "fetch1 actual1:{:?}, script_id:{:?}",
+    actual1,
+    actual1.script_id()
+  );
   assert!(actual1.script_id().is_some());
   assert!(actual1.script_id().unwrap() > 0);
 }

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -1,0 +1,4 @@
+use super::module::*;
+
+#[test]
+fn fetch_module1() {}

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -14,7 +14,7 @@ fn fetch1() {
 
   let tmpdir = TempDir::new().unwrap();
 
-  const SRC1: &str = r#"
+  let src1: &str = r#"
   export const PI = 3.14159;
   export function Hello(a, b) {
     return a+b;
@@ -29,7 +29,7 @@ fn fetch1() {
 
   {
     let mut fp = std::fs::File::create(&fetch1).unwrap();
-    fp.write_all(SRC1.as_bytes()).unwrap();
+    fp.write_all(src1.as_bytes()).unwrap();
     fp.flush().unwrap();
   }
 
@@ -56,9 +56,10 @@ fn fetch2() {
   let tmpdir = TempDir::new().unwrap();
 
   // Actually it's rust code...
-  const SRC2: &str = r#"
+  let src2: &str = r#"
   #[test]
   fn fetch2() {
+    println!("hello");
   }
   "#;
 
@@ -66,7 +67,7 @@ fn fetch2() {
 
   {
     let mut fp = std::fs::File::create(&fetch2).unwrap();
-    fp.write_all(SRC2.as_bytes()).unwrap();
+    fp.write_all(src2.as_bytes()).unwrap();
     fp.flush().unwrap();
   }
 

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -78,3 +78,67 @@ fn fetch2() {
     fetch_module(&mut scope, fetch2.as_os_str().to_str().unwrap(), None);
   assert!(actual2.is_none());
 }
+
+#[test]
+fn fetch_tree3() {
+  let _guard = acquire_sequential_guard();
+
+  let tmpdir = TempDir::new().unwrap();
+
+  let src1: &str = r#"
+  export const PI = 3.14159;
+  "#;
+
+  let src2: &str = r#"
+  import { PI } from "./pi.js";
+
+  function addPI(a:number, b:number) :number {
+    return PI+a+b;
+  }
+
+  export { addPI };
+  "#;
+
+  let src3: &str = r#"
+  import * as pi from "./util/pi.js";
+  import addUtil from "./util/add";
+
+  const result = addUtil.addPI(1.0, 2.5);
+  "#;
+
+  let tmp_util_dir = tmpdir.join("util");
+  let fetch1 = tmp_util_dir.join("pi.js");
+  let fetch2 = tmp_util_dir.join("add.ts");
+  let fetch3 = tmpdir.join("fetch3.js");
+
+  {
+    std::fs::create_dir_all(tmp_util_dir).unwrap();
+
+    let mut fp1 = std::fs::File::create(&fetch1).unwrap();
+    fp1.write_all(src1.as_bytes()).unwrap();
+    fp1.flush().unwrap();
+
+    let mut fp2 = std::fs::File::create(&fetch2).unwrap();
+    fp2.write_all(src2.as_bytes()).unwrap();
+    fp2.flush().unwrap();
+
+    let mut fp3 = std::fs::File::create(&fetch3).unwrap();
+    fp3.write_all(src3.as_bytes()).unwrap();
+    fp3.flush().unwrap();
+  }
+
+  test_log_init();
+  let mut jsrt = make_js_runtime();
+  let mut scope = jsrt.handle_scope();
+  let actual1 =
+    fetch_module(&mut scope, fetch1.as_os_str().to_str().unwrap(), None);
+  assert!(actual1.is_some());
+  let actual1 = actual1.unwrap();
+  info!(
+    "fetch1 actual1:{:?}, script_id:{:?}",
+    actual1,
+    actual1.script_id()
+  );
+  assert!(actual1.script_id().is_some());
+  assert!(actual1.script_id().unwrap() > 0);
+}

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -147,25 +147,36 @@ fn fetch_tree3() {
   let state = state.borrow();
 
   let path3 = resolve_import(None, fetch3.to_str().unwrap(), None);
+  info!("fetch_tree3 path3:{:?}, fetch3:{:?}", path3, fetch3);
   assert!(path3.is_ok());
   let path3 = path3.unwrap();
-  assert!(state.module_map.seen().borrow().contains_key(&path3));
+  assert!(state.module_map.get(&path3).is_some());
 
   let path1 = resolve_import(
     Some(fetch3.to_str().unwrap()),
     fetch1.to_str().unwrap(),
     None,
   );
+  info!("fetch_tree3 path1:{:?}, fetch1:{:?}", path1, fetch1);
   assert!(path1.is_ok());
   let path1 = path1.unwrap();
-  assert!(state.module_map.seen().borrow().contains_key(&path1));
+  assert!(state.module_map.get(&path1).is_some());
 
+  let fetch2_without_ext =
+    fetch2.parent().unwrap().join(fetch2.file_stem().unwrap());
+  info!(
+    "fetch_tree3 fetch2:{:?},fetch2.file_stem:{:?},fetch2.without_extension:{:?}",
+    fetch2,
+    fetch2.file_stem(),
+    fetch2_without_ext
+  );
   let path2 = resolve_import(
     Some(fetch3.to_str().unwrap()),
-    fetch2.to_str().unwrap(),
+    fetch2_without_ext.to_str().unwrap(),
     None,
   );
+  info!("fetch_tree3 path2:{:?}, fetch2:{:?}", path2, fetch2);
   assert!(path2.is_ok());
   let path2 = path2.unwrap();
-  assert!(state.module_map.seen().borrow().contains_key(&path2));
+  assert!(state.module_map.get(&path2).is_some());
 }

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -24,7 +24,7 @@ fn test_fetch1() {
   export { World };
   "#;
 
-  let fetch1 = tmpdir.join("fetch1.rs");
+  let fetch1 = tmpdir.join("fetch1.js");
 
   {
     let mut src1 = std::fs::File::create(&fetch1).unwrap();

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -1,4 +1,8 @@
 use super::module::*;
 
+use crate::test::log as test_log_init;
+
 #[test]
-fn fetch_module1() {}
+fn fetch_module1() {
+  test_log_init();
+}

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -180,3 +180,112 @@ fn fetch_tree3() {
   let path2 = path2.unwrap();
   assert!(state.module_map.get(&path2).is_some());
 }
+
+#[test]
+fn fetch_tree4() {
+  let _guard = acquire_sequential_guard();
+  test_log_init();
+
+  let tmpdir = TempDir::new().unwrap();
+
+  let src1: &str = r#"
+  export const PI = 3.14159;
+  "#;
+
+  let src2: &str = r#"
+  import { PI } from "./index.js";
+
+  function addPI(a:number, b:number) :number {
+    return PI+a+b;
+  }
+
+  export { addPI };
+  "#;
+
+  let src3: &str = r#"
+  import * as pi from "./util";
+  import addUtil from "./util/add";
+
+  const result = addUtil.addPI(1.0, 2.5);
+  "#;
+
+  let tmp_util_dir = tmpdir.join("util");
+  let fetch1 = tmp_util_dir.join("index.js");
+  let fetch2 = tmp_util_dir.join("add.ts");
+  let fetch3 = tmpdir.join("index.js");
+
+  {
+    std::fs::create_dir_all(tmp_util_dir).unwrap();
+
+    let mut fp1 = std::fs::File::create(&fetch1).unwrap();
+    fp1.write_all(src1.as_bytes()).unwrap();
+    fp1.flush().unwrap();
+
+    let mut fp2 = std::fs::File::create(&fetch2).unwrap();
+    fp2.write_all(src2.as_bytes()).unwrap();
+    fp2.flush().unwrap();
+
+    let mut fp3 = std::fs::File::create(&fetch3).unwrap();
+    fp3.write_all(src3.as_bytes()).unwrap();
+    fp3.flush().unwrap();
+  }
+
+  let mut jsrt = make_js_runtime();
+  let mut scope = jsrt.handle_scope();
+  let actual1 = fetch_module_tree(&mut scope, fetch3.to_str().unwrap(), None);
+  assert!(actual1.is_some());
+  let actual1 = actual1.unwrap();
+  info!(
+    "fetch_tree4 actual1:{:?}, script_id:{:?}",
+    actual1,
+    actual1.script_id()
+  );
+  assert!(actual1.script_id().is_some());
+  assert!(actual1.script_id().unwrap() > 0);
+
+  let state = JsRuntime::state(&scope);
+  let state = state.borrow();
+
+  let fetch3_path = resolve_import(None, fetch3.to_str().unwrap(), None);
+  info!(
+    "fetch_tree4 fetch3_path:{:?}, fetch3:{:?}",
+    fetch3_path, fetch3
+  );
+  assert!(fetch3_path.is_ok());
+  let fetch3_path = fetch3_path.unwrap();
+  assert!(state.module_map.get(&fetch3_path).is_some());
+
+  let fetch1_path = resolve_import(
+    Some(tmpdir.to_str().unwrap()),
+    fetch1.to_str().unwrap(),
+    None,
+  );
+  info!(
+    "fetch_tree4 fetch1_path:{:?}, fetch1:{:?}",
+    fetch1_path, fetch1
+  );
+  assert!(fetch1_path.is_ok());
+  let fetch1_path = fetch1_path.unwrap();
+  assert!(state.module_map.get(&fetch1_path).is_some());
+
+  let fetch2_without_ext =
+    fetch2.parent().unwrap().join(fetch2.file_stem().unwrap());
+  info!(
+    "fetch_tree4 fetch2:{:?},fetch2.file_stem:{:?},fetch2.without_extension:{:?}",
+    fetch2,
+    fetch2.file_stem(),
+    fetch2_without_ext
+  );
+  let fetch2_path = resolve_import(
+    Some(fetch3.to_str().unwrap()),
+    fetch2_without_ext.to_str().unwrap(),
+    None,
+  );
+  info!(
+    "fetch_tree4 fetch2_path:{:?}, fetch2:{:?}",
+    fetch2_path, fetch2
+  );
+  assert!(fetch2_path.is_ok());
+  let fetch2_path = fetch2_path.unwrap();
+  assert!(state.module_map.get(&fetch2_path).is_some());
+}

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -11,6 +11,7 @@ use std::io::Write;
 #[test]
 fn fetch1() {
   let _guard = acquire_sequential_guard();
+  test_log_init();
 
   let tmpdir = TempDir::new().unwrap();
 
@@ -33,7 +34,6 @@ fn fetch1() {
     fp.flush().unwrap();
   }
 
-  test_log_init();
   let mut jsrt = make_js_runtime();
   let mut scope = jsrt.handle_scope();
   let actual1 =
@@ -52,6 +52,7 @@ fn fetch1() {
 #[test]
 fn fetch2() {
   let _guard = acquire_sequential_guard();
+  test_log_init();
 
   let tmpdir = TempDir::new().unwrap();
 
@@ -71,7 +72,6 @@ fn fetch2() {
     fp.flush().unwrap();
   }
 
-  test_log_init();
   let mut jsrt = make_js_runtime();
   let mut scope = jsrt.handle_scope();
   let actual2 =
@@ -82,6 +82,7 @@ fn fetch2() {
 #[test]
 fn fetch_tree3() {
   let _guard = acquire_sequential_guard();
+  test_log_init();
 
   let tmpdir = TempDir::new().unwrap();
 
@@ -127,7 +128,6 @@ fn fetch_tree3() {
     fp3.flush().unwrap();
   }
 
-  test_log_init();
   let mut jsrt = make_js_runtime();
   let mut scope = jsrt.handle_scope();
   let actual1 =

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -9,7 +9,7 @@ use assert_fs::TempDir;
 use std::io::Write;
 
 #[test]
-fn test_fetch1() {
+fn fetch1() {
   let _guard = acquire_sequential_guard();
 
   let tmpdir = TempDir::new().unwrap();
@@ -28,9 +28,9 @@ fn test_fetch1() {
   let fetch1 = tmpdir.join("fetch1.js");
 
   {
-    let mut src1 = std::fs::File::create(&fetch1).unwrap();
-    src1.write_all(SRC1.as_bytes()).unwrap();
-    src1.flush().unwrap();
+    let mut fp = std::fs::File::create(&fetch1).unwrap();
+    fp.write_all(SRC1.as_bytes()).unwrap();
+    fp.flush().unwrap();
   }
 
   test_log_init();
@@ -47,4 +47,33 @@ fn test_fetch1() {
   );
   assert!(actual1.script_id().is_some());
   assert!(actual1.script_id().unwrap() > 0);
+}
+
+#[test]
+fn fetch2() {
+  let _guard = acquire_sequential_guard();
+
+  let tmpdir = TempDir::new().unwrap();
+
+  // Actually it's rust code...
+  const SRC2: &str = r#"
+  #[test]
+  fn fetch2() {
+  }
+  "#;
+
+  let fetch2 = tmpdir.join("fetch2.js");
+
+  {
+    let mut fp = std::fs::File::create(&fetch2).unwrap();
+    fp.write_all(SRC2.as_bytes()).unwrap();
+    fp.flush().unwrap();
+  }
+
+  test_log_init();
+  let mut jsrt = make_js_runtime();
+  let mut scope = jsrt.handle_scope();
+  let actual2 =
+    fetch_module(&mut scope, fetch2.as_os_str().to_str().unwrap(), None);
+  assert!(actual2.is_none());
 }

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -1,6 +1,5 @@
 use super::module::*;
 
-use crate::js::JsRuntime;
 use crate::test::js::make_js_runtime;
 use crate::test::log::init as test_log_init;
 
@@ -8,6 +7,6 @@ use crate::test::log::init as test_log_init;
 fn test_fetch1() {
   test_log_init();
   let mut jsrt = make_js_runtime();
-  let scope = jsrt.handle_scope();
-  // let module = fetch_module(&mut scope, filename, source);
+  let mut scope = jsrt.handle_scope();
+  let module = fetch_module(&mut scope, "", None);
 }

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -1,12 +1,44 @@
 use super::module::*;
 
+use crate::test::constant::acquire_sequential_guard;
 use crate::test::js::make_js_runtime;
 use crate::test::log::init as test_log_init;
 
+use assert_fs::TempDir;
+use std::io::Write;
+
 #[test]
 fn test_fetch1() {
+  let _guard = acquire_sequential_guard();
+
+  let tmpdir = TempDir::new().unwrap();
+
+  const SRC1: &str = r#"
+  export const PI = 3.14159;
+  export function Hello(a, b) {
+    return a+b;
+  }
+  function World(a, b) {
+    return a-b;
+  }
+  export { World };
+  "#;
+
+  let fetch1 = tmpdir.join("fetch1.rs");
+
+  {
+    let mut src1 = std::fs::File::create(&fetch1).unwrap();
+    src1.write_all(SRC1.as_bytes()).unwrap();
+    src1.flush().unwrap();
+  }
+
   test_log_init();
   let mut jsrt = make_js_runtime();
   let mut scope = jsrt.handle_scope();
-  let module = fetch_module(&mut scope, "", None);
+  let actual1 =
+    fetch_module(&mut scope, fetch1.as_os_str().to_str().unwrap(), None);
+  assert!(actual1.is_some());
+  let actual1 = actual1.unwrap();
+  assert!(actual1.script_id().is_some());
+  assert!(actual1.script_id().unwrap() > 0);
 }

--- a/rsvim_core/src/lib.rs
+++ b/rsvim_core/src/lib.rs
@@ -22,6 +22,8 @@ pub mod test;
 #[cfg(test)]
 mod buf_tests;
 #[cfg(test)]
+mod cli_tests;
+#[cfg(test)]
 mod constant_tests;
 #[cfg(test)]
 mod js_tests;

--- a/rsvim_core/src/log.rs
+++ b/rsvim_core/src/log.rs
@@ -4,7 +4,7 @@ use jiff::Zoned;
 use tracing_appender;
 use tracing_subscriber::{self, EnvFilter};
 
-/// Initialize logging.
+/// Initialize file logging, always use file logging.
 ///
 /// It uses `RSVIM_LOG` environment variable to control the logging level.
 /// Defaults to `error`. The logs are written into file if log level >= `INFO`, otherwise it prints
@@ -12,40 +12,25 @@ use tracing_subscriber::{self, EnvFilter};
 pub fn init() {
   let env_filter = EnvFilter::from_env("RSVIM_LOG");
 
-  if env_filter.max_level_hint().unwrap() >= tracing::Level::INFO {
-    // Only create file logs for debug level.
-    let now = Zoned::now();
-    let log_name = format!(
-      "rsvim_{:0>4}-{:0>2}-{:0>2}_{:0>2}-{:0>2}-{:0>2}-{:0>3}.log",
-      now.date().year(),
-      now.date().month(),
-      now.date().day(),
-      now.time().hour(),
-      now.time().minute(),
-      now.time().second(),
-      now.time().millisecond(),
-    );
-    tracing_subscriber::FmtSubscriber::builder()
-      .with_file(true)
-      .with_line_number(true)
-      .with_thread_ids(true)
-      .with_thread_names(true)
-      .with_level(true)
-      .with_ansi(false)
-      .with_env_filter(env_filter)
-      .with_writer(tracing_appender::rolling::never(".", log_name))
-      .init();
-  } else {
-    // Otherwise print logs to terminal.
-    tracing_subscriber::FmtSubscriber::builder()
-      .with_file(true)
-      .with_line_number(true)
-      .with_thread_ids(false)
-      .with_thread_names(false)
-      .with_level(true)
-      .with_ansi(false)
-      .with_env_filter(env_filter)
-      .with_writer(std::io::stderr)
-      .init();
-  }
+  let now = Zoned::now();
+  let log_name = format!(
+    "rsvim_{:0>4}-{:0>2}-{:0>2}_{:0>2}-{:0>2}-{:0>2}-{:0>3}.log",
+    now.date().year(),
+    now.date().month(),
+    now.date().day(),
+    now.time().hour(),
+    now.time().minute(),
+    now.time().second(),
+    now.time().millisecond(),
+  );
+  tracing_subscriber::FmtSubscriber::builder()
+    .with_file(true)
+    .with_line_number(true)
+    .with_thread_ids(true)
+    .with_thread_names(true)
+    .with_level(true)
+    .with_ansi(false)
+    .with_env_filter(env_filter)
+    .with_writer(tracing_appender::rolling::never(".", log_name))
+    .init();
 }

--- a/rsvim_core/src/log.rs
+++ b/rsvim_core/src/log.rs
@@ -7,8 +7,7 @@ use tracing_subscriber::{self, EnvFilter};
 /// Initialize file logging, always use file logging.
 ///
 /// It uses `RSVIM_LOG` environment variable to control the logging level.
-/// Defaults to `error`. The logs are written into file if log level >= `INFO`, otherwise it prints
-/// to terminal.
+/// Defaults to `error`.
 pub fn init() {
   let env_filter = EnvFilter::from_env("RSVIM_LOG");
 

--- a/rsvim_core/src/test.rs
+++ b/rsvim_core/src/test.rs
@@ -7,6 +7,8 @@ pub mod buf;
 #[cfg(test)]
 pub mod constant;
 #[cfg(test)]
+pub mod js;
+#[cfg(test)]
 pub mod log;
 #[cfg(test)]
 pub mod tree;

--- a/rsvim_core/src/test/js.rs
+++ b/rsvim_core/src/test/js.rs
@@ -4,7 +4,6 @@ use crate::content::TextContents;
 use crate::js::{JsRuntime, JsRuntimeOptions};
 use crate::prelude::*;
 use crate::state::State;
-use crate::state::fsm::StatefulValue;
 use crate::ui::tree::Tree;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -18,7 +17,6 @@ pub fn make_js_runtime() -> JsRuntime {
 
   let cli_opt = CliOpt::new(false, vec![]);
   let state = State::to_arc(State::new(jsrt_tick_dispatcher.clone()));
-  // let _stateful_machine = StatefulValue::default();
 
   let tree = Tree::to_arc(Tree::new(canvas_size));
   let buffers_manager = BuffersManager::to_arc(BuffersManager::new());

--- a/rsvim_core/src/test/js.rs
+++ b/rsvim_core/src/test/js.rs
@@ -1,0 +1,45 @@
+use crate::buf::BuffersManager;
+use crate::cli::CliOpt;
+use crate::content::TextContents;
+use crate::js::{JsRuntime, JsRuntimeOptions};
+use crate::prelude::*;
+use crate::state::State;
+use crate::state::fsm::StatefulValue;
+use crate::ui::tree::Tree;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::mpsc::channel;
+
+pub fn make_js_runtime() -> JsRuntime {
+  let canvas_size = U16Size::new(10, 10);
+  let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
+  let (jsrt_to_mstr, _mstr_from_jsrt) = channel(*CHANNEL_BUF_SIZE);
+  let (_mstr_to_jsrt, jsrt_from_mstr) = channel(*CHANNEL_BUF_SIZE);
+
+  let cli_opt = CliOpt::new(false, vec![]);
+  let state = State::to_arc(State::new(jsrt_tick_dispatcher.clone()));
+  // let _stateful_machine = StatefulValue::default();
+
+  let tree = Tree::to_arc(Tree::new(canvas_size));
+  let buffers_manager = BuffersManager::to_arc(BuffersManager::new());
+  let text_contents = TextContents::to_arc(TextContents::new(canvas_size));
+
+  let startup_moment = Instant::now();
+  let startup_unix_epoch = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .unwrap()
+    .as_millis();
+
+  JsRuntime::new_without_snapshot(
+    JsRuntimeOptions::default(),
+    startup_moment,
+    startup_unix_epoch,
+    jsrt_to_mstr,
+    jsrt_from_mstr,
+    cli_opt.clone(),
+    tree.clone(),
+    buffers_manager.clone(),
+    text_contents.clone(),
+    state.clone(),
+  )
+}


### PR DESCRIPTION
This PR completes several tasks:
1. Split test cases from `crate::cli`
2. Fix `FsModuleLoader` detection when module specifier has no extension
3. Add test cases for fetching modules and fs loaders

TODO: fix #555 