### PR TITLE
fix(insert): refactor "CursorInsert" op and insert tab

### DIFF
--- a/rsvim_core/src/state/fsm/command_line_ex_tests.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex_tests.rs
@@ -113,7 +113,7 @@ pub fn make_canvas(tree: TreeArc, terminal_size: U16Size) -> CanvasArc {
 pub fn assert_viewport(
   text: &Text,
   actual: &Viewport,
-  expect: &Vec<&str>,
+  expect_rows: &Vec<&str>,
   expect_start_line: usize,
   expect_end_line: usize,
   expect_start_fills: &BTreeMap<usize, usize>,
@@ -131,8 +131,8 @@ pub fn assert_viewport(
   for (k, v) in actual.lines().iter() {
     info!("actual line[{:?}]: {:?}", k, v);
   }
-  for (i, e) in expect.iter().enumerate() {
-    info!("expect line[{}]:{:?}", i, e);
+  for (i, e) in expect_rows.iter().enumerate() {
+    info!("expect row[{}]:{:?}", i, e);
   }
   assert_eq!(expect_start_fills.len(), expect_end_fills.len());
   for (k, start_v) in expect_start_fills.iter() {
@@ -228,9 +228,9 @@ pub fn assert_viewport(
       }
       info!(
         "row-{:?}, payload actual:{:?}, expect:{:?}",
-        r, payload, expect[*r as usize]
+        r, payload, expect_rows[*r as usize]
       );
-      assert_eq!(payload, expect[*r as usize]);
+      assert_eq!(payload, expect_rows[*r as usize]);
     }
   }
 }

--- a/rsvim_core/src/state/fsm/command_line_ex_tests.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex_tests.rs
@@ -268,6 +268,7 @@ mod tests_goto_normal_mode {
   use crate::buf::opt::BufferLocalOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
+  use crate::state::ops::CursorInsertPayload;
   use crate::state::{self, State, StateArc};
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
@@ -365,7 +366,10 @@ mod tests_goto_normal_mode {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Bye"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Bye".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = lock!(tree.clone())
@@ -536,7 +540,10 @@ mod tests_goto_normal_mode {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Bye"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Bye".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = lock!(tree.clone())
@@ -628,6 +635,7 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
   use crate::buf::opt::BufferLocalOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
+  use crate::state::ops::CursorInsertPayload;
   use crate::state::{self, State, StateArc};
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
@@ -727,7 +735,9 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
     {
       stateful.cursor_insert(
         &data_access,
-        CompactString::new("Bye1 Bye2 Bye3 Bye4 Bye5 Bye6 Bye7"),
+        CursorInsertPayload::Text(
+          "Bye1 Bye2 Bye3 Bye4 Bye5 Bye6 Bye7".to_compact_string(),
+        ),
       );
 
       let tree = data_access.tree.clone();

--- a/rsvim_core/src/state/fsm/command_line_ex_tests.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex_tests.rs
@@ -110,7 +110,7 @@ pub fn make_canvas(tree: TreeArc, terminal_size: U16Size) -> CanvasArc {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn assert_viewport_scroll(
+pub fn assert_viewport(
   text: &Text,
   actual: &Viewport,
   expect: &Vec<&str>,
@@ -339,7 +339,7 @@ mod tests_goto_normal_mode {
       let expect = vec![""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         lock!(contents).command_line_content(),
         &viewport,
         &expect,
@@ -386,7 +386,7 @@ mod tests_goto_normal_mode {
       let expect = vec![line0.as_str()];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         lock!(contents).command_line_content(),
         &viewport,
         &expect,
@@ -426,7 +426,7 @@ mod tests_goto_normal_mode {
       let expect = vec![""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         lock!(contents).command_line_content(),
         &viewport,
         &expect,
@@ -510,7 +510,7 @@ mod tests_goto_normal_mode {
       let expect = vec![""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         lock!(contents).command_line_content(),
         &viewport,
         &expect,
@@ -557,7 +557,7 @@ mod tests_goto_normal_mode {
       let expect = vec![line0.as_str()];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         lock!(contents).command_line_content(),
         &viewport,
         &expect,
@@ -597,7 +597,7 @@ mod tests_goto_normal_mode {
       let expect = vec![""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         lock!(contents).command_line_content(),
         &viewport,
         &expect,
@@ -699,7 +699,7 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
       let expect = vec![""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         lock!(contents).command_line_content(),
         &viewport,
         &expect,
@@ -749,7 +749,7 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
       let expect = vec![line0.as_str()];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         lock!(contents).command_line_content(),
         &viewport,
         &expect,

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -37,6 +37,9 @@ impl InsertStateful {
             KeyCode::Char(c) => {
               Some(Operation::CursorInsert(c.to_compact_string()))
             }
+            KeyCode::Tab => {
+              Some(Operation::CursorInsert('\t'.to_compact_string()))
+            }
             KeyCode::Enter => {
               let eol = {
                 let tree = data_access.tree.clone();

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -2,8 +2,8 @@
 
 use crate::prelude::*;
 use crate::state::fsm::{Stateful, StatefulDataAccess, StatefulValue};
-use crate::state::ops::Operation;
 use crate::state::ops::cursor_ops;
+use crate::state::ops::{CursorInsertPayload, Operation};
 use crate::ui::canvas::CursorStyle;
 use crate::ui::tree::*;
 
@@ -34,25 +34,14 @@ impl InsertStateful {
             KeyCode::Right => Some(Operation::CursorMoveRightBy(1)),
             KeyCode::Home => Some(Operation::CursorMoveLeftBy(usize::MAX)),
             KeyCode::End => Some(Operation::CursorMoveRightBy(usize::MAX)),
-            KeyCode::Char(c) => {
-              Some(Operation::CursorInsert(c.to_compact_string()))
-            }
+            KeyCode::Char(c) => Some(Operation::CursorInsert(
+              CursorInsertPayload::Text(c.to_compact_string()),
+            )),
             KeyCode::Tab => {
-              Some(Operation::CursorInsert('\t'.to_compact_string()))
+              Some(Operation::CursorInsert(CursorInsertPayload::Tab))
             }
             KeyCode::Enter => {
-              let eol = {
-                let tree = data_access.tree.clone();
-                let tree = lock!(tree);
-                debug_assert!(tree.current_window_id().is_some());
-                let current_window = tree.current_window().unwrap();
-                let buffer = current_window.buffer().upgrade().unwrap();
-                let buffer = lock!(buffer);
-                buffer.options().end_of_line()
-              };
-              let eol = format!("{eol}");
-              trace!("Insert eol:{eol:?}");
-              Some(Operation::CursorInsert(eol.to_compact_string()))
+              Some(Operation::CursorInsert(CursorInsertPayload::Eol))
             }
             KeyCode::Backspace => Some(Operation::CursorDelete(-1)),
             KeyCode::Delete => Some(Operation::CursorDelete(1)),
@@ -92,7 +81,9 @@ impl Stateful for InsertStateful {
       | Operation::CursorMoveLeftBy(_)
       | Operation::CursorMoveRightBy(_)
       | Operation::CursorMoveTo((_, _)) => self.cursor_move(&data_access, op),
-      Operation::CursorInsert(text) => self.cursor_insert(&data_access, text),
+      Operation::CursorInsert(payload) => {
+        self.cursor_insert(&data_access, payload)
+      }
       Operation::CursorDelete(n) => self.cursor_delete(&data_access, n),
       _ => unreachable!(),
     }
@@ -127,7 +118,7 @@ impl InsertStateful {
   pub fn cursor_insert(
     &self,
     data_access: &StatefulDataAccess,
-    payload: CompactString,
+    payload: CursorInsertPayload,
   ) -> StatefulValue {
     let tree = data_access.tree.clone();
     let mut tree = lock!(tree);
@@ -135,6 +126,17 @@ impl InsertStateful {
     let current_window_id = current_window.id();
     let buffer = current_window.buffer().upgrade().unwrap();
     let mut buffer = lock!(buffer);
+
+    let payload = match payload {
+      CursorInsertPayload::Text(c) => c,
+      CursorInsertPayload::Tab => '\t'.to_compact_string(),
+      CursorInsertPayload::Eol => {
+        let eol = buffer.options().end_of_line();
+        let eol = format!("{eol}");
+        trace!("Insert eol:{eol:?}");
+        eol.to_compact_string()
+      }
+    };
 
     cursor_ops::cursor_insert(
       &mut tree,

--- a/rsvim_core/src/state/fsm/insert.rs
+++ b/rsvim_core/src/state/fsm/insert.rs
@@ -7,7 +7,7 @@ use crate::state::ops::{CursorInsertPayload, Operation};
 use crate::ui::canvas::CursorStyle;
 use crate::ui::tree::*;
 
-use compact_str::{CompactString, ToCompactString};
+use compact_str::ToCompactString;
 use crossterm::event::{Event, KeyCode, KeyEventKind};
 
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -2255,7 +2255,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Bye, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Bye, ".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -2377,7 +2380,10 @@ mod tests_insert_text {
 
     // Insert-3
     {
-      stateful.cursor_insert(&data_access, CompactString::new(" Go!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text(" Go!".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual3 = get_cursor_viewport(tree.clone());
@@ -2486,7 +2492,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Bye, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Bye, ".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -5847,7 +5847,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Hello, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Hello, ".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 0);
@@ -5935,7 +5938,10 @@ mod tests_insert_text {
 
     // Insert-3
     {
-      stateful.cursor_insert(&data_access, CompactString::new("World!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("World!".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 2);
@@ -5979,8 +5985,10 @@ mod tests_insert_text {
 
     // Insert-4
     {
-      stateful
-        .cursor_insert(&data_access, CompactString::new("Let's go further!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Let's go further!".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 2);
@@ -6070,7 +6078,10 @@ mod tests_insert_text {
 
     // Insert-6
     {
-      stateful.cursor_insert(&data_access, CompactString::new("DDDDDDDDDD"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("DDDDDDDDDD".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 7);
@@ -6158,7 +6169,10 @@ mod tests_insert_text {
 
     // Insert-8
     {
-      stateful.cursor_insert(&data_access, CompactString::new("abc"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("abc".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 7);
@@ -6252,7 +6266,7 @@ mod tests_insert_text {
         "{}\n",
         characters.iter().collect::<String>()
       ));
-      stateful.cursor_insert(&data_access, text2);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text2));
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -6439,7 +6453,10 @@ mod tests_insert_text {
 
     // Insert-3
     {
-      stateful.cursor_insert(&data_access, CompactString::new("你好，Rsvim！"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("你好，Rsvim！".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 1);

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -2729,7 +2729,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Bye, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Bye, ".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -2851,7 +2854,10 @@ mod tests_insert_text {
 
     // Insert-3
     {
-      stateful.cursor_insert(&data_access, CompactString::new(" Go!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text(" Go!".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual3 = get_cursor_viewport(tree.clone());
@@ -3003,7 +3009,10 @@ mod tests_insert_text {
 
     // Insert-2
     {
-      stateful.cursor_insert(&data_access, CompactString::new("a"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("a".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -3143,7 +3152,7 @@ mod tests_insert_text {
       let text2 = CompactString::new(format!(
         "Let's{buf_eol}insert{buf_eol}multiple lines!{buf_eol}"
       ));
-      stateful.cursor_insert(&data_access, text2);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text2));
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -3194,7 +3203,7 @@ mod tests_insert_text {
       let text2 = CompactString::new(format!(
         "Insert two lines again!{buf_eol}There's no line-break"
       ));
-      stateful.cursor_insert(&data_access, text2);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text2));
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -3284,7 +3293,7 @@ mod tests_insert_text {
       let text5 = CompactString::new(format!(
         "Final 3 lines.{buf_eol}The inserted 2nd{buf_eol}The inserted 3rd{buf_eol}"
       ));
-      stateful.cursor_insert(&data_access, text5);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text5));
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -3324,7 +3333,10 @@ mod tests_insert_text {
 
     // Insert-6
     {
-      stateful.cursor_insert(&data_access, "Insert 4th".to_compact_string());
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Insert 4th".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -3461,7 +3473,7 @@ mod tests_insert_text {
       let text2 = CompactString::new(format!(
         "Let's{buf_eol}insert{buf_eol}multiple lines!{buf_eol}"
       ));
-      stateful.cursor_insert(&data_access, text2);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text2));
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -3512,7 +3524,7 @@ mod tests_insert_text {
       let text2 = CompactString::new(format!(
         "Insert two lines again!{buf_eol}There's no line-break"
       ));
-      stateful.cursor_insert(&data_access, text2);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text2));
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -3602,7 +3614,7 @@ mod tests_insert_text {
       let text5 = CompactString::new(format!(
         "Final 3 lines.{buf_eol}The inserted 2nd{buf_eol}The inserted 3rd{buf_eol}"
       ));
-      stateful.cursor_insert(&data_access, text5);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text5));
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -3647,7 +3659,10 @@ mod tests_insert_text {
 
     // Insert-6
     {
-      stateful.cursor_insert(&data_access, "Insert 4th".to_compact_string());
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Insert 4th".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -3784,7 +3799,7 @@ mod tests_insert_text {
       let text2 = CompactString::new(format!(
         "Let's{buf_eol}insert{buf_eol}multiple lines!{buf_eol}"
       ));
-      stateful.cursor_insert(&data_access, text2);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text2));
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -3835,7 +3850,7 @@ mod tests_insert_text {
       let text2 = CompactString::new(format!(
         "Insert two lines again!{buf_eol}There's no line-break"
       ));
-      stateful.cursor_insert(&data_access, text2);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text2));
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -3925,7 +3940,7 @@ mod tests_insert_text {
       let text5 = CompactString::new(format!(
         "Final 3 lines.{buf_eol}The inserted 2nd{buf_eol}The inserted 3rd{buf_eol}"
       ));
-      stateful.cursor_insert(&data_access, text5);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text5));
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -3965,7 +3980,10 @@ mod tests_insert_text {
 
     // Insert-6
     {
-      stateful.cursor_insert(&data_access, "Insert 4th".to_compact_string());
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Insert 4th".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -4042,7 +4060,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, "Hi".to_compact_string());
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Hi".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -4116,7 +4137,10 @@ mod tests_insert_text {
       let buf_eol = lock!(buf).options().end_of_line();
       let line1 = format!("Hi{buf_eol}");
 
-      stateful.cursor_insert(&data_access, line1.to_compact_string());
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text(line1.to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -4192,7 +4216,10 @@ mod tests_insert_text {
       let buf_eol = lock!(buf).options().end_of_line();
       let buf_eol = format!("{buf_eol}");
 
-      stateful.cursor_insert(&data_access, buf_eol.to_compact_string());
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text(buf_eol.to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual2 = get_cursor_viewport(tree.clone());
@@ -4276,7 +4303,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Hello, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Hello, ".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 0);
@@ -4368,7 +4398,10 @@ mod tests_insert_text {
 
     // Insert-3
     {
-      stateful.cursor_insert(&data_access, CompactString::new("World!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("World!".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 2);
@@ -4414,7 +4447,10 @@ mod tests_insert_text {
 
     // Insert-4
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Go!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Go!".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 2);
@@ -4504,7 +4540,10 @@ mod tests_insert_text {
 
     // Insert-6
     {
-      stateful.cursor_insert(&data_access, CompactString::new("DDDDDDDDDD"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("DDDDDDDDDD".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 7);
@@ -4592,7 +4631,10 @@ mod tests_insert_text {
 
     // Insert-8
     {
-      stateful.cursor_insert(&data_access, CompactString::new("abc"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("abc".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 7);
@@ -4691,7 +4733,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Hello, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Hello, ".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 0);
@@ -4783,7 +4828,10 @@ mod tests_insert_text {
 
     // Insert-3
     {
-      stateful.cursor_insert(&data_access, CompactString::new("World!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("World!".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 2);
@@ -4829,7 +4877,10 @@ mod tests_insert_text {
 
     // Insert-4
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Go!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Go!".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 2);
@@ -4919,7 +4970,10 @@ mod tests_insert_text {
 
     // Insert-6
     {
-      stateful.cursor_insert(&data_access, CompactString::new("DDDDDDDDDD"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("DDDDDDDDDD".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 7);
@@ -5007,7 +5061,10 @@ mod tests_insert_text {
 
     // Insert-8
     {
-      stateful.cursor_insert(&data_access, CompactString::new("abc"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("abc".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 7);
@@ -5106,7 +5163,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Hello, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Hello, ".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 0);
@@ -5198,7 +5258,10 @@ mod tests_insert_text {
 
     // Insert-3
     {
-      stateful.cursor_insert(&data_access, CompactString::new("World!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("World!".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 2);
@@ -5244,7 +5307,10 @@ mod tests_insert_text {
 
     // Insert-4
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Go!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Go!".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 2);
@@ -5334,7 +5400,10 @@ mod tests_insert_text {
 
     // Insert-6
     {
-      stateful.cursor_insert(&data_access, CompactString::new("DDDDDDDDDD"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("DDDDDDDDDD".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 7);
@@ -5422,7 +5491,10 @@ mod tests_insert_text {
 
     // Insert-8
     {
-      stateful.cursor_insert(&data_access, CompactString::new("abc"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("abc".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 7);
@@ -5499,7 +5571,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("a"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("a".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 0);
@@ -5571,7 +5646,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("b"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("b".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 0);
@@ -5643,7 +5721,10 @@ mod tests_insert_text {
 
     // Insert-1
     {
-      stateful.cursor_insert(&data_access, CompactString::new("这个"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("这个".to_compact_string()),
+      );
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 0);

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -2617,7 +2617,10 @@ mod tests_insert_text {
 
     // Insert-3
     {
-      stateful.cursor_insert(&data_access, CompactString::new(" Go!"));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text(" Go!".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual3 = get_cursor_viewport(tree.clone());

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -79,7 +79,7 @@ pub fn get_cursor_viewport(tree: TreeArc) -> CursorViewportArc {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn assert_viewport_scroll(
+pub fn assert_viewport(
   buffer: BufferArc,
   actual: &Viewport,
   expect: &Vec<&str>,
@@ -356,7 +356,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -392,7 +392,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -481,7 +481,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -517,7 +517,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -606,7 +606,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -642,7 +642,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -724,7 +724,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -758,7 +758,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -792,7 +792,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -826,7 +826,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -860,7 +860,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -894,7 +894,7 @@ mod tests_cursor_move {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -981,7 +981,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1015,7 +1015,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1049,7 +1049,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1083,7 +1083,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1117,7 +1117,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1151,7 +1151,7 @@ mod tests_cursor_move {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1238,7 +1238,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1272,7 +1272,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1306,7 +1306,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1340,7 +1340,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1374,7 +1374,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1408,7 +1408,7 @@ mod tests_cursor_move {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1490,7 +1490,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1524,7 +1524,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1558,7 +1558,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1592,7 +1592,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1626,7 +1626,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1660,7 +1660,7 @@ mod tests_cursor_move {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1747,7 +1747,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1781,7 +1781,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1815,7 +1815,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1849,7 +1849,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1883,7 +1883,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1917,7 +1917,7 @@ mod tests_cursor_move {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2004,7 +2004,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2038,7 +2038,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2072,7 +2072,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2106,7 +2106,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2140,7 +2140,7 @@ mod tests_cursor_move {
         vec![(3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2174,7 +2174,7 @@ mod tests_cursor_move {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2286,7 +2286,7 @@ mod tests_insert_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2347,7 +2347,7 @@ mod tests_insert_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2408,7 +2408,7 @@ mod tests_insert_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2517,7 +2517,7 @@ mod tests_insert_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2578,7 +2578,7 @@ mod tests_insert_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2639,7 +2639,7 @@ mod tests_insert_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2748,7 +2748,7 @@ mod tests_insert_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2809,7 +2809,7 @@ mod tests_insert_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2870,7 +2870,7 @@ mod tests_insert_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2961,7 +2961,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3013,7 +3013,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3102,7 +3102,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3153,7 +3153,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3197,7 +3197,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3243,7 +3243,7 @@ mod tests_insert_text {
         vec![(5, 0), (6, 0), (7, 0), (8, 0), (9, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3287,7 +3287,7 @@ mod tests_insert_text {
         vec![(8, 0), (9, 0), (10, 0), (11, 0), (12, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3332,7 +3332,7 @@ mod tests_insert_text {
         vec![(8, 0), (9, 0), (10, 0), (11, 0), (12, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3420,7 +3420,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3471,7 +3471,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3515,7 +3515,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3561,7 +3561,7 @@ mod tests_insert_text {
         vec![(5, 0), (6, 0), (7, 0), (8, 0), (9, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3610,7 +3610,7 @@ mod tests_insert_text {
         vec![(8, 0), (9, 0), (10, 0), (11, 0), (12, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3655,7 +3655,7 @@ mod tests_insert_text {
         vec![(8, 0), (9, 0), (10, 0), (11, 0), (12, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3743,7 +3743,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3794,7 +3794,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3838,7 +3838,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3884,7 +3884,7 @@ mod tests_insert_text {
         vec![(5, 0), (6, 0), (7, 0), (8, 0), (9, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3928,7 +3928,7 @@ mod tests_insert_text {
         vec![(8, 0), (9, 0), (10, 0), (11, 0), (12, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3973,7 +3973,7 @@ mod tests_insert_text {
         vec![(8, 0), (9, 0), (10, 0), (11, 0), (12, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4044,7 +4044,7 @@ mod tests_insert_text {
       let expect = vec![l0.as_str(), ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4116,7 +4116,7 @@ mod tests_insert_text {
       let expect = vec![line1.as_str(), ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4192,7 +4192,7 @@ mod tests_insert_text {
       let expect = vec![buf_eol.as_str(), ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4284,7 +4284,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4330,7 +4330,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4376,7 +4376,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4420,7 +4420,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4466,7 +4466,7 @@ mod tests_insert_text {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4510,7 +4510,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0), (8, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4554,7 +4554,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0), (8, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4598,7 +4598,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4699,7 +4699,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4745,7 +4745,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4791,7 +4791,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4835,7 +4835,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4881,7 +4881,7 @@ mod tests_insert_text {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4925,7 +4925,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0), (8, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4969,7 +4969,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0), (8, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5013,7 +5013,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5114,7 +5114,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5160,7 +5160,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5206,7 +5206,7 @@ mod tests_insert_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5250,7 +5250,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5296,7 +5296,7 @@ mod tests_insert_text {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5340,7 +5340,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0), (8, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5384,7 +5384,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0), (8, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5428,7 +5428,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5500,7 +5500,7 @@ mod tests_insert_text {
       let expect = vec![a.as_str(), ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5572,7 +5572,7 @@ mod tests_insert_text {
       let expect = vec![b.as_str(), ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5644,7 +5644,7 @@ mod tests_insert_text {
       let expect = vec![b.as_str(), ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5733,7 +5733,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5777,7 +5777,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5821,7 +5821,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5866,7 +5866,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5912,7 +5912,7 @@ mod tests_insert_text {
         vec![(4, 0), (5, 0), (6, 0), (7, 0), (8, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5956,7 +5956,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0), (8, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6000,7 +6000,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0), (8, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6044,7 +6044,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0), (6, 0), (7, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6136,7 +6136,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6232,7 +6232,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6277,7 +6277,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6322,7 +6322,7 @@ mod tests_insert_text {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6450,7 +6450,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6511,7 +6511,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6572,7 +6572,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6633,7 +6633,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6685,7 +6685,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6737,7 +6737,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6789,7 +6789,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6841,7 +6841,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6893,7 +6893,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6947,7 +6947,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7001,7 +7001,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7110,7 +7110,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7171,7 +7171,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7232,7 +7232,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7293,7 +7293,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7345,7 +7345,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7397,7 +7397,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7449,7 +7449,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7501,7 +7501,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7553,7 +7553,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7607,7 +7607,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7661,7 +7661,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7770,7 +7770,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7831,7 +7831,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7892,7 +7892,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7953,7 +7953,7 @@ mod tests_delete_text {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8005,7 +8005,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8057,7 +8057,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8109,7 +8109,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8161,7 +8161,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8213,7 +8213,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8267,7 +8267,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8321,7 +8321,7 @@ mod tests_delete_text {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8395,7 +8395,7 @@ mod tests_delete_text {
       let expect = vec![""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8469,7 +8469,7 @@ mod tests_delete_text {
       let expect = vec![""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -6348,7 +6348,7 @@ mod tests_insert_text {
         "{}\n",
         characters.iter().collect::<String>()
       ));
-      stateful.cursor_insert(&data_access, text2);
+      stateful.cursor_insert(&data_access, CursorInsertPayload::Text(text2));
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -5767,7 +5767,7 @@ mod tests_insert_text {
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
       assert_eq!(actual1.line_idx(), 0);
-      assert_eq!(actual1.char_idx(), 2);
+      assert_eq!(actual1.char_idx(), 3);
       assert_eq!(actual1.row_idx(), 1);
       assert_eq!(actual1.column_idx(), 8);
 

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -82,7 +82,7 @@ pub fn get_cursor_viewport(tree: TreeArc) -> CursorViewportArc {
 pub fn assert_viewport(
   buffer: BufferArc,
   actual: &Viewport,
-  expect: &Vec<&str>,
+  expect_rows: &Vec<&str>,
   expect_start_line: usize,
   expect_end_line: usize,
   expect_start_fills: &BTreeMap<usize, usize>,
@@ -100,8 +100,8 @@ pub fn assert_viewport(
   for (k, v) in actual.lines().iter() {
     info!("actual line[{:?}]: {:?}", k, v);
   }
-  for (i, e) in expect.iter().enumerate() {
-    info!("expect line[{}]:{:?}", i, e);
+  for (i, e) in expect_rows.iter().enumerate() {
+    info!("expect row[{}]:{:?}", i, e);
   }
   assert_eq!(expect_start_fills.len(), expect_end_fills.len());
   for (k, start_v) in expect_start_fills.iter() {
@@ -202,9 +202,9 @@ pub fn assert_viewport(
       }
       info!(
         "row-{:?}, payload actual:{:?}, expect:{:?}",
-        r, payload, expect[*r as usize]
+        r, payload, expect_rows[*r as usize]
       );
-      assert_eq!(payload, expect[*r as usize]);
+      assert_eq!(payload, expect_rows[*r as usize]);
     }
   }
 }

--- a/rsvim_core/src/state/fsm/normal_tests.rs
+++ b/rsvim_core/src/state/fsm/normal_tests.rs
@@ -8726,6 +8726,7 @@ mod tests_goto_insert_mode {
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
   use crate::state::fsm::InsertStateful;
+  use crate::state::ops::CursorInsertPayload;
   use crate::state::{State, StateArc};
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
@@ -8739,6 +8740,7 @@ mod tests_goto_insert_mode {
     WindowLocalOptions, WindowLocalOptionsBuilder,
   };
 
+  use compact_str::ToCompactString;
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
   };
@@ -8810,7 +8812,10 @@ mod tests_goto_insert_mode {
     let stateful = InsertStateful::default();
     // Insert-2
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Bye, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Bye, ".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -8909,7 +8914,10 @@ mod tests_goto_insert_mode {
     let stateful = InsertStateful::default();
     // Insert-2
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Bye, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Bye, ".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -9008,7 +9016,10 @@ mod tests_goto_insert_mode {
     let stateful = InsertStateful::default();
     // Insert-2
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Bye, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Bye, ".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());
@@ -9106,7 +9117,10 @@ mod tests_goto_insert_mode {
     let stateful = InsertStateful::default();
     // Insert-2
     {
-      stateful.cursor_insert(&data_access, CompactString::new("Bye, "));
+      stateful.cursor_insert(
+        &data_access,
+        CursorInsertPayload::Text("Bye, ".to_compact_string()),
+      );
 
       let tree = data_access.tree.clone();
       let actual1 = get_cursor_viewport(tree.clone());

--- a/rsvim_core/src/state/fsm/normal_tests.rs
+++ b/rsvim_core/src/state/fsm/normal_tests.rs
@@ -113,7 +113,7 @@ pub fn make_canvas(tree: TreeArc, terminal_size: U16Size) -> CanvasArc {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn assert_viewport_scroll(
+pub fn assert_viewport(
   buffer: BufferArc,
   actual: &Viewport,
   expect: &Vec<&str>,
@@ -1469,7 +1469,7 @@ mod tests_raw_window_scroll_y_by {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1500,7 +1500,7 @@ mod tests_raw_window_scroll_y_by {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1566,7 +1566,7 @@ mod tests_raw_window_scroll_y_by {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1607,7 +1607,7 @@ mod tests_raw_window_scroll_y_by {
         vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1667,7 +1667,7 @@ mod tests_raw_window_scroll_y_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1708,7 +1708,7 @@ mod tests_raw_window_scroll_y_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1766,7 +1766,7 @@ mod tests_raw_window_scroll_y_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1805,7 +1805,7 @@ mod tests_raw_window_scroll_y_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1863,7 +1863,7 @@ mod tests_raw_window_scroll_y_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1901,7 +1901,7 @@ mod tests_raw_window_scroll_y_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1931,7 +1931,7 @@ mod tests_raw_window_scroll_y_by {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(8, 0), (9, 0), (10, 0)].into_iter().collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1961,7 +1961,7 @@ mod tests_raw_window_scroll_y_by {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(7, 0), (8, 0), (9, 0), (10, 0)].into_iter().collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -1999,7 +1999,7 @@ mod tests_raw_window_scroll_y_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2037,7 +2037,7 @@ mod tests_raw_window_scroll_y_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2075,7 +2075,7 @@ mod tests_raw_window_scroll_y_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2140,7 +2140,7 @@ mod tests_raw_window_scroll_y_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2186,7 +2186,7 @@ mod tests_raw_window_scroll_y_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(4, 0), (5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2251,7 +2251,7 @@ mod tests_raw_window_scroll_y_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2297,7 +2297,7 @@ mod tests_raw_window_scroll_y_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(8, 0), (9, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2343,7 +2343,7 @@ mod tests_raw_window_scroll_y_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(9, 0), (10, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2373,7 +2373,7 @@ mod tests_raw_window_scroll_y_by {
       let expect = vec!["", "", ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(10, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2419,7 +2419,7 @@ mod tests_raw_window_scroll_y_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(8, 0), (9, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2487,7 +2487,7 @@ mod tests_raw_window_scroll_x_by {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2518,7 +2518,7 @@ mod tests_raw_window_scroll_x_by {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2584,7 +2584,7 @@ mod tests_raw_window_scroll_x_by {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2634,7 +2634,7 @@ mod tests_raw_window_scroll_x_by {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2694,7 +2694,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2735,7 +2735,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2793,7 +2793,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2834,7 +2834,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2892,7 +2892,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2933,7 +2933,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -2969,7 +2969,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3004,7 +3004,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3045,7 +3045,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3103,7 +3103,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3141,7 +3141,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3179,7 +3179,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3217,7 +3217,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3255,7 +3255,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3293,7 +3293,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3331,7 +3331,7 @@ mod tests_raw_window_scroll_x_by {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3396,7 +3396,7 @@ mod tests_raw_window_scroll_x_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3442,7 +3442,7 @@ mod tests_raw_window_scroll_x_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3507,7 +3507,7 @@ mod tests_raw_window_scroll_x_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3553,7 +3553,7 @@ mod tests_raw_window_scroll_x_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3601,7 +3601,7 @@ mod tests_raw_window_scroll_x_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3649,7 +3649,7 @@ mod tests_raw_window_scroll_x_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3697,7 +3697,7 @@ mod tests_raw_window_scroll_x_by {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3789,7 +3789,7 @@ mod tests_raw_window_scroll_to {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3830,7 +3830,7 @@ mod tests_raw_window_scroll_to {
         vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0), (7, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3888,7 +3888,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3926,7 +3926,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3956,7 +3956,7 @@ mod tests_raw_window_scroll_to {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(8, 0), (9, 0), (10, 0)].into_iter().collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -3986,7 +3986,7 @@ mod tests_raw_window_scroll_to {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(7, 0), (8, 0), (9, 0), (10, 0)].into_iter().collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4024,7 +4024,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4062,7 +4062,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4100,7 +4100,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4158,7 +4158,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4196,7 +4196,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4234,7 +4234,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4272,7 +4272,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4310,7 +4310,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4348,7 +4348,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4386,7 +4386,7 @@ mod tests_raw_window_scroll_to {
           .into_iter()
           .collect();
 
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4583,7 +4583,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4626,7 +4626,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4715,7 +4715,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4758,7 +4758,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4847,7 +4847,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4890,7 +4890,7 @@ mod tests_cursor_move {
       ]
       .into_iter()
       .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4963,7 +4963,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -4995,7 +4995,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5028,7 +5028,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5060,7 +5060,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5092,7 +5092,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5119,7 +5119,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5145,7 +5145,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5171,7 +5171,7 @@ mod tests_cursor_move {
         vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5197,7 +5197,7 @@ mod tests_cursor_move {
         vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5275,7 +5275,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5307,7 +5307,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5340,7 +5340,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5372,7 +5372,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5404,7 +5404,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5431,7 +5431,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5457,7 +5457,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5483,7 +5483,7 @@ mod tests_cursor_move {
         vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5509,7 +5509,7 @@ mod tests_cursor_move {
         vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5587,7 +5587,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5619,7 +5619,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5652,7 +5652,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5684,7 +5684,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5716,7 +5716,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5743,7 +5743,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5769,7 +5769,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5795,7 +5795,7 @@ mod tests_cursor_move {
         vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5821,7 +5821,7 @@ mod tests_cursor_move {
         vec![(2, 0), (3, 0), (4, 0), (5, 0), (6, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5899,7 +5899,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -5948,7 +5948,7 @@ mod tests_cursor_move {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0)]
           .into_iter()
           .collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6035,7 +6035,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6070,7 +6070,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6105,7 +6105,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(6, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6140,7 +6140,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6216,7 +6216,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6251,7 +6251,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6286,7 +6286,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6321,7 +6321,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6356,7 +6356,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6391,7 +6391,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6426,7 +6426,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6461,7 +6461,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6496,7 +6496,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6555,7 +6555,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6595,7 +6595,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6627,7 +6627,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6659,7 +6659,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6691,7 +6691,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(4, 0), (5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6723,7 +6723,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6787,7 +6787,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6827,7 +6827,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6859,7 +6859,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6891,7 +6891,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6923,7 +6923,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(4, 0), (5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -6955,7 +6955,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7019,7 +7019,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7059,7 +7059,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7091,7 +7091,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7123,7 +7123,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7155,7 +7155,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(4, 0), (5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7187,7 +7187,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7246,7 +7246,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7286,7 +7286,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7318,7 +7318,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(4, 0), (5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7350,7 +7350,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7414,7 +7414,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7454,7 +7454,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7487,7 +7487,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0), (5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7519,7 +7519,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7583,7 +7583,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7623,7 +7623,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7656,7 +7656,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0), (5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7688,7 +7688,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7765,7 +7765,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7800,7 +7800,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7835,7 +7835,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(6, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7870,7 +7870,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7947,7 +7947,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -7982,7 +7982,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8017,7 +8017,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8052,7 +8052,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8087,7 +8087,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8122,7 +8122,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8157,7 +8157,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8192,7 +8192,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8227,7 +8227,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8287,7 +8287,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8327,7 +8327,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8359,7 +8359,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8391,7 +8391,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8423,7 +8423,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(4, 0), (5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8455,7 +8455,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8514,7 +8514,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8554,7 +8554,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(2, 0), (3, 0), (4, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8586,7 +8586,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(4, 0), (5, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8618,7 +8618,7 @@ mod tests_cursor_move {
       ];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0), (3, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8823,7 +8823,7 @@ mod tests_goto_insert_mode {
       let expect = vec!["ShBye, ould go to insert mode\n", ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -8922,7 +8922,7 @@ mod tests_goto_insert_mode {
       let expect = vec!["ShoBye, uld go to insert mode\n", ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -9021,7 +9021,7 @@ mod tests_goto_insert_mode {
       let expect = vec!["Should go to insert modeBye, \n", ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,
@@ -9121,7 +9121,7 @@ mod tests_goto_insert_mode {
       let expect = vec![line1.as_str(), "Bye, \n", ""];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0), (1, 0), (2, 0)].into_iter().collect();
-      assert_viewport_scroll(
+      assert_viewport(
         buf.clone(),
         &viewport,
         &expect,

--- a/rsvim_core/src/state/fsm/normal_tests.rs
+++ b/rsvim_core/src/state/fsm/normal_tests.rs
@@ -116,7 +116,7 @@ pub fn make_canvas(tree: TreeArc, terminal_size: U16Size) -> CanvasArc {
 pub fn assert_viewport(
   buffer: BufferArc,
   actual: &Viewport,
-  expect: &Vec<&str>,
+  expect_rows: &Vec<&str>,
   expect_start_line: usize,
   expect_end_line: usize,
   expect_start_fills: &BTreeMap<usize, usize>,
@@ -134,8 +134,8 @@ pub fn assert_viewport(
   for (k, v) in actual.lines().iter() {
     info!("actual line[{:?}]: {:?}", k, v);
   }
-  for (i, e) in expect.iter().enumerate() {
-    info!("expect line[{}]:{:?}", i, e);
+  for (i, e) in expect_rows.iter().enumerate() {
+    info!("expect rows[{}]:{:?}", i, e);
   }
   assert_eq!(expect_start_fills.len(), expect_end_fills.len());
   for (k, start_v) in expect_start_fills.iter() {
@@ -232,9 +232,9 @@ pub fn assert_viewport(
       }
       info!(
         "row-{:?}, payload actual:{:?}, expect:{:?}",
-        r, payload, expect[*r as usize]
+        r, payload, expect_rows[*r as usize]
       );
-      assert_eq!(payload, expect[*r as usize]);
+      assert_eq!(payload, expect_rows[*r as usize]);
     }
   }
 }

--- a/rsvim_core/src/state/ops.rs
+++ b/rsvim_core/src/state/ops.rs
@@ -65,7 +65,7 @@ pub enum Operation {
   GotoNormalMode,
 
   /// Insert text at cursor.
-  CursorInsert(/* text */ CompactString),
+  CursorInsert(/* text */ CursorInsertPayload),
 
   /// Delete N-chars text, to the left of cursor if negative, to the right of cursor if positive.
   CursorDelete(/* N-chars */ isize),
@@ -100,7 +100,7 @@ pub enum GotoInsertModeVariant {
 }
 
 #[derive(Debug, Clone)]
-pub enum CursorInsertVariant {
+pub enum CursorInsertPayload {
   Text(CompactString),
 
   // End-of-line

--- a/rsvim_core/src/state/ops.rs
+++ b/rsvim_core/src/state/ops.rs
@@ -99,7 +99,7 @@ pub enum GotoInsertModeVariant {
   NewLine,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CursorInsertPayload {
   Text(CompactString),
 

--- a/rsvim_core/src/state/ops.rs
+++ b/rsvim_core/src/state/ops.rs
@@ -98,3 +98,14 @@ pub enum GotoInsertModeVariant {
   /// Create a new line and move cursor to next line
   NewLine,
 }
+
+#[derive(Debug, Clone)]
+pub enum CursorInsertVariant {
+  Text(CompactString),
+
+  // End-of-line
+  Eol,
+
+  // Tab
+  Tab,
+}


### PR DESCRIPTION
This PR refactors the "Operation::CursorInsert(CompactString)" enum for insert mode, the internal data structure is changed to:

```rust
enum Operation {
  CursorInsert(CursorInsertPayload),
  // ...
}
enum CursorInsertPayload {
  Text(CompactString),
  Tab,
  Eol
}
```

This is mostly because some chars (like eol, tab) can be evaluate into different actual chars based on different editor options. For example:
- With default tab option, "Tab" key will insert '\t'. With "expandtab" option (it is not implemented yet, but will be implemented eventually), it will insert N spaces.
- On unix system, "Eol" will insert '\n', on Windows, it will insert "\r\n".

"Operation" hides these low level details, and provide a more user friendly api.