### PR TITLE
refactor(ui): shorten window/command-line widget names

### DIFF
--- a/rsvim_core/src/buf.rs
+++ b/rsvim_core/src/buf.rs
@@ -62,7 +62,7 @@ impl Buffer {
   /// NOTE: This API should not be used to create new buffer, please use [`BuffersManager`] APIs to
   /// manage buffer instances.
   pub fn _new(
-    opts: BufferLocalOptions,
+    opts: BufferOptions,
     canvas_size: U16Size,
     rope: Rope,
     filename: Option<PathBuf>,
@@ -93,11 +93,11 @@ impl Buffer {
     &mut self.text
   }
 
-  pub fn options(&self) -> &BufferLocalOptions {
+  pub fn options(&self) -> &BufferOptions {
     self.text.options()
   }
 
-  pub fn set_options(&mut self, options: &BufferLocalOptions) {
+  pub fn set_options(&mut self, options: &BufferOptions) {
     self.text.set_options(options);
   }
 
@@ -146,7 +146,7 @@ pub struct BuffersManager {
   buffers_by_path: HashMap<Option<PathBuf>, BufferArc>,
 
   // Global-local options for buffers.
-  global_local_options: BufferLocalOptions,
+  global_local_options: BufferOptions,
 }
 
 arc_mutex_ptr!(BuffersManager);
@@ -163,9 +163,7 @@ impl BuffersManager {
     BuffersManager {
       buffers: BTreeMap::new(),
       buffers_by_path: HashMap::new(),
-      global_local_options: BufferLocalOptionsBuilder::default()
-        .build()
-        .unwrap(),
+      global_local_options: BufferOptionsBuilder::default().build().unwrap(),
     }
   }
 
@@ -411,15 +409,15 @@ impl Default for BuffersManager {
 
 // Options {
 impl BuffersManager {
-  pub fn global_local_options(&self) -> &BufferLocalOptions {
+  pub fn global_local_options(&self) -> &BufferOptions {
     &self.global_local_options
   }
 
-  pub fn global_local_options_mut(&mut self) -> &mut BufferLocalOptions {
+  pub fn global_local_options_mut(&mut self) -> &mut BufferOptions {
     &mut self.global_local_options
   }
 
-  pub fn set_global_local_options(&mut self, options: &BufferLocalOptions) {
+  pub fn set_global_local_options(&mut self, options: &BufferOptions) {
     self.global_local_options = *options;
   }
 }

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -18,7 +18,7 @@ mod file_format_tests;
 
 #[derive(Debug, Copy, Clone, Builder)]
 /// Local buffer options.
-pub struct BufferLocalOptions {
+pub struct BufferOptions {
   #[builder(default = defaults::buf::TAB_STOP)]
   tab_stop: u16,
 
@@ -29,7 +29,7 @@ pub struct BufferLocalOptions {
   file_format: FileFormatOption,
 }
 
-impl BufferLocalOptions {
+impl BufferOptions {
   /// Buffer 'tab-stop' option.
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27tabstop%27>.

--- a/rsvim_core/src/buf/opt_tests.rs
+++ b/rsvim_core/src/buf/opt_tests.rs
@@ -4,7 +4,7 @@ use crate::defaults;
 
 #[test]
 fn default1() {
-  let opt1 = BufferLocalOptionsBuilder::default().build().unwrap();
+  let opt1 = BufferOptionsBuilder::default().build().unwrap();
   assert_eq!(opt1.tab_stop(), defaults::buf::TAB_STOP);
   assert_eq!(opt1.file_encoding(), defaults::buf::FILE_ENCODING);
 }

--- a/rsvim_core/src/buf/text.rs
+++ b/rsvim_core/src/buf/text.rs
@@ -1,6 +1,6 @@
 //! Text content backend for buffer.
 
-use crate::buf::opt::BufferLocalOptions;
+use crate::buf::opt::BufferOptions;
 use crate::buf::unicode;
 use crate::prelude::*;
 
@@ -22,7 +22,7 @@ mod cidx_tests;
 pub struct Text {
   rope: Rope,
   cached_lines_width: RefCell<LruCache<usize, ColumnIndex, RandomState>>,
-  options: BufferLocalOptions,
+  options: BufferOptions,
 }
 
 arc_mutex_ptr!(Text);
@@ -33,11 +33,7 @@ fn _cached_size(canvas_size: U16Size) -> std::num::NonZeroUsize {
 }
 
 impl Text {
-  pub fn new(
-    opts: BufferLocalOptions,
-    canvas_size: U16Size,
-    rope: Rope,
-  ) -> Self {
+  pub fn new(opts: BufferOptions, canvas_size: U16Size, rope: Rope) -> Self {
     let cache_size = _cached_size(canvas_size);
     Self {
       rope,
@@ -223,11 +219,11 @@ impl Text {
 
 // Options {
 impl Text {
-  pub fn options(&self) -> &BufferLocalOptions {
+  pub fn options(&self) -> &BufferOptions {
     &self.options
   }
 
-  pub fn set_options(&mut self, options: &BufferLocalOptions) {
+  pub fn set_options(&mut self, options: &BufferOptions) {
     self.options = *options;
   }
 }

--- a/rsvim_core/src/buf/text/cidx.rs
+++ b/rsvim_core/src/buf/text/cidx.rs
@@ -1,6 +1,6 @@
 //! Indexes mappings between character and its display width.
 
-use crate::buf::opt::BufferLocalOptions;
+use crate::buf::opt::BufferOptions;
 use crate::buf::unicode;
 use ropey::RopeSlice;
 
@@ -112,7 +112,7 @@ impl ColumnIndex {
   // Build cache beyond the bound by `char_idx` or `width`.
   fn _build_cache(
     &mut self,
-    options: &BufferLocalOptions,
+    options: &BufferOptions,
     buf_line: &RopeSlice,
     char_idx_bound: Option<usize>,
     width_bound: Option<usize>,
@@ -164,7 +164,7 @@ impl ColumnIndex {
   // Build cache until `char_idx`.
   fn _build_cache_until_char(
     &mut self,
-    options: &BufferLocalOptions,
+    options: &BufferOptions,
     buf_line: &RopeSlice,
     char_idx: usize,
   ) {
@@ -186,7 +186,7 @@ impl ColumnIndex {
   ///    length.
   pub fn width_before(
     &mut self,
-    options: &BufferLocalOptions,
+    options: &BufferOptions,
     buf_line: &RopeSlice,
     char_idx: usize,
   ) -> usize {
@@ -225,7 +225,7 @@ impl ColumnIndex {
   ///    the line length.
   pub fn width_until(
     &mut self,
-    options: &BufferLocalOptions,
+    options: &BufferOptions,
     buf_line: &RopeSlice,
     char_idx: usize,
   ) -> usize {
@@ -251,7 +251,7 @@ impl ColumnIndex {
   // Build cache until specified `width`.
   fn _build_cache_until_width(
     &mut self,
-    options: &BufferLocalOptions,
+    options: &BufferOptions,
     buf_line: &RopeSlice,
     width: usize,
   ) {
@@ -273,7 +273,7 @@ impl ColumnIndex {
   /// 2. It returns the previous char index otherwise.
   pub fn char_before(
     &mut self,
-    options: &BufferLocalOptions,
+    options: &BufferOptions,
     buf_line: &RopeSlice,
     width: usize,
   ) -> Option<usize> {
@@ -318,7 +318,7 @@ impl ColumnIndex {
   /// 2. It returns the **current** char index otherwise.
   pub fn char_at(
     &mut self,
-    options: &BufferLocalOptions,
+    options: &BufferOptions,
     buf_line: &RopeSlice,
     width: usize,
   ) -> Option<usize> {
@@ -368,7 +368,7 @@ impl ColumnIndex {
   /// 2. It returns the next char index otherwise.
   pub fn char_after(
     &mut self,
-    options: &BufferLocalOptions,
+    options: &BufferOptions,
     buf_line: &RopeSlice,
     width: usize,
   ) -> Option<usize> {
@@ -406,7 +406,7 @@ impl ColumnIndex {
   ///    returns the last char index.
   pub fn last_char_until(
     &mut self,
-    options: &BufferLocalOptions,
+    options: &BufferOptions,
     buf_line: &RopeSlice,
     width: usize,
   ) -> Option<usize> {

--- a/rsvim_core/src/buf/text/cidx_tests.rs
+++ b/rsvim_core/src/buf/text/cidx_tests.rs
@@ -1,14 +1,14 @@
 use super::cidx::*;
 
-use crate::buf::opt::{BufferLocalOptions, BufferLocalOptionsBuilder};
+use crate::buf::opt::{BufferOptions, BufferOptionsBuilder};
 use crate::buf::text::Text;
 use crate::prelude::*;
 use crate::tests::log::init as test_log_init;
 
 use ropey::{Rope, RopeBuilder, RopeSlice};
 
-fn make_default_opts() -> BufferLocalOptions {
-  BufferLocalOptionsBuilder::default().build().unwrap()
+fn make_default_opts() -> BufferOptions {
+  BufferOptionsBuilder::default().build().unwrap()
 }
 
 fn make_rope_from_lines(lines: Vec<&str>) -> Rope {
@@ -20,7 +20,7 @@ fn make_rope_from_lines(lines: Vec<&str>) -> Rope {
 }
 
 fn make_text_from_rope(
-  opts: BufferLocalOptions,
+  opts: BufferOptions,
   terminal_size: U16Size,
   rp: Rope,
 ) -> Text {
@@ -151,7 +151,7 @@ fn print_text_line_details(text: Text, line_idx: usize, msg: &str) {
 }
 
 fn assert_width_at(
-  options: &BufferLocalOptions,
+  options: &BufferOptions,
   buf_line: &RopeSlice,
   actual: &mut ColumnIndex,
   expect: &[usize],
@@ -164,7 +164,7 @@ fn assert_width_at(
 }
 
 fn assert_width_at_rev(
-  options: &BufferLocalOptions,
+  options: &BufferOptions,
   buf_line: &RopeSlice,
   actual: &mut ColumnIndex,
   expect: &[(usize, usize)],
@@ -177,7 +177,7 @@ fn assert_width_at_rev(
 }
 
 fn assert_width_before(
-  options: &BufferLocalOptions,
+  options: &BufferOptions,
   buf_line: &RopeSlice,
   actual: &mut ColumnIndex,
   expect: &[usize],
@@ -190,7 +190,7 @@ fn assert_width_before(
 }
 
 fn assert_width_before_rev(
-  options: &BufferLocalOptions,
+  options: &BufferOptions,
   buf_line: &RopeSlice,
   actual: &mut ColumnIndex,
   expect: &[(usize, usize)],
@@ -534,7 +534,7 @@ fn width7() {
 }
 
 fn assert_char_before(
-  options: &BufferLocalOptions,
+  options: &BufferOptions,
   buf_line: &RopeSlice,
   widx: &mut ColumnIndex,
   expect_before: &[(usize, Option<usize>)],
@@ -554,7 +554,7 @@ fn assert_char_before(
 }
 
 fn assert_char_at(
-  options: &BufferLocalOptions,
+  options: &BufferOptions,
   buf_line: &RopeSlice,
   widx: &mut ColumnIndex,
   expect_until: &[(usize, Option<usize>)],
@@ -576,7 +576,7 @@ fn assert_char_at(
 }
 
 fn assert_char_after(
-  options: &BufferLocalOptions,
+  options: &BufferOptions,
   buf_line: &RopeSlice,
   widx: &mut ColumnIndex,
   expect_after: &[(usize, Option<usize>)],
@@ -596,7 +596,7 @@ fn assert_char_after(
 }
 
 fn assert_last_char_until(
-  options: &BufferLocalOptions,
+  options: &BufferOptions,
   buf_line: &RopeSlice,
   widx: &mut ColumnIndex,
   expect_until: &[(usize, Option<usize>)],

--- a/rsvim_core/src/buf/text_tests.rs
+++ b/rsvim_core/src/buf/text_tests.rs
@@ -1,6 +1,6 @@
 use super::text::*;
 
-use crate::buf::opt::{BufferLocalOptionsBuilder, FileFormatOption};
+use crate::buf::opt::{BufferOptionsBuilder, FileFormatOption};
 use crate::coord::U16Size;
 use crate::tests::log::init as test_log_init;
 
@@ -11,7 +11,7 @@ fn last_char1_unix() {
   test_log_init();
 
   let terminal_size = U16Size::new(10, 10);
-  let opt = BufferLocalOptionsBuilder::default()
+  let opt = BufferOptionsBuilder::default()
     .file_format(FileFormatOption::Unix)
     .build()
     .unwrap();
@@ -106,7 +106,7 @@ fn last_char1_win() {
   test_log_init();
 
   let terminal_size = U16Size::new(10, 10);
-  let opt = BufferLocalOptionsBuilder::default()
+  let opt = BufferOptionsBuilder::default()
     .file_format(FileFormatOption::Dos)
     .build()
     .unwrap();
@@ -202,7 +202,7 @@ fn last_char1_mac() {
   test_log_init();
 
   let terminal_size = U16Size::new(10, 10);
-  let opt = BufferLocalOptionsBuilder::default()
+  let opt = BufferOptionsBuilder::default()
     .file_format(FileFormatOption::Mac)
     .build()
     .unwrap();

--- a/rsvim_core/src/buf/unicode.rs
+++ b/rsvim_core/src/buf/unicode.rs
@@ -1,6 +1,6 @@
 //! Unicode utils.
 
-use crate::buf::opt::{BufferLocalOptions, FileFormatOption};
+use crate::buf::opt::{BufferOptions, FileFormatOption};
 use crate::defaults::ascii::AsciiControlCodeFormatter;
 
 use ascii::AsciiChar;
@@ -14,7 +14,7 @@ use icu::properties::{CodePointMapData, props::EastAsianWidth};
 /// [Unicode Standard Annex #11](https://www.unicode.org/reports/tr11/),
 /// implemented with
 /// [icu::properties::EastAsianWidth](https://docs.rs/icu/latest/icu/properties/maps/fn.east_asian_width.html#).
-pub fn char_width(opt: &BufferLocalOptions, c: char) -> usize {
+pub fn char_width(opt: &BufferOptions, c: char) -> usize {
   if c.is_ascii_control() {
     let ac = AsciiChar::from_ascii(c).unwrap();
     match ac {
@@ -47,7 +47,7 @@ pub fn char_width(opt: &BufferLocalOptions, c: char) -> usize {
 }
 
 /// Get the printable cell symbol and its display width.
-pub fn char_symbol(opt: &BufferLocalOptions, c: char) -> CompactString {
+pub fn char_symbol(opt: &BufferOptions, c: char) -> CompactString {
   if c.is_ascii_control() {
     let ac = AsciiChar::from_ascii(c).unwrap();
     match ac {
@@ -74,12 +74,12 @@ pub fn char_symbol(opt: &BufferLocalOptions, c: char) -> CompactString {
 }
 
 /// Get the display width for a unicode `str`.
-pub fn str_width(opt: &BufferLocalOptions, s: &str) -> usize {
+pub fn str_width(opt: &BufferOptions, s: &str) -> usize {
   s.chars().map(|c| char_width(opt, c)).sum()
 }
 
 /// Get the printable cell symbols and the display width for a unicode `str`.
-pub fn str_symbols(opt: &BufferLocalOptions, s: &str) -> CompactString {
+pub fn str_symbols(opt: &BufferOptions, s: &str) -> CompactString {
   s.chars().map(|c| char_symbol(opt, c)).fold(
     CompactString::with_capacity(s.len()),
     |mut init_symbol, mut symbol| {

--- a/rsvim_core/src/buf/unicode_tests.rs
+++ b/rsvim_core/src/buf/unicode_tests.rs
@@ -1,6 +1,6 @@
 use super::unicode::*;
 
-use crate::buf::opt::{BufferLocalOptionsBuilder, FileFormatOption};
+use crate::buf::opt::{BufferOptionsBuilder, FileFormatOption};
 use crate::defaults::ascii::AsciiControlCodeFormatter;
 use crate::prelude::*;
 use crate::tests::log::init as test_log_init;
@@ -16,7 +16,7 @@ fn char_width1() {
   for i in 0_u8..32_u8 {
     let c = i as char;
     let asciic = AsciiChar::from_ascii(c).unwrap();
-    let opt = BufferLocalOptionsBuilder::default().build().unwrap();
+    let opt = BufferOptionsBuilder::default().build().unwrap();
     let asciifmt = AsciiControlCodeFormatter::from(asciic);
     let formatted = format!("{asciifmt}");
     let formatted_len = formatted.len();
@@ -40,7 +40,7 @@ fn char_width1() {
 
   {
     let c = 'A';
-    let opt = BufferLocalOptionsBuilder::default().build().unwrap();
+    let opt = BufferOptionsBuilder::default().build().unwrap();
     let formatted = format!("{c}");
     let formatted_width = UnicodeWidthChar::width_cjk(c).unwrap();
     info!("c:{c:?},formatted:{formatted:?}({formatted_width})");
@@ -49,7 +49,7 @@ fn char_width1() {
 
   {
     let c = '好';
-    let opt = BufferLocalOptionsBuilder::default().build().unwrap();
+    let opt = BufferOptionsBuilder::default().build().unwrap();
     let formatted = format!("{c}");
     let formatted_width = UnicodeWidthChar::width_cjk(c).unwrap();
     info!("c:{c:?},formatted:{formatted:?}({formatted_width})");

--- a/rsvim_core/src/content.rs
+++ b/rsvim_core/src/content.rs
@@ -1,6 +1,6 @@
 //! Temporary contents except buffers.
 
-use crate::buf::opt::BufferLocalOptionsBuilder;
+use crate::buf::opt::BufferOptionsBuilder;
 use crate::buf::text::Text;
 use crate::prelude::*;
 
@@ -17,8 +17,7 @@ arc_mutex_ptr!(TextContents);
 
 impl TextContents {
   pub fn new(canvas_size: U16Size) -> Self {
-    let command_line_opts =
-      BufferLocalOptionsBuilder::default().build().unwrap();
+    let command_line_opts = BufferOptionsBuilder::default().build().unwrap();
     Self {
       command_line_content: Text::new(
         command_line_opts,

--- a/rsvim_core/src/content.rs
+++ b/rsvim_core/src/content.rs
@@ -9,7 +9,7 @@ use ropey::Rope;
 #[derive(Debug)]
 /// Temporary contents except buffers.
 pub struct TextContents {
-  command_line_content: Text,
+  command_line_input: Text,
   command_line_message: Text,
 }
 
@@ -19,7 +19,7 @@ impl TextContents {
   pub fn new(canvas_size: U16Size) -> Self {
     let command_line_opts = BufferOptionsBuilder::default().build().unwrap();
     Self {
-      command_line_content: Text::new(
+      command_line_input: Text::new(
         command_line_opts,
         canvas_size,
         Rope::new(),
@@ -33,21 +33,21 @@ impl TextContents {
   }
 
   /// Get "command line" input content
-  pub fn command_line_content(&self) -> &Text {
-    &self.command_line_content
+  pub fn command_line_input(&self) -> &Text {
+    &self.command_line_input
   }
 
   /// Get mutable "command line" input content
-  pub fn command_line_content_mut(&mut self) -> &mut Text {
-    &mut self.command_line_content
+  pub fn command_line_input_mut(&mut self) -> &mut Text {
+    &mut self.command_line_input
   }
 
-  /// Get "command line" echo message
+  /// Get "command line" message
   pub fn command_line_message(&self) -> &Text {
     &self.command_line_message
   }
 
-  /// Get mutable "command line" echo message
+  /// Get mutable "command line" message
   pub fn command_line_message_mut(&mut self) -> &mut Text {
     &mut self.command_line_message
   }

--- a/rsvim_core/src/defaults/buf.rs
+++ b/rsvim_core/src/defaults/buf.rs
@@ -1,4 +1,4 @@
-//! Vim buffer's default options.
+//! Vim buffer's options default value.
 
 use crate::buf::opt::*;
 

--- a/rsvim_core/src/defaults/win.rs
+++ b/rsvim_core/src/defaults/win.rs
@@ -1,6 +1,4 @@
-//! Vim window's default options.
-//!
-//! See: [`crate::ui::widget::window::WindowLocalOptions`].
+//! Vim window's options default value.
 
 pub const WRAP: bool = true;
 

--- a/rsvim_core/src/state/fsm/command_line_ex.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex.rs
@@ -253,11 +253,11 @@ impl CommandLineExStateful {
 
     let cmdline = tree.command_line_mut().unwrap();
     let cmdline_id = cmdline.id();
-    debug_assert_eq!(cmdline.cursor_viewport().line_idx(), 0);
+    debug_assert_eq!(cmdline.input_cursor_viewport().line_idx(), 0);
     debug_assert!(
       text
         .rope()
-        .get_line(cmdline.cursor_viewport().line_idx())
+        .get_line(cmdline.input_cursor_viewport().line_idx())
         .is_some()
     );
 

--- a/rsvim_core/src/state/fsm/command_line_ex.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex.rs
@@ -156,7 +156,7 @@ impl CommandLineExStateful {
     let contents = data_access.contents.clone();
     let mut contents = lock!(contents);
     let cmdline_content =
-      contents.command_line_content().rope().to_compact_string();
+      contents.command_line_input().rope().to_compact_string();
 
     cursor_ops::cursor_clear(
       &mut tree,
@@ -200,7 +200,7 @@ impl CommandLineExStateful {
     cursor_ops::cursor_move(
       &mut tree,
       cmdline_id,
-      contents.command_line_content(),
+      contents.command_line_input(),
       op,
       true,
     );

--- a/rsvim_core/src/state/fsm/command_line_ex.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex.rs
@@ -8,7 +8,7 @@ use crate::state::ops::{CursorInsertPayload, Operation, cursor_ops};
 use crate::ui::canvas::CursorStyle;
 use crate::ui::tree::*;
 use crate::ui::widget::command_line::CommandLineNode;
-use crate::ui::widget::command_line::indicator::CommandLineIndicatorSymbol;
+use crate::ui::widget::command_line::indicator::IndicatorSymbol;
 
 use crate::state::ops::message_ops::{refresh_view, set_message_visible};
 use compact_str::{CompactString, ToCompactString};
@@ -169,7 +169,7 @@ impl CommandLineExStateful {
       .command_line_mut()
       .unwrap()
       .indicator_mut()
-      .set_symbol(CommandLineIndicatorSymbol::Empty);
+      .set_symbol(IndicatorSymbol::Empty);
 
     cmdline_content.to_compact_string()
   }

--- a/rsvim_core/src/state/fsm/command_line_ex.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex.rs
@@ -161,7 +161,7 @@ impl CommandLineExStateful {
     cursor_ops::cursor_clear(
       &mut tree,
       cmdline_id,
-      contents.command_line_content_mut(),
+      contents.command_line_input_mut(),
     );
 
     let cmdline_content = cmdline_content.trim();
@@ -231,7 +231,7 @@ impl CommandLineExStateful {
     cursor_ops::cursor_insert(
       &mut tree,
       cmdline_id,
-      contents.command_line_content_mut(),
+      contents.command_line_input_mut(),
       payload,
     );
 
@@ -249,7 +249,7 @@ impl CommandLineExStateful {
     let mut tree = lock!(tree);
     let contents = data_access.contents.clone();
     let mut contents = lock!(contents);
-    let text = contents.command_line_content_mut();
+    let text = contents.command_line_input_mut();
 
     let cmdline = tree.command_line_mut().unwrap();
     let cmdline_id = cmdline.id();

--- a/rsvim_core/src/state/fsm/command_line_ex.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex.rs
@@ -7,9 +7,8 @@ use crate::state::fsm::{Stateful, StatefulDataAccess, StatefulValue};
 use crate::state::ops::{CursorInsertPayload, Operation, cursor_ops};
 use crate::ui::canvas::CursorStyle;
 use crate::ui::tree::*;
-use crate::ui::widget::command_line::{
-  CommandLineIndicatorSymbol, CommandLineNode,
-};
+use crate::ui::widget::command_line::CommandLineNode;
+use crate::ui::widget::command_line::indicator::CommandLineIndicatorSymbol;
 
 use crate::state::ops::message_ops::{refresh_view, set_message_visible};
 use compact_str::{CompactString, ToCompactString};

--- a/rsvim_core/src/state/fsm/command_line_ex_tests.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex_tests.rs
@@ -3,7 +3,7 @@
 use super::command_line_ex::*;
 
 use crate::buf::opt::FileFormatOption;
-use crate::buf::opt::{BufferLocalOptions, BufferLocalOptionsBuilder};
+use crate::buf::opt::{BufferOptions, BufferOptionsBuilder};
 use crate::buf::text::Text;
 use crate::buf::{BufferArc, BuffersManagerArc};
 use crate::content::{TextContents, TextContentsArc};
@@ -42,7 +42,7 @@ pub fn make_tree(
   BufferArc,
   TextContentsArc,
 ) {
-  let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+  let buf_opts = BufferOptionsBuilder::default().build().unwrap();
   let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
   let bufs = make_buffers_manager(buf_opts, vec![buf.clone()]);
   let tree =
@@ -55,7 +55,7 @@ pub fn make_tree(
 
 pub fn make_tree_with_cmdline_and_buffer_options(
   terminal_size: U16Size,
-  buffer_local_opts: BufferLocalOptions,
+  buffer_local_opts: BufferOptions,
   window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
@@ -90,7 +90,7 @@ pub fn make_tree_with_cmdline(
   BufferArc,
   TextContentsArc,
 ) {
-  let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+  let buf_opts = BufferOptionsBuilder::default().build().unwrap();
   make_tree_with_cmdline_and_buffer_options(
     terminal_size,
     buf_opts,
@@ -263,7 +263,7 @@ pub fn assert_canvas(actual: &Canvas, expect: &[&str]) {
 mod tests_goto_normal_mode {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
   use crate::state::ops::CursorInsertPayload;
@@ -455,7 +455,7 @@ mod tests_goto_normal_mode {
     test_log_init();
 
     let terminal_size = U16Size::new(11, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -630,7 +630,7 @@ mod tests_goto_normal_mode {
 mod tests_confirm_ex_command_and_goto_normal_mode {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
   use crate::state::ops::CursorInsertPayload;

--- a/rsvim_core/src/state/fsm/command_line_ex_tests.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex_tests.rs
@@ -335,7 +335,7 @@ mod tests_goto_normal_mode {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
       assert_viewport(
-        lock!(contents).command_line_content(),
+        lock!(contents).command_line_input(),
         &viewport,
         &expect,
         0,
@@ -377,16 +377,14 @@ mod tests_goto_normal_mode {
 
       let viewport =
         lock!(tree.clone()).command_line().unwrap().input_viewport();
-      let cmdline_eol = lock!(contents)
-        .command_line_content()
-        .options()
-        .end_of_line();
+      let cmdline_eol =
+        lock!(contents).command_line_input().options().end_of_line();
       let line0 = format!("Bye{cmdline_eol}");
       let expect = vec![line0.as_str()];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
       assert_viewport(
-        lock!(contents).command_line_content(),
+        lock!(contents).command_line_input(),
         &viewport,
         &expect,
         0,
@@ -427,7 +425,7 @@ mod tests_goto_normal_mode {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
       assert_viewport(
-        lock!(contents).command_line_content(),
+        lock!(contents).command_line_input(),
         &viewport,
         &expect,
         0,
@@ -510,7 +508,7 @@ mod tests_goto_normal_mode {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
       assert_viewport(
-        lock!(contents).command_line_content(),
+        lock!(contents).command_line_input(),
         &viewport,
         &expect,
         0,
@@ -552,16 +550,14 @@ mod tests_goto_normal_mode {
 
       let viewport =
         lock!(tree.clone()).command_line().unwrap().input_viewport();
-      let cmdline_eol = lock!(contents)
-        .command_line_content()
-        .options()
-        .end_of_line();
+      let cmdline_eol =
+        lock!(contents).command_line_input().options().end_of_line();
       let line0 = format!("Bye{cmdline_eol}");
       let expect = vec![line0.as_str()];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
       assert_viewport(
-        lock!(contents).command_line_content(),
+        lock!(contents).command_line_input(),
         &viewport,
         &expect,
         0,
@@ -602,7 +598,7 @@ mod tests_goto_normal_mode {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
       assert_viewport(
-        lock!(contents).command_line_content(),
+        lock!(contents).command_line_input(),
         &viewport,
         &expect,
         0,
@@ -701,7 +697,7 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
       assert_viewport(
-        lock!(contents).command_line_content(),
+        lock!(contents).command_line_input(),
         &viewport,
         &expect,
         0,
@@ -745,16 +741,14 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
 
       let viewport =
         lock!(tree.clone()).command_line().unwrap().input_viewport();
-      let cmdline_eol = lock!(contents)
-        .command_line_content()
-        .options()
-        .end_of_line();
+      let cmdline_eol =
+        lock!(contents).command_line_input().options().end_of_line();
       let line0 = format!("Bye6 Bye7{cmdline_eol}");
       let expect = vec![line0.as_str()];
       let expect_fills: BTreeMap<usize, usize> =
         vec![(0, 0)].into_iter().collect();
       assert_viewport(
-        lock!(contents).command_line_content(),
+        lock!(contents).command_line_input(),
         &viewport,
         &expect,
         0,

--- a/rsvim_core/src/state/fsm/command_line_ex_tests.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex_tests.rs
@@ -323,7 +323,7 @@ mod tests_goto_normal_mode {
       let actual1 = lock!(tree.clone())
         .command_line()
         .unwrap()
-        .cursor_viewport();
+        .input_cursor_viewport();
       assert_eq!(actual1.line_idx(), 0);
       assert_eq!(actual1.char_idx(), 0);
       assert_eq!(actual1.row_idx(), 0);
@@ -369,7 +369,7 @@ mod tests_goto_normal_mode {
       let actual1 = lock!(tree.clone())
         .command_line()
         .unwrap()
-        .cursor_viewport();
+        .input_cursor_viewport();
       assert_eq!(actual1.line_idx(), 0);
       assert_eq!(actual1.char_idx(), 3);
       assert_eq!(actual1.row_idx(), 0);
@@ -413,7 +413,7 @@ mod tests_goto_normal_mode {
       let actual1 = lock!(tree.clone())
         .command_line()
         .unwrap()
-        .cursor_viewport();
+        .input_cursor_viewport();
       assert_eq!(actual1.line_idx(), 0);
       assert_eq!(actual1.char_idx(), 0);
       assert_eq!(actual1.row_idx(), 0);
@@ -496,7 +496,7 @@ mod tests_goto_normal_mode {
       let actual1 = lock!(tree.clone())
         .command_line()
         .unwrap()
-        .cursor_viewport();
+        .input_cursor_viewport();
       assert_eq!(actual1.line_idx(), 0);
       assert_eq!(actual1.char_idx(), 0);
       assert_eq!(actual1.row_idx(), 0);
@@ -542,7 +542,7 @@ mod tests_goto_normal_mode {
       let actual1 = lock!(tree.clone())
         .command_line()
         .unwrap()
-        .cursor_viewport();
+        .input_cursor_viewport();
       assert_eq!(actual1.line_idx(), 0);
       assert_eq!(actual1.char_idx(), 3);
       assert_eq!(actual1.row_idx(), 0);
@@ -586,7 +586,7 @@ mod tests_goto_normal_mode {
       let actual1 = lock!(tree.clone())
         .command_line()
         .unwrap()
-        .cursor_viewport();
+        .input_cursor_viewport();
       assert_eq!(actual1.line_idx(), 0);
       assert_eq!(actual1.char_idx(), 0);
       assert_eq!(actual1.row_idx(), 0);
@@ -685,7 +685,7 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
       let actual1 = lock!(tree.clone())
         .command_line()
         .unwrap()
-        .cursor_viewport();
+        .input_cursor_viewport();
       assert_eq!(actual1.line_idx(), 0);
       assert_eq!(actual1.char_idx(), 0);
       assert_eq!(actual1.row_idx(), 0);
@@ -733,7 +733,7 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
       let actual1 = lock!(tree.clone())
         .command_line()
         .unwrap()
-        .cursor_viewport();
+        .input_cursor_viewport();
       assert_eq!(actual1.line_idx(), 0);
       assert_eq!(actual1.char_idx(), 34);
       assert_eq!(actual1.row_idx(), 0);

--- a/rsvim_core/src/state/fsm/command_line_ex_tests.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex_tests.rs
@@ -24,9 +24,7 @@ use crate::ui::viewport::{
   ViewportSearchDirection,
 };
 use crate::ui::widget::command_line::CommandLine;
-use crate::ui::widget::window::{
-  WindowLocalOptions, WindowLocalOptionsBuilder,
-};
+use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::{CompactString, ToCompactString};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -35,7 +33,7 @@ use tokio::sync::mpsc::{Receiver, Sender, channel};
 
 pub fn make_tree(
   terminal_size: U16Size,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
   TreeArc,
@@ -58,7 +56,7 @@ pub fn make_tree(
 pub fn make_tree_with_cmdline_and_buffer_options(
   terminal_size: U16Size,
   buffer_local_opts: BufferLocalOptions,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
   TreeArc,
@@ -83,7 +81,7 @@ pub fn make_tree_with_cmdline_and_buffer_options(
 
 pub fn make_tree_with_cmdline(
   terminal_size: U16Size,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
   TreeArc,
@@ -278,9 +276,7 @@ mod tests_goto_normal_mode {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::state::fsm::NormalStateful;
   use crossterm::event::{
@@ -293,10 +289,8 @@ mod tests_goto_normal_mode {
     test_log_init();
 
     let terminal_size = U16Size::new(11, 5);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![];
     let (tree, state, bufs, _buf, contents) =
       make_tree_with_cmdline(terminal_size, window_options, lines);
@@ -465,10 +459,8 @@ mod tests_goto_normal_mode {
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![];
     let (tree, state, bufs, _buf, contents) =
       make_tree_with_cmdline_and_buffer_options(
@@ -651,9 +643,7 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::state::fsm::NormalStateful;
   use crossterm::event::{
@@ -666,10 +656,8 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
     test_log_init();
 
     let terminal_size = U16Size::new(11, 5);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![];
     let (tree, state, bufs, _buf, contents) =
       make_tree_with_cmdline(terminal_size, window_options, lines);

--- a/rsvim_core/src/state/fsm/command_line_ex_tests.rs
+++ b/rsvim_core/src/state/fsm/command_line_ex_tests.rs
@@ -24,7 +24,7 @@ use crate::ui::viewport::{
   ViewportSearchDirection,
 };
 use crate::ui::widget::command_line::CommandLine;
-use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
+use crate::ui::widget::window::opt::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::{CompactString, ToCompactString};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -276,7 +276,6 @@ mod tests_goto_normal_mode {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::state::fsm::NormalStateful;
   use crossterm::event::{
@@ -643,7 +642,6 @@ mod tests_confirm_ex_command_and_goto_normal_mode {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::state::fsm::NormalStateful;
   use crossterm::event::{

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -21,9 +21,7 @@ use crate::ui::viewport::{
 };
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::window::content::{self, WindowContent};
-use crate::ui::widget::window::{
-  WindowLocalOptions, WindowLocalOptionsBuilder,
-};
+use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::ToCompactString;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -34,7 +32,7 @@ use tokio::sync::mpsc::{Receiver, Sender, channel};
 pub fn make_tree_with_buffer_opts(
   terminal_size: U16Size,
   buffer_local_opts: BufferLocalOptions,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
   TreeArc,
@@ -55,7 +53,7 @@ pub fn make_tree_with_buffer_opts(
 
 pub fn make_tree(
   terminal_size: U16Size,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
   TreeArc,
@@ -211,7 +209,7 @@ pub fn assert_viewport(
 
 pub fn make_canvas(
   terminal_size: U16Size,
-  window_options: WindowLocalOptions,
+  window_options: WindowOptions,
   buffer: BufferArc,
   viewport: ViewportArc,
 ) -> Canvas {
@@ -274,9 +272,7 @@ mod tests_cursor_move {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::buf::opt::FileFormatOption;
   use crossterm::event::{
@@ -299,10 +295,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -424,10 +417,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 10),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -549,10 +539,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 10),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -675,7 +662,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 6),
-      WindowLocalOptionsBuilder::default()
+      WindowOptionsBuilder::default()
         .wrap(true)
         .line_break(false)
         .build()
@@ -932,7 +919,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 6),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
+      WindowOptionsBuilder::default()
         .wrap(true)
         .line_break(false)
         .build()
@@ -1189,7 +1176,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 6),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
+      WindowOptionsBuilder::default()
         .wrap(true)
         .line_break(false)
         .build()
@@ -1441,7 +1428,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 6),
-      WindowLocalOptionsBuilder::default()
+      WindowOptionsBuilder::default()
         .wrap(true)
         .line_break(true)
         .build()
@@ -1698,7 +1685,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 6),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
+      WindowOptionsBuilder::default()
         .wrap(true)
         .line_break(true)
         .build()
@@ -1955,7 +1942,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 6),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
+      WindowOptionsBuilder::default()
         .wrap(true)
         .line_break(true)
         .build()
@@ -2202,9 +2189,7 @@ mod tests_insert_text {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::buf::opt::FileFormatOption;
   use compact_str::CompactString;
@@ -2219,10 +2204,8 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and small test lines.\n",
@@ -2452,10 +2435,8 @@ mod tests_insert_text {
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\r\n",
       "This is a quite simple and small test lines.\r\n",
@@ -2689,10 +2670,8 @@ mod tests_insert_text {
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\r",
       "This is a quite simple and small test lines.\r",
@@ -2922,10 +2901,8 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let window_option = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_option =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and small test lines.\n",
@@ -3068,10 +3045,8 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let window_option = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_option =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and small test lines.\n",
@@ -3389,10 +3364,8 @@ mod tests_insert_text {
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
-    let window_option = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_option =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\r\n",
       "This is a quite simple and small test lines.\r\n",
@@ -3715,10 +3688,8 @@ mod tests_insert_text {
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
-    let window_option = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_option =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\r",
       "This is a quite simple and small test lines.\r",
@@ -4032,10 +4003,8 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let window_option = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_option =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![];
     let (tree, state, bufs, buf, contents) =
       make_tree(terminal_size, window_option, lines);
@@ -4106,10 +4075,8 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let window_option = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_option =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![""];
     let (tree, state, bufs, buf, contents) =
       make_tree(terminal_size, window_option, lines);
@@ -4185,10 +4152,8 @@ mod tests_insert_text {
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
-    let window_option = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_option =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![];
     let (tree, state, bufs, buf, contents) =
       make_tree_with_buffer_opts(terminal_size, buf_opts, window_option, lines);
@@ -4260,7 +4225,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let window_options = WindowLocalOptionsBuilder::default()
+    let window_options = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -4686,7 +4651,7 @@ mod tests_insert_text {
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
-    let window_options = WindowLocalOptionsBuilder::default()
+    let window_options = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -5116,7 +5081,7 @@ mod tests_insert_text {
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
-    let window_options = WindowLocalOptionsBuilder::default()
+    let window_options = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -5542,7 +5507,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let window_options = WindowLocalOptionsBuilder::default()
+    let window_options = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -5617,7 +5582,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let window_options = WindowLocalOptionsBuilder::default()
+    let window_options = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -5692,7 +5657,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let window_options = WindowLocalOptionsBuilder::default()
+    let window_options = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -5806,7 +5771,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let window_options = WindowLocalOptionsBuilder::default()
+    let window_options = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -6220,10 +6185,8 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(200, 10);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines =
       vec!["abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\n"];
     let (tree, state, bufs, buf, contents) =
@@ -6316,10 +6279,8 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(200, 10);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines =
       vec!["abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\n"];
     let (tree, state, bufs, buf, contents) =
@@ -6515,9 +6476,7 @@ mod tests_delete_text {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::buf::opt::FileFormatOption;
   use compact_str::CompactString;
@@ -6532,10 +6491,8 @@ mod tests_delete_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\n",
       "This is a quite simple and small test lines.\n",
@@ -7188,10 +7145,8 @@ mod tests_delete_text {
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\r\n",
       "This is a quite simple and small test lines.\r\n",
@@ -7848,10 +7803,8 @@ mod tests_delete_text {
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![
       "Hello, RSVIM!\r",
       "This is a quite simple and small test lines.\r",
@@ -8504,10 +8457,8 @@ mod tests_delete_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![];
     let (tree, state, bufs, buf, contents) =
       make_tree(terminal_size, window_options, lines);
@@ -8578,10 +8529,8 @@ mod tests_delete_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let window_options = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let window_options =
+      WindowOptionsBuilder::default().wrap(false).build().unwrap();
     let lines = vec![];
     let (tree, state, bufs, buf, contents) =
       make_tree(terminal_size, window_options, lines);

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -20,8 +20,8 @@ use crate::ui::viewport::{
   ViewportSearchDirection,
 };
 use crate::ui::widget::Widgetable;
-use crate::ui::widget::window::content::{self, WindowContent};
-use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
+use crate::ui::widget::window::content::WindowContent;
+use crate::ui::widget::window::opt::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::ToCompactString;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -272,7 +272,6 @@ mod tests_cursor_move {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::buf::opt::FileFormatOption;
   use crossterm::event::{
@@ -2189,7 +2188,6 @@ mod tests_insert_text {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::buf::opt::FileFormatOption;
   use compact_str::CompactString;
@@ -6476,7 +6474,6 @@ mod tests_delete_text {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::buf::opt::FileFormatOption;
   use compact_str::CompactString;

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -20,7 +20,7 @@ use crate::ui::viewport::{
   ViewportSearchDirection,
 };
 use crate::ui::widget::Widgetable;
-use crate::ui::widget::window::content::WindowContent;
+use crate::ui::widget::window::content::Content;
 use crate::ui::widget::window::opt::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::ToCompactString;
@@ -222,11 +222,8 @@ pub fn make_canvas(
       terminal_size.height() as isize,
     ),
   );
-  let window_content = WindowContent::new(
-    shape,
-    Arc::downgrade(&buffer),
-    Arc::downgrade(&viewport),
-  );
+  let window_content =
+    Content::new(shape, Arc::downgrade(&buffer), Arc::downgrade(&viewport));
   let mut canvas = Canvas::new(terminal_size);
   window_content.draw(&mut canvas);
   canvas

--- a/rsvim_core/src/state/fsm/insert_tests.rs
+++ b/rsvim_core/src/state/fsm/insert_tests.rs
@@ -2,7 +2,7 @@
 
 use super::insert::*;
 
-use crate::buf::opt::{BufferLocalOptions, BufferLocalOptionsBuilder};
+use crate::buf::opt::{BufferOptions, BufferOptionsBuilder};
 use crate::buf::{BufferArc, BuffersManagerArc};
 use crate::content::{TextContents, TextContentsArc};
 use crate::prelude::*;
@@ -31,7 +31,7 @@ use tokio::sync::mpsc::{Receiver, Sender, channel};
 
 pub fn make_tree_with_buffer_opts(
   terminal_size: U16Size,
-  buffer_local_opts: BufferLocalOptions,
+  buffer_local_opts: BufferOptions,
   window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
@@ -62,7 +62,7 @@ pub fn make_tree(
   BufferArc,
   TextContentsArc,
 ) {
-  let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+  let buf_opts = BufferOptionsBuilder::default().build().unwrap();
   make_tree_with_buffer_opts(terminal_size, buf_opts, window_local_opts, lines)
 }
 
@@ -410,7 +410,7 @@ mod tests_cursor_move {
       "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\r\n",
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\r\n",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -532,7 +532,7 @@ mod tests_cursor_move {
       "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\r",
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\r",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -912,7 +912,7 @@ mod tests_cursor_move {
       "11th.\r\n",
       "12th.\r\n",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -1169,7 +1169,7 @@ mod tests_cursor_move {
       "11th.\r",
       "12th.\r",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -1678,7 +1678,7 @@ mod tests_cursor_move {
       "11th.\r\n",
       "12th.\r\n",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -1935,7 +1935,7 @@ mod tests_cursor_move {
       "11th.\r",
       "12th.\r",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -2431,7 +2431,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -2666,7 +2666,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -3360,7 +3360,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -3684,7 +3684,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -4148,7 +4148,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -4647,7 +4647,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -5077,7 +5077,7 @@ mod tests_insert_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -7141,7 +7141,7 @@ mod tests_delete_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -7799,7 +7799,7 @@ mod tests_delete_text {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -7,7 +7,7 @@ use crate::state::ops::cursor_ops;
 use crate::state::ops::{GotoInsertModeVariant, Operation};
 use crate::ui::canvas::CursorStyle;
 use crate::ui::tree::*;
-use crate::ui::widget::command_line::indicator::CommandLineIndicatorSymbol;
+use crate::ui::widget::command_line::indicator::IndicatorSymbol;
 use crate::ui::widget::window::WindowNode;
 
 use compact_str::CompactString;
@@ -135,9 +135,7 @@ impl NormalStateful {
     let _previous_cursor = cmdline.insert_cursor(cursor);
     debug_assert!(_previous_cursor.is_none());
     cmdline.move_cursor_to(0, 0);
-    cmdline
-      .indicator_mut()
-      .set_symbol(CommandLineIndicatorSymbol::Ex);
+    cmdline.indicator_mut().set_symbol(IndicatorSymbol::Ex);
 
     StatefulValue::CommandLineExMode(super::CommandLineExStateful::default())
   }

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -7,7 +7,7 @@ use crate::state::ops::cursor_ops;
 use crate::state::ops::{GotoInsertModeVariant, Operation};
 use crate::ui::canvas::CursorStyle;
 use crate::ui::tree::*;
-use crate::ui::widget::command_line::CommandLineIndicatorSymbol;
+use crate::ui::widget::command_line::indicator::CommandLineIndicatorSymbol;
 use crate::ui::widget::window::WindowNode;
 
 use compact_str::CompactString;

--- a/rsvim_core/src/state/fsm/normal_tests.rs
+++ b/rsvim_core/src/state/fsm/normal_tests.rs
@@ -2,7 +2,7 @@
 
 use super::normal::*;
 
-use crate::buf::opt::{BufferLocalOptions, BufferLocalOptionsBuilder};
+use crate::buf::opt::{BufferOptions, BufferOptionsBuilder};
 use crate::buf::{BufferArc, BuffersManagerArc};
 use crate::content::{TextContents, TextContentsArc};
 use crate::prelude::*;
@@ -22,7 +22,7 @@ use crate::ui::viewport::{
   ViewportSearchDirection,
 };
 use crate::ui::widget::command_line::CommandLine;
-use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
+use crate::ui::widget::window::opt::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::CompactString;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -31,7 +31,7 @@ use tokio::sync::mpsc::{Receiver, Sender, channel};
 
 pub fn make_tree_with_buffer_opts(
   terminal_size: U16Size,
-  buffer_local_opts: BufferLocalOptions,
+  buffer_local_opts: BufferOptions,
   window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
@@ -62,7 +62,7 @@ pub fn make_tree(
   BufferArc,
   TextContentsArc,
 ) {
-  let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+  let buf_opts = BufferOptionsBuilder::default().build().unwrap();
   make_tree_with_buffer_opts(terminal_size, buf_opts, window_local_opts, lines)
 }
 
@@ -77,7 +77,7 @@ pub fn make_tree_with_cmdline(
   BufferArc,
   TextContentsArc,
 ) {
-  let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+  let buf_opts = BufferOptionsBuilder::default().build().unwrap();
   let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
   let bufs = make_buffers_manager(buf_opts, vec![buf.clone()]);
   let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -267,7 +267,7 @@ pub fn assert_canvas(actual: &Canvas, expect: &[&str]) {
 mod tests_raw_cursor_move_y_by {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::content::TextContents;
   use crate::prelude::*;
@@ -477,7 +477,7 @@ mod tests_raw_cursor_move_y_by {
 
     let terminal_size = U16Size::new(10, 10);
     let lines = vec![];
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -573,7 +573,7 @@ mod tests_raw_cursor_move_y_by {
 mod tests_raw_cursor_move_x_by {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::content::TextContents;
   use crate::prelude::*;
@@ -594,7 +594,7 @@ mod tests_raw_cursor_move_x_by {
 
     let terminal_size = U16Size::new(10, 10);
     let lines = vec![];
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -646,7 +646,7 @@ mod tests_raw_cursor_move_x_by {
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
     ];
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -699,7 +699,7 @@ mod tests_raw_cursor_move_x_by {
     ];
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -751,7 +751,7 @@ mod tests_raw_cursor_move_x_by {
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
     ];
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -811,7 +811,7 @@ mod tests_raw_cursor_move_x_by {
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
     ];
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -864,7 +864,7 @@ mod tests_raw_cursor_move_x_by {
 mod tests_raw_cursor_move_by {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::content::TextContents;
   use crate::prelude::*;
@@ -893,7 +893,7 @@ mod tests_raw_cursor_move_by {
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
     ];
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -970,7 +970,7 @@ mod tests_raw_cursor_move_by {
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
     ];
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -1052,7 +1052,7 @@ mod tests_raw_cursor_move_by {
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
     ];
     let terminal_size = U16Size::new(50, 50);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines.clone());
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -1112,7 +1112,7 @@ mod tests_raw_cursor_move_by {
 mod tests_raw_cursor_move_to {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::content::TextContents;
   use crate::prelude::*;
@@ -1141,7 +1141,7 @@ mod tests_raw_cursor_move_to {
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
     ];
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -1218,7 +1218,7 @@ mod tests_raw_cursor_move_to {
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\n",
     ];
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines);
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -1301,7 +1301,7 @@ mod tests_raw_cursor_move_to {
     ];
 
     let terminal_size = U16Size::new(50, 50);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let buf = make_buffer_from_lines(terminal_size, buf_opts, lines.clone());
     let bufs = make_buffers_manager(buf_opts, vec![buf]);
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
@@ -1364,7 +1364,7 @@ mod tests_raw_cursor_move_to {
 mod tests_raw_window_scroll_y_by {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
   use crate::state::{State, StateArc};
@@ -2361,7 +2361,7 @@ mod tests_raw_window_scroll_y_by {
 mod tests_raw_window_scroll_x_by {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
   use crate::state::{State, StateArc};
@@ -3613,7 +3613,7 @@ mod tests_raw_window_scroll_x_by {
 mod tests_raw_window_scroll_to {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
   use crate::state::{State, StateArc};
@@ -4291,7 +4291,7 @@ mod tests_raw_window_scroll_to {
 mod tests_cursor_move {
   use super::*;
 
-  use crate::buf::opt::{BufferLocalOptionsBuilder, FileFormatOption};
+  use crate::buf::opt::{BufferOptionsBuilder, FileFormatOption};
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
   use crate::state::{State, StateArc};
@@ -4529,7 +4529,7 @@ mod tests_cursor_move {
       "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\r\n",
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\r\n",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -4658,7 +4658,7 @@ mod tests_cursor_move {
       "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\r",
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\r",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -5091,7 +5091,7 @@ mod tests_cursor_move {
       "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\r\n",
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\r\n",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -5400,7 +5400,7 @@ mod tests_cursor_move {
       "     * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\r",
       "     * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\r",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -6599,7 +6599,7 @@ mod tests_cursor_move {
       "    * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\r\n",
       "    * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\r\n",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -6828,7 +6828,7 @@ mod tests_cursor_move {
       "    * The extra parts are been truncated if both line-wrap and word-wrap options are not set.\r",
       "    * The extra parts are split into the next row, if either line-wrap or word-wrap options are been set. If the extra parts are still too long to put in the next row, repeat this operation again and again. This operation also eats more rows in the window, thus it may contains less lines in the buffer.\r",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -7217,7 +7217,7 @@ mod tests_cursor_move {
       "  * The extra parts are been truncated.\r\n",
       "  * The extra parts are split into next row.\r\n",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -7383,7 +7383,7 @@ mod tests_cursor_move {
       "  * The extra parts are been truncated.\r",
       "  * The extra parts are split into next row.\r",
     ];
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -8467,7 +8467,7 @@ mod tests_cursor_move {
 mod tests_goto_command_line_ex_mode {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
   use crate::state::{State, StateArc};
@@ -8550,7 +8550,7 @@ mod tests_goto_command_line_ex_mode {
 mod tests_goto_insert_mode {
   use super::*;
 
-  use crate::buf::opt::BufferLocalOptionsBuilder;
+  use crate::buf::opt::BufferOptionsBuilder;
   use crate::buf::{BufferArc, BuffersManagerArc};
   use crate::prelude::*;
   use crate::state::fsm::InsertStateful;

--- a/rsvim_core/src/state/fsm/normal_tests.rs
+++ b/rsvim_core/src/state/fsm/normal_tests.rs
@@ -8742,7 +8742,7 @@ mod tests_goto_insert_mode {
 
   use crate::state::ops::cursor_ops::_update_viewport_after_text_changed;
   use crate::state::ops::message_ops::{refresh_view, set_message_visible};
-  use crate::ui::widget::command_line::CommandLineNode::CommandLineMessage;
+  use crate::ui::widget::command_line::CommandLineNode::Message;
   use compact_str::ToCompactString;
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,

--- a/rsvim_core/src/state/fsm/normal_tests.rs
+++ b/rsvim_core/src/state/fsm/normal_tests.rs
@@ -8512,7 +8512,7 @@ mod tests_goto_command_line_ex_mode {
     let actual_cursor = lock!(tree.clone())
       .command_line()
       .unwrap()
-      .cursor_viewport();
+      .input_cursor_viewport();
     assert_eq!(actual_cursor.line_idx(), 0);
     assert_eq!(actual_cursor.char_idx(), 0);
     assert_eq!(actual_cursor.row_idx(), 0);

--- a/rsvim_core/src/state/fsm/normal_tests.rs
+++ b/rsvim_core/src/state/fsm/normal_tests.rs
@@ -275,7 +275,6 @@ mod tests_raw_cursor_move_y_by {
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
   use crate::tests::tree::make_tree_with_buffers;
-  use crate::ui::widget::window::WindowOptionsBuilder;
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -581,7 +580,6 @@ mod tests_raw_cursor_move_x_by {
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
   use crate::tests::tree::make_tree_with_buffers;
-  use crate::ui::widget::window::WindowOptionsBuilder;
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -872,7 +870,6 @@ mod tests_raw_cursor_move_by {
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
   use crate::tests::tree::make_tree_with_buffers;
-  use crate::ui::widget::window::WindowOptionsBuilder;
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -1120,7 +1117,6 @@ mod tests_raw_cursor_move_to {
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
   use crate::tests::tree::make_tree_with_buffers;
-  use crate::ui::widget::window::WindowOptionsBuilder;
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -1376,9 +1372,7 @@ mod tests_raw_window_scroll_y_by {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowOptions, WindowOptionsBuilder, content,
-  };
+  use crate::ui::widget::window::content;
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -2373,7 +2367,6 @@ mod tests_raw_window_scroll_x_by {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -3625,7 +3618,6 @@ mod tests_raw_window_scroll_to {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -4303,7 +4295,6 @@ mod tests_cursor_move {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -8479,7 +8470,6 @@ mod tests_goto_command_line_ex_mode {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -8564,7 +8554,6 @@ mod tests_goto_insert_mode {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::state::ops::cursor_ops::_update_viewport_after_text_changed;
   use crate::state::ops::message_ops::{refresh_view, set_message_visible};

--- a/rsvim_core/src/state/fsm/normal_tests.rs
+++ b/rsvim_core/src/state/fsm/normal_tests.rs
@@ -22,9 +22,7 @@ use crate::ui::viewport::{
   ViewportSearchDirection,
 };
 use crate::ui::widget::command_line::CommandLine;
-use crate::ui::widget::window::{
-  WindowLocalOptions, WindowLocalOptionsBuilder,
-};
+use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::CompactString;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -34,7 +32,7 @@ use tokio::sync::mpsc::{Receiver, Sender, channel};
 pub fn make_tree_with_buffer_opts(
   terminal_size: U16Size,
   buffer_local_opts: BufferLocalOptions,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
   TreeArc,
@@ -55,7 +53,7 @@ pub fn make_tree_with_buffer_opts(
 
 pub fn make_tree(
   terminal_size: U16Size,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
   TreeArc,
@@ -70,7 +68,7 @@ pub fn make_tree(
 
 pub fn make_tree_with_cmdline(
   terminal_size: U16Size,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   lines: Vec<&str>,
 ) -> (
   TreeArc,
@@ -277,7 +275,7 @@ mod tests_raw_cursor_move_y_by {
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
   use crate::tests::tree::make_tree_with_buffers;
-  use crate::ui::widget::window::WindowLocalOptionsBuilder;
+  use crate::ui::widget::window::WindowOptionsBuilder;
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -290,10 +288,7 @@ mod tests_raw_cursor_move_y_by {
 
     let (tree, state, bufs, _buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec![],
     );
 
@@ -339,10 +334,7 @@ mod tests_raw_cursor_move_y_by {
     ];
     let (tree, state, bufs, _buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -388,10 +380,7 @@ mod tests_raw_cursor_move_y_by {
     ];
     let (tree, state, bufs, _buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -444,10 +433,7 @@ mod tests_raw_cursor_move_y_by {
     ];
     let (tree, state, bufs, _buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -497,10 +483,7 @@ mod tests_raw_cursor_move_y_by {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -547,10 +530,7 @@ mod tests_raw_cursor_move_y_by {
     ];
     let (tree, state, bufs, _buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -601,7 +581,7 @@ mod tests_raw_cursor_move_x_by {
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
   use crate::tests::tree::make_tree_with_buffers;
-  use crate::ui::widget::window::WindowLocalOptionsBuilder;
+  use crate::ui::widget::window::WindowOptionsBuilder;
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -620,10 +600,7 @@ mod tests_raw_cursor_move_x_by {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -675,10 +652,7 @@ mod tests_raw_cursor_move_x_by {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -731,10 +705,7 @@ mod tests_raw_cursor_move_x_by {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -786,10 +757,7 @@ mod tests_raw_cursor_move_x_by {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -849,10 +817,7 @@ mod tests_raw_cursor_move_x_by {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -907,7 +872,7 @@ mod tests_raw_cursor_move_by {
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
   use crate::tests::tree::make_tree_with_buffers;
-  use crate::ui::widget::window::WindowLocalOptionsBuilder;
+  use crate::ui::widget::window::WindowOptionsBuilder;
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -934,10 +899,7 @@ mod tests_raw_cursor_move_by {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -1014,10 +976,7 @@ mod tests_raw_cursor_move_by {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -1099,10 +1058,7 @@ mod tests_raw_cursor_move_by {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -1164,7 +1120,7 @@ mod tests_raw_cursor_move_to {
   use crate::tests::buf::{make_buffer_from_lines, make_buffers_manager};
   use crate::tests::log::init as test_log_init;
   use crate::tests::tree::make_tree_with_buffers;
-  use crate::ui::widget::window::WindowLocalOptionsBuilder;
+  use crate::ui::widget::window::WindowOptionsBuilder;
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -1191,10 +1147,7 @@ mod tests_raw_cursor_move_to {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -1271,10 +1224,7 @@ mod tests_raw_cursor_move_to {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -1357,10 +1307,7 @@ mod tests_raw_cursor_move_to {
     let contents = TextContents::to_arc(TextContents::new(terminal_size));
     let tree = make_tree_with_buffers(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       bufs.clone(),
     );
     let (jsrt_tick_dispatcher, _jsrt_tick_queue) = channel(1);
@@ -1430,7 +1377,7 @@ mod tests_raw_window_scroll_y_by {
     ViewportSearchDirection,
   };
   use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder, content,
+    WindowOptions, WindowOptionsBuilder, content,
   };
 
   use crossterm::event::{
@@ -1445,10 +1392,7 @@ mod tests_raw_window_scroll_y_by {
 
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec![],
     );
 
@@ -1527,10 +1471,7 @@ mod tests_raw_window_scroll_y_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -1637,10 +1578,7 @@ mod tests_raw_window_scroll_y_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 7),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -1738,10 +1676,7 @@ mod tests_raw_window_scroll_y_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 5),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -1835,10 +1770,7 @@ mod tests_raw_window_scroll_y_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 5),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -2105,10 +2037,7 @@ mod tests_raw_window_scroll_y_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(15, 15),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -2216,10 +2145,7 @@ mod tests_raw_window_scroll_y_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(15, 15),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -2447,9 +2373,7 @@ mod tests_raw_window_scroll_x_by {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -2463,10 +2387,7 @@ mod tests_raw_window_scroll_x_by {
 
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec![],
     );
 
@@ -2545,10 +2466,7 @@ mod tests_raw_window_scroll_x_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -2664,10 +2582,7 @@ mod tests_raw_window_scroll_x_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 7),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -2765,10 +2680,7 @@ mod tests_raw_window_scroll_x_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 5),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -2864,10 +2776,7 @@ mod tests_raw_window_scroll_x_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 5),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -3075,10 +2984,7 @@ mod tests_raw_window_scroll_x_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 5),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -3361,10 +3267,7 @@ mod tests_raw_window_scroll_x_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(15, 15),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -3472,10 +3375,7 @@ mod tests_raw_window_scroll_x_by {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(15, 15),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -3725,9 +3625,7 @@ mod tests_raw_window_scroll_to {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -3750,10 +3648,7 @@ mod tests_raw_window_scroll_to {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -3860,10 +3755,7 @@ mod tests_raw_window_scroll_to {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 5),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -4130,10 +4022,7 @@ mod tests_raw_window_scroll_to {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 5),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -4414,9 +4303,7 @@ mod tests_cursor_move {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -4430,10 +4317,7 @@ mod tests_cursor_move {
 
     let (tree, state, bufs, _buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec![],
     );
 
@@ -4478,10 +4362,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, _buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -4526,10 +4407,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -4658,10 +4536,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 10),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -4790,10 +4665,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 10),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -4917,10 +4789,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 5),
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -5229,10 +5098,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 5),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -5541,10 +5407,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(10, 5),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -5847,10 +5710,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       lines,
     );
 
@@ -5986,10 +5846,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -6167,10 +6024,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -6523,10 +6377,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(25, 7),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -6755,10 +6606,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(25, 7),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -6987,10 +6835,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(25, 7),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -7214,10 +7059,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(25, 7),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -7382,10 +7224,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(15, 7),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -7551,10 +7390,7 @@ mod tests_cursor_move {
     let (tree, state, bufs, buf, contents) = make_tree_with_buffer_opts(
       U16Size::new(15, 7),
       buf_opts,
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -7715,7 +7551,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
+      WindowOptionsBuilder::default()
         .wrap(true)
         .line_break(true)
         .build()
@@ -7897,7 +7733,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(10, 10),
-      WindowLocalOptionsBuilder::default()
+      WindowOptionsBuilder::default()
         .wrap(true)
         .line_break(true)
         .build()
@@ -8254,7 +8090,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(25, 7),
-      WindowLocalOptionsBuilder::default()
+      WindowOptionsBuilder::default()
         .wrap(true)
         .line_break(true)
         .build()
@@ -8482,10 +8318,7 @@ mod tests_cursor_move {
     ];
     let (tree, state, bufs, buf, contents) = make_tree(
       U16Size::new(25, 7),
-      WindowLocalOptionsBuilder::default()
-        .wrap(true)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(true).build().unwrap(),
       lines,
     );
 
@@ -8646,9 +8479,7 @@ mod tests_goto_command_line_ex_mode {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crossterm::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
@@ -8663,10 +8494,7 @@ mod tests_goto_command_line_ex_mode {
     let terminal_size = U16Size::new(10, 10);
     let (tree, state, bufs, _buf, contents) = make_tree_with_cmdline(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec![],
     );
 
@@ -8736,9 +8564,7 @@ mod tests_goto_insert_mode {
     CursorViewport, CursorViewportArc, Viewport, ViewportArc,
     ViewportSearchDirection,
   };
-  use crate::ui::widget::window::{
-    WindowLocalOptions, WindowLocalOptionsBuilder,
-  };
+  use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
   use crate::state::ops::cursor_ops::_update_viewport_after_text_changed;
   use crate::state::ops::message_ops::{refresh_view, set_message_visible};
@@ -8759,10 +8585,7 @@ mod tests_goto_insert_mode {
     let terminal_size = U16Size::new(30, 3);
     let (tree, state, bufs, buf, contents) = make_tree(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec!["Should go to insert mode\n"],
     );
 
@@ -8861,10 +8684,7 @@ mod tests_goto_insert_mode {
     let terminal_size = U16Size::new(30, 3);
     let (tree, state, bufs, buf, contents) = make_tree(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec!["Should go to insert mode\n"],
     );
 
@@ -8963,10 +8783,7 @@ mod tests_goto_insert_mode {
     let terminal_size = U16Size::new(30, 3);
     let (tree, state, bufs, buf, contents) = make_tree(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec!["Should go to insert mode\n"],
     );
 
@@ -9065,10 +8882,7 @@ mod tests_goto_insert_mode {
     let terminal_size = U16Size::new(30, 3);
     let (tree, state, bufs, buf, contents) = make_tree(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec!["Should go to insert mode\n"],
     );
 
@@ -9168,10 +8982,7 @@ mod tests_goto_insert_mode {
     let terminal_size = U16Size::new(60, 3);
     let (tree, state, bufs, _buf, contents) = make_tree_with_cmdline(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec!["Should go to insert mode with message command line\n"],
     );
 
@@ -9253,10 +9064,7 @@ mod tests_goto_insert_mode {
     let terminal_size = U16Size::new(60, 3);
     let (tree, state, bufs, _buf, contents) = make_tree_with_cmdline(
       terminal_size,
-      WindowLocalOptionsBuilder::default()
-        .wrap(false)
-        .build()
-        .unwrap(),
+      WindowOptionsBuilder::default().wrap(false).build().unwrap(),
       vec!["Should go to insert mode with message command line\n"],
     );
 

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -381,7 +381,7 @@ pub fn _update_viewport_after_text_changed(
       window.cursor_viewport(),
     ),
     TreeNode::CommandLine(cmdline) => (
-      *cmdline.content().actual_shape(),
+      *cmdline.input().actual_shape(),
       *cmdline.options(),
       cmdline.input_viewport(),
       cmdline.input_cursor_viewport(),
@@ -437,7 +437,7 @@ pub fn _update_viewport_after_text_changed(
         window.set_cursor_viewport(updated_cursor_viewport)
       }
       TreeNode::CommandLine(cmdline) => {
-        cmdline.set_cursor_viewport(updated_cursor_viewport)
+        cmdline.set_input_cursor_viewport(updated_cursor_viewport)
       }
       _ => unreachable!(),
     }
@@ -472,7 +472,7 @@ pub fn cursor_move(
       window.cursor_viewport(),
     ),
     TreeNode::CommandLine(cmdline) => (
-      *cmdline.content().actual_shape(),
+      *cmdline.input().actual_shape(),
       *cmdline.options(),
       cmdline.input_viewport(),
       cmdline.input_cursor_viewport(),
@@ -564,7 +564,7 @@ pub fn cursor_move(
           }
         }
         TreeNode::CommandLine(cmdline) => {
-          cmdline.set_cursor_viewport(new_cursor_viewport.clone());
+          cmdline.set_input_cursor_viewport(new_cursor_viewport.clone());
           if cmdline.cursor_id().is_some() {
             cmdline.move_cursor_to(
               new_cursor_viewport.column_idx() as isize,

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -9,7 +9,7 @@ use crate::ui::viewport::{
   CursorViewport, CursorViewportArc, Viewport, ViewportArc,
   ViewportSearchDirection,
 };
-use crate::ui::widget::window::WindowLocalOptions;
+use crate::ui::widget::window::WindowOptions;
 
 use compact_str::CompactString;
 
@@ -293,7 +293,7 @@ pub fn raw_cursor_viewport_move_to(
 pub fn raw_viewport_scroll_to(
   viewport: &Viewport,
   actual_shape: &U16Rect,
-  window_options: &WindowLocalOptions,
+  window_options: &WindowOptions,
   text: &Text,
   window_scroll_to_op: Operation,
 ) -> Option<ViewportArc> {

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -9,7 +9,7 @@ use crate::ui::viewport::{
   CursorViewport, CursorViewportArc, Viewport, ViewportArc,
   ViewportSearchDirection,
 };
-use crate::ui::widget::window::WindowOptions;
+use crate::ui::widget::window::opt::WindowOptions;
 
 use compact_str::CompactString;
 

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -384,7 +384,7 @@ pub fn _update_viewport_after_text_changed(
       *cmdline.content().actual_shape(),
       *cmdline.options(),
       cmdline.input_viewport(),
-      cmdline.cursor_viewport(),
+      cmdline.input_cursor_viewport(),
     ),
     _ => unreachable!(),
   };
@@ -415,7 +415,7 @@ pub fn _update_viewport_after_text_changed(
     TreeNode::Window(window) => window.set_viewport(updated_viewport.clone()),
     TreeNode::CommandLine(cmdline) => {
       cmdline.set_message_viewport(updated_viewport.clone());
-      cmdline.set_content_viewport(updated_viewport.clone())
+      cmdline.set_input_viewport(updated_viewport.clone())
     }
     _ => unreachable!(),
   }
@@ -475,7 +475,7 @@ pub fn cursor_move(
       *cmdline.content().actual_shape(),
       *cmdline.options(),
       cmdline.input_viewport(),
-      cmdline.cursor_viewport(),
+      cmdline.input_cursor_viewport(),
     ),
     _ => unreachable!(),
   };
@@ -530,7 +530,7 @@ pub fn cursor_move(
         match node {
           TreeNode::Window(window) => window.set_viewport(new_viewport.clone()),
           TreeNode::CommandLine(cmdline) => {
-            cmdline.set_content_viewport(new_viewport.clone())
+            cmdline.set_input_viewport(new_viewport.clone())
           }
           _ => unreachable!(),
         }
@@ -599,7 +599,7 @@ pub fn cursor_insert(
   let node = tree.node_mut(id).unwrap();
   let cursor_viewport = match node {
     TreeNode::Window(window) => window.cursor_viewport(),
-    TreeNode::CommandLine(cmdline) => cmdline.cursor_viewport(),
+    TreeNode::CommandLine(cmdline) => cmdline.input_cursor_viewport(),
     _ => unreachable!(),
   };
 
@@ -654,7 +654,7 @@ pub fn cursor_delete(
   let node = tree.node_mut(id).unwrap();
   let cursor_viewport = match node {
     TreeNode::Window(window) => window.cursor_viewport(),
-    TreeNode::CommandLine(cmdline) => cmdline.cursor_viewport(),
+    TreeNode::CommandLine(cmdline) => cmdline.input_cursor_viewport(),
     _ => unreachable!(),
   };
 

--- a/rsvim_core/src/state/ops/message_ops.rs
+++ b/rsvim_core/src/state/ops/message_ops.rs
@@ -9,7 +9,7 @@ use crate::{geo_rect_as, lock};
 /// - If `visible` is false: hide the message and show the content.
 pub fn set_message_visible(command_line: &mut CommandLine, visible: bool) {
   command_line.indicator_mut().set_visible(!visible);
-  command_line.content_mut().set_visible(!visible);
+  command_line.input_mut().set_visible(!visible);
   command_line.message_mut().set_visible(visible);
   let message_contents = command_line
     .message_mut()
@@ -22,7 +22,7 @@ pub fn set_message_visible(command_line: &mut CommandLine, visible: bool) {
 
 /// Refresh the command line view to have no content in both content and message widgets.
 pub fn refresh_view(command_line: &mut CommandLine) {
-  let cmdline_content_shape = command_line.content_mut().shape();
+  let cmdline_content_shape = command_line.input_mut().shape();
   let cmdline_content_shape = geo_rect_as!(cmdline_content_shape, u16);
   let text_contents = command_line.text_contents().upgrade().unwrap();
   let mut text_contents = lock!(text_contents);

--- a/rsvim_core/src/state/ops/message_ops.rs
+++ b/rsvim_core/src/state/ops/message_ops.rs
@@ -38,7 +38,7 @@ pub fn refresh_view(command_line: &mut CommandLine) {
   let content_viewport_arc = Viewport::to_arc(content_viewport);
   let message = text_contents.command_line_message_mut();
   message.clear();
-  command_line.set_content_viewport(content_viewport_arc.clone());
+  command_line.set_input_viewport(content_viewport_arc.clone());
   let message_viewport = Viewport::view(
     command_line.options(),
     message,

--- a/rsvim_core/src/state/ops/message_ops.rs
+++ b/rsvim_core/src/state/ops/message_ops.rs
@@ -11,19 +11,19 @@ pub fn set_message_visible(command_line: &mut CommandLine, visible: bool) {
   command_line.indicator_mut().set_visible(!visible);
   command_line.input_mut().set_visible(!visible);
   command_line.message_mut().set_visible(visible);
-  let message_contents = command_line
+  let text_contents = command_line
     .message_mut()
     .get_text_contents_mut()
     .upgrade()
     .unwrap();
-  let mut message_contents = lock!(message_contents);
-  message_contents.command_line_input_mut().clear();
+  let mut text_contents = lock!(text_contents);
+  text_contents.command_line_input_mut().clear();
 }
 
 /// Refresh the command line view to have no content in both content and message widgets.
 pub fn refresh_view(command_line: &mut CommandLine) {
-  let cmdline_content_shape = command_line.input_mut().shape();
-  let cmdline_content_shape = geo_rect_as!(cmdline_content_shape, u16);
+  let input_shape = command_line.input_mut().shape();
+  let cmdline_content_shape = geo_rect_as!(input_shape, u16);
   let text_contents = command_line.text_contents().upgrade().unwrap();
   let mut text_contents = lock!(text_contents);
   let content = text_contents.command_line_input_mut();

--- a/rsvim_core/src/state/ops/message_ops.rs
+++ b/rsvim_core/src/state/ops/message_ops.rs
@@ -23,29 +23,19 @@ pub fn set_message_visible(command_line: &mut CommandLine, visible: bool) {
 /// Refresh the command line view to have no content in both content and message widgets.
 pub fn refresh_view(command_line: &mut CommandLine) {
   let input_shape = command_line.input_mut().shape();
-  let cmdline_content_shape = geo_rect_as!(input_shape, u16);
+  let input_actual_shape = geo_rect_as!(input_shape, u16);
   let text_contents = command_line.text_contents().upgrade().unwrap();
   let mut text_contents = lock!(text_contents);
   let content = text_contents.command_line_input_mut();
   content.clear();
-  let content_viewport = Viewport::view(
-    command_line.options(),
-    content,
-    &cmdline_content_shape,
-    0,
-    0,
-  );
-  let content_viewport_arc = Viewport::to_arc(content_viewport);
+  let input_viewport =
+    Viewport::view(command_line.options(), content, &input_actual_shape, 0, 0);
+  let input_viewport_arc = Viewport::to_arc(input_viewport);
   let message = text_contents.command_line_message_mut();
   message.clear();
-  command_line.set_input_viewport(content_viewport_arc.clone());
-  let message_viewport = Viewport::view(
-    command_line.options(),
-    message,
-    &cmdline_content_shape,
-    0,
-    0,
-  );
+  command_line.set_input_viewport(input_viewport_arc.clone());
+  let message_viewport =
+    Viewport::view(command_line.options(), message, &input_actual_shape, 0, 0);
   let message_viewport_arc = Viewport::to_arc(message_viewport);
   command_line.set_message_viewport(message_viewport_arc.clone());
 }

--- a/rsvim_core/src/state/ops/message_ops.rs
+++ b/rsvim_core/src/state/ops/message_ops.rs
@@ -17,7 +17,7 @@ pub fn set_message_visible(command_line: &mut CommandLine, visible: bool) {
     .upgrade()
     .unwrap();
   let mut message_contents = lock!(message_contents);
-  message_contents.command_line_content_mut().clear();
+  message_contents.command_line_input_mut().clear();
 }
 
 /// Refresh the command line view to have no content in both content and message widgets.
@@ -26,7 +26,7 @@ pub fn refresh_view(command_line: &mut CommandLine) {
   let cmdline_content_shape = geo_rect_as!(cmdline_content_shape, u16);
   let text_contents = command_line.text_contents().upgrade().unwrap();
   let mut text_contents = lock!(text_contents);
-  let content = text_contents.command_line_content_mut();
+  let content = text_contents.command_line_input_mut();
   content.clear();
   let content_viewport = Viewport::view(
     command_line.options(),

--- a/rsvim_core/src/tests/buf.rs
+++ b/rsvim_core/src/tests/buf.rs
@@ -2,7 +2,7 @@
 
 #![allow(unused_imports)]
 
-use crate::buf::opt::BufferLocalOptions;
+use crate::buf::opt::BufferOptions;
 use crate::buf::text::Text;
 use crate::buf::{Buffer, BufferArc, BuffersManager, BuffersManagerArc};
 use crate::prelude::*;
@@ -14,7 +14,7 @@ use std::io::BufReader;
 
 pub fn make_buffer_from_lines(
   terminal_size: U16Size,
-  opts: BufferLocalOptions,
+  opts: BufferOptions,
   lines: Vec<&str>,
 ) -> BufferArc {
   let mut rpb: RopeBuilder = RopeBuilder::new();
@@ -28,7 +28,7 @@ pub fn make_buffer_from_lines(
 
 pub fn make_empty_buffer(
   terminal_size: U16Size,
-  opts: BufferLocalOptions,
+  opts: BufferOptions,
 ) -> BufferArc {
   let buf =
     Buffer::_new(opts, terminal_size, Rope::new(), None, None, None, None);
@@ -36,7 +36,7 @@ pub fn make_empty_buffer(
 }
 
 pub fn make_buffers_manager(
-  opts: BufferLocalOptions,
+  opts: BufferOptions,
   bufs: Vec<BufferArc>,
 ) -> BuffersManagerArc {
   let mut bm = BuffersManager::new();

--- a/rsvim_core/src/tests/tree.rs
+++ b/rsvim_core/src/tests/tree.rs
@@ -7,7 +7,7 @@ use crate::content::TextContentsArc;
 use crate::prelude::*;
 use crate::ui::tree::*;
 use crate::ui::widget::command_line::CommandLine;
-use crate::ui::widget::command_line::indicator::CommandLineIndicatorSymbol;
+use crate::ui::widget::command_line::indicator::IndicatorSymbol;
 use crate::ui::widget::cursor::Cursor;
 use crate::ui::widget::window::{Window, WindowLocalOptions};
 

--- a/rsvim_core/src/tests/tree.rs
+++ b/rsvim_core/src/tests/tree.rs
@@ -9,14 +9,14 @@ use crate::ui::tree::*;
 use crate::ui::widget::command_line::CommandLine;
 use crate::ui::widget::command_line::indicator::IndicatorSymbol;
 use crate::ui::widget::cursor::Cursor;
-use crate::ui::widget::window::{Window, WindowLocalOptions};
+use crate::ui::widget::window::{Window, WindowOptions};
 
 use std::sync::Arc;
 
 /// Create tree with 1 window and 1 buffer, the buffer is in buffers manager.
 pub fn make_tree_with_buffers(
   canvas_size: U16Size,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   buffers_manager: BuffersManagerArc,
 ) -> TreeArc {
   // UI Tree
@@ -57,7 +57,7 @@ pub fn make_tree_with_buffers(
 /// command-line is in the text contents.
 pub fn make_tree_with_buffers_cmdline(
   canvas_size: U16Size,
-  window_local_opts: WindowLocalOptions,
+  window_local_opts: WindowOptions,
   buffers_manager: BuffersManagerArc,
   text_contents: TextContentsArc,
 ) -> TreeArc {

--- a/rsvim_core/src/tests/tree.rs
+++ b/rsvim_core/src/tests/tree.rs
@@ -6,9 +6,8 @@ use crate::buf::BuffersManagerArc;
 use crate::content::TextContentsArc;
 use crate::prelude::*;
 use crate::ui::tree::*;
-use crate::ui::widget::command_line::{
-  CommandLine, CommandLineIndicatorSymbol,
-};
+use crate::ui::widget::command_line::CommandLine;
+use crate::ui::widget::command_line::indicator::CommandLineIndicatorSymbol;
 use crate::ui::widget::cursor::Cursor;
 use crate::ui::widget::window::{Window, WindowLocalOptions};
 

--- a/rsvim_core/src/tests/tree.rs
+++ b/rsvim_core/src/tests/tree.rs
@@ -9,7 +9,8 @@ use crate::ui::tree::*;
 use crate::ui::widget::command_line::CommandLine;
 use crate::ui::widget::command_line::indicator::IndicatorSymbol;
 use crate::ui::widget::cursor::Cursor;
-use crate::ui::widget::window::{Window, WindowOptions};
+use crate::ui::widget::window::Window;
+use crate::ui::widget::window::opt::WindowOptions;
 
 use std::sync::Arc;
 

--- a/rsvim_core/src/ui/tree.rs
+++ b/rsvim_core/src/ui/tree.rs
@@ -5,8 +5,9 @@ use crate::ui::canvas::{Canvas, CanvasArc};
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::command_line::CommandLine;
 use crate::ui::widget::root::RootContainer;
-use crate::ui::widget::window::{
-  Window, WindowGlobalOptions, WindowGlobalOptionsBuilder, WindowOptions,
+use crate::ui::widget::window::Window;
+use crate::ui::widget::window::opt::{
+  WindowGlobalOptions, WindowGlobalOptionsBuilder, WindowOptions,
   WindowOptionsBuilder,
 };
 use crate::{inode_enum_dispatcher, widget_enum_dispatcher};

--- a/rsvim_core/src/ui/tree.rs
+++ b/rsvim_core/src/ui/tree.rs
@@ -6,8 +6,8 @@ use crate::ui::widget::Widgetable;
 use crate::ui::widget::command_line::CommandLine;
 use crate::ui::widget::root::RootContainer;
 use crate::ui::widget::window::{
-  Window, WindowGlobalOptions, WindowGlobalOptionsBuilder, WindowLocalOptions,
-  WindowLocalOptionsBuilder,
+  Window, WindowGlobalOptions, WindowGlobalOptionsBuilder, WindowOptions,
+  WindowOptionsBuilder,
 };
 use crate::{inode_enum_dispatcher, widget_enum_dispatcher};
 
@@ -147,7 +147,7 @@ pub struct Tree {
   global_options: WindowGlobalOptions,
 
   // Global-local options for windows.
-  global_local_options: WindowLocalOptions,
+  global_local_options: WindowOptions,
 }
 
 arc_mutex_ptr!(Tree);
@@ -173,9 +173,7 @@ impl Tree {
       window_ids: BTreeSet::new(),
       current_window_id: None,
       global_options: WindowGlobalOptionsBuilder::default().build().unwrap(),
-      global_local_options: WindowLocalOptionsBuilder::default()
-        .build()
-        .unwrap(),
+      global_local_options: WindowOptionsBuilder::default().build().unwrap(),
     }
   }
 
@@ -462,15 +460,15 @@ impl Tree {
     self.global_options = *options;
   }
 
-  pub fn global_local_options(&self) -> &WindowLocalOptions {
+  pub fn global_local_options(&self) -> &WindowOptions {
     &self.global_local_options
   }
 
-  pub fn global_local_options_mut(&mut self) -> &mut WindowLocalOptions {
+  pub fn global_local_options_mut(&mut self) -> &mut WindowOptions {
     &mut self.global_local_options
   }
 
-  pub fn set_global_local_options(&mut self, options: &WindowLocalOptions) {
+  pub fn set_global_local_options(&mut self, options: &WindowOptions) {
     self.global_local_options = *options;
   }
 }

--- a/rsvim_core/src/ui/viewport.rs
+++ b/rsvim_core/src/ui/viewport.rs
@@ -3,7 +3,7 @@
 use crate::buf::text::Text;
 use crate::prelude::*;
 use crate::ui::canvas::Canvas;
-use crate::ui::widget::window::WindowOptions;
+use crate::ui::widget::window::opt::WindowOptions;
 
 use litemap::LiteMap;
 use std::ops::Range;

--- a/rsvim_core/src/ui/viewport.rs
+++ b/rsvim_core/src/ui/viewport.rs
@@ -3,7 +3,7 @@
 use crate::buf::text::Text;
 use crate::prelude::*;
 use crate::ui::canvas::Canvas;
-use crate::ui::widget::window::WindowLocalOptions;
+use crate::ui::widget::window::WindowOptions;
 
 use litemap::LiteMap;
 use std::ops::Range;
@@ -555,7 +555,7 @@ impl Viewport {
   /// NOTE: By default the viewport should starts from (0, 0), i.e. when first open buffer in a
   /// window.
   pub fn view(
-    opts: &WindowLocalOptions,
+    opts: &WindowOptions,
     text: &Text,
     shape: &U16Rect,
     start_line: usize,
@@ -585,7 +585,7 @@ impl Viewport {
   pub fn search_anchor(
     &self,
     direction: ViewportSearchDirection,
-    opts: &WindowLocalOptions,
+    opts: &WindowOptions,
     text: &Text,
     shape: &U16Rect,
     target_cursor_line: usize,

--- a/rsvim_core/src/ui/viewport/sync.rs
+++ b/rsvim_core/src/ui/viewport/sync.rs
@@ -5,7 +5,7 @@
 use crate::buf::text::Text;
 use crate::prelude::*;
 use crate::ui::viewport::{LineViewport, RowViewport};
-use crate::ui::widget::window::WindowOptions;
+use crate::ui::widget::window::opt::WindowOptions;
 
 use icu::segmenter::{WordSegmenter, options::WordBreakInvariantOptions};
 use itertools::Itertools;

--- a/rsvim_core/src/ui/viewport/sync.rs
+++ b/rsvim_core/src/ui/viewport/sync.rs
@@ -5,7 +5,7 @@
 use crate::buf::text::Text;
 use crate::prelude::*;
 use crate::ui::viewport::{LineViewport, RowViewport};
-use crate::ui::widget::window::WindowLocalOptions;
+use crate::ui::widget::window::WindowOptions;
 
 use icu::segmenter::{WordSegmenter, options::WordBreakInvariantOptions};
 use itertools::Itertools;
@@ -51,7 +51,7 @@ impl ViewportLineRange {
 
 /// Calculate viewport from top to bottom.
 pub fn sync(
-  opts: &WindowLocalOptions,
+  opts: &WindowOptions,
   text: &Text,
   shape: &U16Rect,
   start_line: usize,
@@ -1693,7 +1693,7 @@ mod wrap_detail {
 // Returns `start_line`, `start_column` for the new viewport.
 pub fn search_anchor_downward(
   viewport: &Viewport,
-  opts: &WindowLocalOptions,
+  opts: &WindowOptions,
   text: &Text,
   shape: &U16Rect,
   target_cursor_line: usize,
@@ -1917,7 +1917,7 @@ fn search_anchor_downward_wrap(
 // Returns `start_line`, `start_column` for the new viewport.
 pub fn search_anchor_upward(
   viewport: &Viewport,
-  opts: &WindowLocalOptions,
+  opts: &WindowOptions,
   text: &Text,
   window_actual_shape: &U16Rect,
   target_cursor_line: usize,
@@ -2095,7 +2095,7 @@ fn search_anchor_upward_wrap(
 // Returns `start_line`, `start_column` for the new viewport.
 pub fn search_anchor_leftward(
   viewport: &Viewport,
-  opts: &WindowLocalOptions,
+  opts: &WindowOptions,
   text: &Text,
   window_actual_shape: &U16Rect,
   target_cursor_line: usize,
@@ -2259,7 +2259,7 @@ fn search_anchor_leftward_wrap(
 // Returns `start_line`, `start_column` for the new viewport.
 pub fn search_anchor_rightward(
   viewport: &Viewport,
-  opts: &WindowLocalOptions,
+  opts: &WindowOptions,
   text: &Text,
   window_actual_shape: &U16Rect,
   target_cursor_line: usize,

--- a/rsvim_core/src/ui/viewport_tests.rs
+++ b/rsvim_core/src/ui/viewport_tests.rs
@@ -3,17 +3,16 @@
 use super::viewport::*;
 
 use crate::buf::BufferArc;
-use crate::buf::opt::{
-  BufferLocalOptions, BufferLocalOptionsBuilder, FileFormatOption,
-};
+use crate::buf::opt::{BufferOptions, BufferOptionsBuilder, FileFormatOption};
 use crate::prelude::*;
 use crate::tests::buf::{make_buffer_from_lines, make_empty_buffer};
 use crate::tests::log::init as test_log_init;
 use crate::ui::canvas::{Canvas, Cell};
 use crate::ui::tree::*;
 use crate::ui::widget::Widgetable;
+use crate::ui::widget::window::Window;
 use crate::ui::widget::window::content::WindowContent;
-use crate::ui::widget::window::{Window, WindowOptions, WindowOptionsBuilder};
+use crate::ui::widget::window::opt::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::ToCompactString;
 use ropey::{Rope, RopeBuilder};
@@ -375,7 +374,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -433,7 +432,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(27, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -489,7 +488,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -535,7 +534,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(20, 20);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_empty_buffer(terminal_size, buf_opts);
@@ -561,7 +560,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -638,7 +637,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(27, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -689,7 +688,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(20, 20);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(terminal_size, buf_opts, vec![]);
@@ -715,7 +714,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(20, 20);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(terminal_size, buf_opts, vec![""]);
@@ -741,7 +740,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(20, 20);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(terminal_size, buf_opts, vec![]);
@@ -767,7 +766,7 @@ mod tests_view_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -829,7 +828,7 @@ mod tests_view_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(30, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Unix)
       .build()
       .unwrap();
@@ -874,7 +873,7 @@ mod tests_view_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(29, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -917,7 +916,7 @@ mod tests_view_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(30, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Unix)
       .build()
       .unwrap();
@@ -962,7 +961,7 @@ mod tests_view_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(29, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -1009,7 +1008,7 @@ mod tests_view_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -1067,7 +1066,7 @@ mod tests_view_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -1125,7 +1124,7 @@ mod tests_view_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -1183,7 +1182,7 @@ mod tests_view_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -1241,7 +1240,7 @@ mod tests_view_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -1294,7 +1293,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1333,7 +1332,7 @@ mod tests_view_wrap_nolinebreak {
   #[test]
   fn new2() {
     let terminal_size = U16Size::new(27, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1392,7 +1391,7 @@ mod tests_view_wrap_nolinebreak {
   #[test]
   fn new3() {
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1426,7 +1425,7 @@ mod tests_view_wrap_nolinebreak {
   #[test]
   fn new4() {
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_empty_buffer(terminal_size, buf_opts);
@@ -1442,7 +1441,7 @@ mod tests_view_wrap_nolinebreak {
   #[test]
   fn new5() {
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1482,7 +1481,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1523,7 +1522,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1564,7 +1563,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1605,7 +1604,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1647,7 +1646,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(terminal_size, buf_opts, vec![]);
@@ -1675,7 +1674,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_empty_buffer(terminal_size, buf_opts);
@@ -1703,7 +1702,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(terminal_size, buf_opts, vec![""]);
@@ -1731,7 +1730,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 8);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1770,7 +1769,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1808,7 +1807,7 @@ mod tests_view_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1843,7 +1842,7 @@ mod tests_view_wrap_nolinebreak {
   #[test]
   fn update1() {
     let terminal_size = U16Size::new(15, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -1925,7 +1924,7 @@ mod tests_view_wrap_nolinebreak {
   #[test]
   fn update2() {
     let terminal_size = U16Size::new(15, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -2007,7 +2006,7 @@ mod tests_view_wrap_nolinebreak {
   #[test]
   fn update3() {
     let terminal_size = U16Size::new(15, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -2065,7 +2064,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 13);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Unix)
       .build()
       .unwrap();
@@ -2112,7 +2111,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 13);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -2159,7 +2158,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 13);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Unix)
       .build()
       .unwrap();
@@ -2206,7 +2205,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 13);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -2253,7 +2252,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Unix)
       .build()
       .unwrap();
@@ -2294,7 +2293,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -2335,7 +2334,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Unix)
       .build()
       .unwrap();
@@ -2376,7 +2375,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -2417,7 +2416,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Unix)
       .build()
       .unwrap();
@@ -2457,7 +2456,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -2497,7 +2496,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Unix)
       .build()
       .unwrap();
@@ -2537,7 +2536,7 @@ mod tests_view_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -2581,7 +2580,7 @@ mod tests_view_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -2622,7 +2621,7 @@ mod tests_view_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -2663,7 +2662,7 @@ mod tests_view_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -2709,7 +2708,7 @@ mod tests_view_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -2750,7 +2749,7 @@ mod tests_view_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -2795,7 +2794,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -2846,7 +2845,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(27, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -2906,7 +2905,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 11);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -2959,7 +2958,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_empty_buffer(terminal_size, buf_opts);
@@ -2983,7 +2982,7 @@ mod tests_view_wrap_linebreak {
   #[test]
   fn new5() {
     let terminal_size = U16Size::new(31, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -3034,7 +3033,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -3085,7 +3084,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 11);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -3137,7 +3136,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 11);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -3189,7 +3188,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -3240,7 +3239,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -3291,7 +3290,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 31);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -3365,7 +3364,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 31);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -3437,7 +3436,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 31);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(terminal_size, buf_opts, vec![]);
@@ -3463,7 +3462,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 31);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(terminal_size, buf_opts, vec![""]);
@@ -3489,7 +3488,7 @@ mod tests_view_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buffer = make_buffer_from_lines(
@@ -3544,7 +3543,7 @@ mod tests_view_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -3595,7 +3594,7 @@ mod tests_view_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -3646,7 +3645,7 @@ mod tests_view_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -3697,7 +3696,7 @@ mod tests_view_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -3748,7 +3747,7 @@ mod tests_view_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 11);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -3800,7 +3799,7 @@ mod tests_view_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -3843,7 +3842,7 @@ mod tests_search_anchor_downward_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -4015,7 +4014,7 @@ mod tests_search_anchor_downward_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -4236,7 +4235,7 @@ mod tests_search_anchor_downward_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -4463,7 +4462,7 @@ mod tests_search_anchor_downward_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -4693,7 +4692,7 @@ mod tests_search_anchor_downward_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -4850,7 +4849,7 @@ mod tests_search_anchor_downward_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -5080,7 +5079,7 @@ mod tests_search_anchor_downward_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -5310,7 +5309,7 @@ mod tests_search_anchor_downward_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -5548,7 +5547,7 @@ mod tests_search_anchor_downward_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -5785,7 +5784,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -5998,7 +5997,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -6211,7 +6210,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -6310,7 +6309,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -6562,7 +6561,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -6633,7 +6632,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -6708,7 +6707,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -6963,7 +6962,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -7218,7 +7217,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -7302,7 +7301,7 @@ mod tests_search_anchor_downward_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -7380,7 +7379,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -7582,7 +7581,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -7789,7 +7788,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -7961,7 +7960,7 @@ mod tests_search_anchor_downward_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -8041,7 +8040,7 @@ mod tests_search_anchor_upward_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -8325,7 +8324,7 @@ mod tests_search_anchor_upward_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -8609,7 +8608,7 @@ mod tests_search_anchor_upward_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -8920,7 +8919,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -9181,7 +9180,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -9436,7 +9435,7 @@ mod tests_search_anchor_upward_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(21, 7);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -9731,7 +9730,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -9986,7 +9985,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -10239,7 +10238,7 @@ mod tests_search_anchor_upward_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(21, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -10457,7 +10456,7 @@ mod tests_search_anchor_horizontally_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -10960,7 +10959,7 @@ mod tests_search_anchor_horizontally_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -11383,7 +11382,7 @@ mod tests_search_anchor_horizontally_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_nowrap();
 
     let buf = make_buffer_from_lines(
@@ -11816,7 +11815,7 @@ mod tests_search_anchor_horizontally_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -12242,7 +12241,7 @@ mod tests_search_anchor_horizontally_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -12668,7 +12667,7 @@ mod tests_search_anchor_horizontally_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -13101,7 +13100,7 @@ mod tests_search_anchor_horizontally_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -13537,7 +13536,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -14068,7 +14067,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -14454,7 +14453,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -14733,7 +14732,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_nolinebreak();
 
     let buf = make_buffer_from_lines(
@@ -15088,7 +15087,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -15477,7 +15476,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -15866,7 +15865,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -16148,7 +16147,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -16430,7 +16429,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -16788,7 +16787,7 @@ mod tests_search_anchor_horizontally_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -17146,7 +17145,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -17341,7 +17340,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -17676,7 +17675,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -18151,7 +18150,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(
@@ -18577,7 +18576,7 @@ mod tests_search_anchor_horizontally_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(17, 4);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = make_wrap_linebreak();
 
     let buf = make_buffer_from_lines(

--- a/rsvim_core/src/ui/viewport_tests.rs
+++ b/rsvim_core/src/ui/viewport_tests.rs
@@ -11,7 +11,7 @@ use crate::ui::canvas::{Canvas, Cell};
 use crate::ui::tree::*;
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::window::Window;
-use crate::ui::widget::window::content::WindowContent;
+use crate::ui::widget::window::content::Content;
 use crate::ui::widget::window::opt::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::ToCompactString;
@@ -193,11 +193,8 @@ pub fn make_canvas(
       terminal_size.height() as isize,
     ),
   );
-  let window_content = WindowContent::new(
-    shape,
-    Arc::downgrade(&buffer),
-    Arc::downgrade(&viewport),
-  );
+  let window_content =
+    Content::new(shape, Arc::downgrade(&buffer), Arc::downgrade(&viewport));
   let mut canvas = Canvas::new(terminal_size);
   window_content.draw(&mut canvas);
   canvas

--- a/rsvim_core/src/ui/viewport_tests.rs
+++ b/rsvim_core/src/ui/viewport_tests.rs
@@ -13,9 +13,7 @@ use crate::ui::canvas::{Canvas, Cell};
 use crate::ui::tree::*;
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::window::content::WindowContent;
-use crate::ui::widget::window::{
-  Window, WindowLocalOptions, WindowLocalOptionsBuilder,
-};
+use crate::ui::widget::window::{Window, WindowOptions, WindowOptionsBuilder};
 
 use compact_str::ToCompactString;
 use ropey::{Rope, RopeBuilder};
@@ -26,19 +24,16 @@ use std::io::{BufReader, BufWriter};
 use std::rc::Rc;
 use std::sync::{Arc, Once};
 
-pub fn make_nowrap() -> WindowLocalOptions {
-  WindowLocalOptionsBuilder::default()
-    .wrap(false)
-    .build()
-    .unwrap()
+pub fn make_nowrap() -> WindowOptions {
+  WindowOptionsBuilder::default().wrap(false).build().unwrap()
 }
 
-pub fn make_wrap_nolinebreak() -> WindowLocalOptions {
-  WindowLocalOptionsBuilder::default().build().unwrap()
+pub fn make_wrap_nolinebreak() -> WindowOptions {
+  WindowOptionsBuilder::default().build().unwrap()
 }
 
-pub fn make_wrap_linebreak() -> WindowLocalOptions {
-  WindowLocalOptionsBuilder::default()
+pub fn make_wrap_linebreak() -> WindowOptions {
+  WindowOptionsBuilder::default()
     .line_break(true)
     .build()
     .unwrap()
@@ -47,7 +42,7 @@ pub fn make_wrap_linebreak() -> WindowLocalOptions {
 pub fn make_window(
   terminal_size: U16Size,
   buffer: BufferArc,
-  window_options: &WindowLocalOptions,
+  window_options: &WindowOptions,
 ) -> Window {
   let mut tree = Tree::new(terminal_size);
   tree.set_global_local_options(window_options);
@@ -186,7 +181,7 @@ pub fn assert_viewport(
 
 pub fn make_canvas(
   terminal_size: U16Size,
-  window_options: WindowLocalOptions,
+  window_options: WindowOptions,
   buffer: BufferArc,
   viewport: ViewportArc,
 ) -> Canvas {

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -95,6 +95,7 @@ impl CommandLine {
     let indicator = Indicator::new(indicator_shape, IndicatorSymbol::Empty);
     let indicator_id = indicator.id();
     let mut indicator_node = CommandLineNode::Indicator(indicator);
+    // Indicator by default is invisible
     indicator_node.set_visible(false);
     base.bounded_insert(root_id, indicator_node);
 
@@ -127,35 +128,37 @@ impl CommandLine {
       );
       (input_viewport, input_cursor_viewport, message_viewport)
     };
+
     let input_viewport = Viewport::to_arc(input_viewport);
     let input_cursor_viewport = CursorViewport::to_arc(input_cursor_viewport);
     let message_viewport = Viewport::to_arc(message_viewport);
 
-    let cmdline_content = Input::new(
+    let input = Input::new(
       input_shape,
       text_contents.clone(),
       Arc::downgrade(&input_viewport),
     );
-    let cmdline_content_id = cmdline_content.id();
-    let mut cmdline_content_node = CommandLineNode::Input(cmdline_content);
-    cmdline_content_node.set_visible(false);
-    base.bounded_insert(root_id, cmdline_content_node);
+    let input_id = input.id();
+    let mut input_node = CommandLineNode::Input(input);
+    // Input by default is invisible
+    input_node.set_visible(false);
+    base.bounded_insert(root_id, input_node);
 
-    let cmdline_message = Message::new(
+    let message = Message::new(
       shape,
       text_contents.clone(),
       Arc::downgrade(&message_viewport),
     );
-    let cmdline_message_id = cmdline_message.id();
-    let cmdline_message_node = CommandLineNode::Message(cmdline_message);
-    base.bounded_insert(root_id, cmdline_message_node);
+    let message_id = message.id();
+    let message_node = CommandLineNode::Message(message);
+    base.bounded_insert(root_id, message_node);
 
     Self {
       base,
       options,
       indicator_id,
-      input_id: cmdline_content_id,
-      message_id: cmdline_message_id,
+      input_id,
+      message_id,
       cursor_id: None,
       text_contents,
       input_viewport,

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -264,8 +264,8 @@ impl CommandLine {
 
 // Widgets {
 impl CommandLine {
-  /// Command-line content widget.
-  pub fn content(&self) -> &Input {
+  /// Command-line input widget.
+  pub fn input(&self) -> &Input {
     debug_assert!(self.base.node(self.input_id).is_some());
     debug_assert!(matches!(
       self.base.node(self.input_id).unwrap(),
@@ -281,8 +281,8 @@ impl CommandLine {
     }
   }
 
-  /// Mutable command-line content widget.
-  pub fn content_mut(&mut self) -> &mut Input {
+  /// Mutable command-line input widget.
+  pub fn input_mut(&mut self) -> &mut Input {
     debug_assert!(self.base.node_mut(self.input_id).is_some());
     debug_assert!(matches!(
       self.base.node_mut(self.input_id).unwrap(),

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -18,7 +18,7 @@ use crate::{
 use indicator::{Indicator, IndicatorSymbol};
 use input::Input;
 use message::Message;
-use root::CommandLineRootContainer;
+use root::RootContainer;
 
 use std::sync::Arc;
 
@@ -33,28 +33,29 @@ pub mod indicator_tests;
 #[derive(Debug, Clone)]
 /// The value holder for each window widget.
 pub enum CommandLineNode {
-  CommandLineRootContainer(CommandLineRootContainer),
-  CommandLineIndicator(Indicator),
-  CommandLineContent(Input),
+  RootContainer(RootContainer),
+  Indicator(Indicator),
+  Input(Input),
   Cursor(Cursor),
-  CommandLineMessage(Message),
+  Message(Message),
 }
 
 inode_enum_dispatcher!(
   CommandLineNode,
-  CommandLineRootContainer,
-  CommandLineIndicator,
-  CommandLineContent,
+  RootContainer,
+  Indicator,
+  Input,
   Cursor,
-  CommandLineMessage
+  Message
 );
+
 widget_enum_dispatcher!(
   CommandLineNode,
-  CommandLineRootContainer,
-  CommandLineIndicator,
-  CommandLineContent,
+  RootContainer,
+  Indicator,
+  Input,
   Cursor,
-  CommandLineMessage
+  Message
 );
 
 #[derive(Debug, Clone)]
@@ -85,10 +86,9 @@ impl CommandLine {
       .build()
       .unwrap();
 
-    let cmdline_root = CommandLineRootContainer::new(shape);
+    let cmdline_root = RootContainer::new(shape);
     let cmdline_root_id = cmdline_root.id();
-    let cmdline_root_node =
-      CommandLineNode::CommandLineRootContainer(cmdline_root);
+    let cmdline_root_node = CommandLineNode::RootContainer(cmdline_root);
 
     let mut base = Itree::new(cmdline_root_node);
 
@@ -98,7 +98,7 @@ impl CommandLine {
       Indicator::new(cmdline_indicator_shape, IndicatorSymbol::Empty);
     let cmdline_indicator_id = cmdline_indicator.id();
     let mut cmdline_indicator_node =
-      CommandLineNode::CommandLineIndicator(cmdline_indicator);
+      CommandLineNode::Indicator(cmdline_indicator);
     cmdline_indicator_node.set_visible(false);
     base.bounded_insert(cmdline_root_id, cmdline_indicator_node);
 
@@ -140,8 +140,7 @@ impl CommandLine {
       Arc::downgrade(&input_viewport),
     );
     let cmdline_content_id = cmdline_content.id();
-    let mut cmdline_content_node =
-      CommandLineNode::CommandLineContent(cmdline_content);
+    let mut cmdline_content_node = CommandLineNode::Input(cmdline_content);
     cmdline_content_node.set_visible(false);
     base.bounded_insert(cmdline_root_id, cmdline_content_node);
 
@@ -151,8 +150,7 @@ impl CommandLine {
       Arc::downgrade(&message_viewport),
     );
     let cmdline_message_id = cmdline_message.id();
-    let cmdline_message_node =
-      CommandLineNode::CommandLineMessage(cmdline_message);
+    let cmdline_message_node = CommandLineNode::Message(cmdline_message);
     base.bounded_insert(cmdline_root_id, cmdline_message_node);
 
     Self {
@@ -208,7 +206,7 @@ impl CommandLine {
   /// Set viewport for content.
   pub fn set_content_viewport(&mut self, viewport: ViewportArc) {
     self.input_viewport = viewport.clone();
-    if let Some(CommandLineNode::CommandLineContent(content)) =
+    if let Some(CommandLineNode::Input(content)) =
       self.base.node_mut(self.content_id)
     {
       content.set_viewport(Arc::downgrade(&viewport));
@@ -218,7 +216,7 @@ impl CommandLine {
   /// Set viewport for message.
   pub fn set_message_viewport(&mut self, viewport: ViewportArc) {
     self.message_viewport = viewport.clone();
-    if let Some(CommandLineNode::CommandLineMessage(content)) =
+    if let Some(CommandLineNode::Message(content)) =
       self.base.node_mut(self.message_id)
     {
       content.set_viewport(Arc::downgrade(&viewport));
@@ -268,11 +266,11 @@ impl CommandLine {
     debug_assert!(self.base.node(self.content_id).is_some());
     debug_assert!(matches!(
       self.base.node(self.content_id).unwrap(),
-      CommandLineNode::CommandLineContent(_)
+      CommandLineNode::Input(_)
     ));
 
     match self.base.node(self.content_id).unwrap() {
-      CommandLineNode::CommandLineContent(w) => {
+      CommandLineNode::Input(w) => {
         debug_assert_eq!(w.id(), self.content_id);
         w
       }
@@ -285,11 +283,11 @@ impl CommandLine {
     debug_assert!(self.base.node_mut(self.content_id).is_some());
     debug_assert!(matches!(
       self.base.node_mut(self.content_id).unwrap(),
-      CommandLineNode::CommandLineContent(_)
+      CommandLineNode::Input(_)
     ));
 
     match self.base.node_mut(self.content_id).unwrap() {
-      CommandLineNode::CommandLineContent(w) => {
+      CommandLineNode::Input(w) => {
         debug_assert_eq!(w.id(), self.content_id);
         w
       }
@@ -302,11 +300,11 @@ impl CommandLine {
     debug_assert!(self.base.node(self.message_id).is_some());
     debug_assert!(matches!(
       self.base.node(self.message_id).unwrap(),
-      CommandLineNode::CommandLineMessage(_)
+      CommandLineNode::Message(_)
     ));
 
     match self.base.node(self.message_id).unwrap() {
-      CommandLineNode::CommandLineMessage(w) => {
+      CommandLineNode::Message(w) => {
         debug_assert_eq!(w.id(), self.message_id);
         w
       }
@@ -319,11 +317,11 @@ impl CommandLine {
     debug_assert!(self.base.node_mut(self.message_id).is_some());
     debug_assert!(matches!(
       self.base.node_mut(self.message_id).unwrap(),
-      CommandLineNode::CommandLineMessage(_)
+      CommandLineNode::Message(_)
     ));
 
     match self.base.node_mut(self.message_id).unwrap() {
-      CommandLineNode::CommandLineMessage(w) => {
+      CommandLineNode::Message(w) => {
         debug_assert_eq!(w.id(), self.message_id);
         w
       }
@@ -336,11 +334,11 @@ impl CommandLine {
     debug_assert!(self.base.node(self.indicator_id).is_some());
     debug_assert!(matches!(
       self.base.node(self.indicator_id).unwrap(),
-      CommandLineNode::CommandLineIndicator(_)
+      CommandLineNode::Indicator(_)
     ));
 
     match self.base.node(self.indicator_id).unwrap() {
-      CommandLineNode::CommandLineIndicator(w) => {
+      CommandLineNode::Indicator(w) => {
         debug_assert_eq!(w.id(), self.indicator_id);
         w
       }
@@ -353,11 +351,11 @@ impl CommandLine {
     debug_assert!(self.base.node_mut(self.indicator_id).is_some());
     debug_assert!(matches!(
       self.base.node_mut(self.indicator_id).unwrap(),
-      CommandLineNode::CommandLineIndicator(_)
+      CommandLineNode::Indicator(_)
     ));
 
     match self.base.node_mut(self.indicator_id).unwrap() {
-      CommandLineNode::CommandLineIndicator(w) => {
+      CommandLineNode::Indicator(w) => {
         debug_assert_eq!(w.id(), self.indicator_id);
         w
       }

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -12,16 +12,16 @@ use crate::ui::widget::command_line::content::CommandLineContent;
 use crate::ui::widget::command_line::indicator::CommandLineIndicator;
 use crate::ui::widget::command_line::root::CommandLineRootContainer;
 use crate::ui::widget::cursor::Cursor;
+use crate::ui::widget::window::WindowLocalOptionsBuilder;
 use crate::ui::widget::window::opt::WindowLocalOptions;
 use crate::{
   geo_rect_as, inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher,
 };
 
+use indicator::CommandLineIndicatorSymbol;
+use message::CommandLineMessage;
+
 use std::sync::Arc;
-// Re-export
-use crate::ui::widget::command_line::message::CommandLineMessage;
-use crate::ui::widget::window::WindowLocalOptionsBuilder;
-pub use indicator::CommandLineIndicatorSymbol;
 
 pub mod content;
 pub mod indicator;

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -9,9 +9,7 @@ use crate::ui::viewport::{
 };
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::cursor::Cursor;
-use crate::ui::widget::window::{
-  WindowLocalOptions, WindowLocalOptionsBuilder,
-};
+use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 use crate::{
   geo_rect_as, inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher,
 };
@@ -62,7 +60,7 @@ widget_enum_dispatcher!(
 /// The Vim command-line.
 pub struct CommandLine {
   base: Itree<CommandLineNode>,
-  options: WindowLocalOptions,
+  options: WindowOptions,
 
   indicator_id: TreeNodeId,
   content_id: TreeNodeId,
@@ -79,7 +77,7 @@ pub struct CommandLine {
 impl CommandLine {
   pub fn new(shape: IRect, text_contents: TextContentsWk) -> Self {
     // Force cmdline window options.
-    let options = WindowLocalOptionsBuilder::default()
+    let options = WindowOptionsBuilder::default()
       .wrap(false)
       .line_break(false)
       .scroll_off(0_u16)
@@ -184,12 +182,12 @@ impl Widgetable for CommandLine {
 
 impl CommandLine {
   /// Get window local options.
-  pub fn options(&self) -> &WindowLocalOptions {
+  pub fn options(&self) -> &WindowOptions {
     &self.options
   }
 
   /// Set window local options.
-  pub fn set_options(&mut self, options: &WindowLocalOptions) {
+  pub fn set_options(&mut self, options: &WindowOptions) {
     self.options = *options;
   }
 

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -15,7 +15,7 @@ use crate::ui::widget::window::{
 use crate::{
   geo_rect_as, inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher,
 };
-use indicator::{CommandLineIndicator, CommandLineIndicatorSymbol};
+use indicator::{Indicator, IndicatorSymbol};
 use input::Input;
 use message::Message;
 use root::CommandLineRootContainer;
@@ -34,7 +34,7 @@ pub mod indicator_tests;
 /// The value holder for each window widget.
 pub enum CommandLineNode {
   CommandLineRootContainer(CommandLineRootContainer),
-  CommandLineIndicator(CommandLineIndicator),
+  CommandLineIndicator(Indicator),
   CommandLineContent(Input),
   Cursor(Cursor),
   CommandLineMessage(Message),
@@ -94,10 +94,8 @@ impl CommandLine {
 
     let cmdline_indicator_shape =
       IRect::new(shape.min().into(), (shape.min().x + 1, shape.max().y));
-    let cmdline_indicator = CommandLineIndicator::new(
-      cmdline_indicator_shape,
-      CommandLineIndicatorSymbol::Empty,
-    );
+    let cmdline_indicator =
+      Indicator::new(cmdline_indicator_shape, IndicatorSymbol::Empty);
     let cmdline_indicator_id = cmdline_indicator.id();
     let mut cmdline_indicator_node =
       CommandLineNode::CommandLineIndicator(cmdline_indicator);
@@ -334,7 +332,7 @@ impl CommandLine {
   }
 
   /// Command-line indicator widget.
-  pub fn indicator(&self) -> &CommandLineIndicator {
+  pub fn indicator(&self) -> &Indicator {
     debug_assert!(self.base.node(self.indicator_id).is_some());
     debug_assert!(matches!(
       self.base.node(self.indicator_id).unwrap(),
@@ -351,7 +349,7 @@ impl CommandLine {
   }
 
   /// Mutable command-line indicator widget.
-  pub fn indicator_mut(&mut self) -> &mut CommandLineIndicator {
+  pub fn indicator_mut(&mut self) -> &mut Indicator {
     debug_assert!(self.base.node_mut(self.indicator_id).is_some());
     debug_assert!(matches!(
       self.base.node_mut(self.indicator_id).unwrap(),

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -203,33 +203,36 @@ impl CommandLine {
     self.message_viewport.clone()
   }
 
-  /// Set viewport for content.
-  pub fn set_content_viewport(&mut self, viewport: ViewportArc) {
+  /// Set viewport for input.
+  pub fn set_input_viewport(&mut self, viewport: ViewportArc) {
     self.input_viewport = viewport.clone();
-    if let Some(CommandLineNode::Input(content)) =
+    if let Some(CommandLineNode::Input(input)) =
       self.base.node_mut(self.input_id)
     {
-      content.set_viewport(Arc::downgrade(&viewport));
+      input.set_viewport(Arc::downgrade(&viewport));
     }
   }
 
   /// Set viewport for message.
   pub fn set_message_viewport(&mut self, viewport: ViewportArc) {
     self.message_viewport = viewport.clone();
-    if let Some(CommandLineNode::Message(content)) =
+    if let Some(CommandLineNode::Message(message)) =
       self.base.node_mut(self.message_id)
     {
-      content.set_viewport(Arc::downgrade(&viewport));
+      message.set_viewport(Arc::downgrade(&viewport));
     }
   }
 
-  /// Get cursor viewport.
-  pub fn cursor_viewport(&self) -> CursorViewportArc {
+  /// Get cursor viewport for input.
+  pub fn input_cursor_viewport(&self) -> CursorViewportArc {
     self.input_cursor_viewport.clone()
   }
 
-  /// Set cursor viewport.
-  pub fn set_cursor_viewport(&mut self, cursor_viewport: CursorViewportArc) {
+  /// Set cursor viewport for input.
+  pub fn set_input_cursor_viewport(
+    &mut self,
+    cursor_viewport: CursorViewportArc,
+  ) {
     self.input_cursor_viewport = cursor_viewport;
   }
 
@@ -248,8 +251,8 @@ impl CommandLine {
     self.indicator_id
   }
 
-  /// Command-line content widget ID.
-  pub fn content_id(&self) -> TreeNodeId {
+  /// Command-line input widget ID.
+  pub fn input_id(&self) -> TreeNodeId {
     self.input_id
   }
 

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -9,7 +9,7 @@ use crate::ui::viewport::{
 };
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::cursor::Cursor;
-use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
+use crate::ui::widget::window::opt::{WindowOptions, WindowOptionsBuilder};
 use crate::{
   geo_rect_as, inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher,
 };

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -8,17 +8,17 @@ use crate::ui::viewport::{
   CursorViewport, CursorViewportArc, Viewport, ViewportArc,
 };
 use crate::ui::widget::Widgetable;
-use crate::ui::widget::command_line::content::CommandLineContent;
-use crate::ui::widget::command_line::indicator::CommandLineIndicator;
-use crate::ui::widget::command_line::root::CommandLineRootContainer;
 use crate::ui::widget::cursor::Cursor;
-use crate::ui::widget::window::WindowLocalOptionsBuilder;
-use crate::ui::widget::window::opt::WindowLocalOptions;
+use crate::ui::widget::window::{
+  WindowLocalOptions, WindowLocalOptionsBuilder,
+};
 use crate::{
   geo_rect_as, inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher,
 };
-use indicator::CommandLineIndicatorSymbol;
+use content::CommandLineContent;
+use indicator::{CommandLineIndicator, CommandLineIndicatorSymbol};
 use message::CommandLineMessage;
+use root::CommandLineRootContainer;
 
 use std::sync::Arc;
 

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -98,29 +98,30 @@ impl CommandLine {
     indicator_node.set_visible(false);
     base.bounded_insert(root_id, indicator_node);
 
-    let cmdline_content_shape =
+    let input_shape =
       IRect::new((shape.min().x + 1, shape.min().y), shape.max().into());
 
     let (input_viewport, input_cursor_viewport, message_viewport) = {
-      let cmdline_content_actual_shape =
-        geo_rect_as!(cmdline_content_shape, u16);
+      let input_actual_shape = geo_rect_as!(input_shape, u16);
       let text_contents = text_contents.upgrade().unwrap();
       let text_contents = lock!(text_contents);
       let input_viewport = Viewport::view(
         &options,
-        text_contents.command_line_content(),
-        &cmdline_content_actual_shape,
+        text_contents.command_line_input(),
+        &input_actual_shape,
         0,
         0,
       );
       let input_cursor_viewport = CursorViewport::from_top_left(
         &input_viewport,
-        text_contents.command_line_content(),
+        text_contents.command_line_input(),
       );
+
+      let message_actual_shape = geo_rect_as!(shape, u16);
       let message_viewport = Viewport::view(
         &options,
         text_contents.command_line_message(),
-        &cmdline_content_actual_shape,
+        &message_actual_shape,
         0,
         0,
       );
@@ -131,7 +132,7 @@ impl CommandLine {
     let message_viewport = Viewport::to_arc(message_viewport);
 
     let cmdline_content = Input::new(
-      cmdline_content_shape,
+      input_shape,
       text_contents.clone(),
       Arc::downgrade(&input_viewport),
     );

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -17,7 +17,6 @@ use crate::ui::widget::window::opt::WindowLocalOptions;
 use crate::{
   geo_rect_as, inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher,
 };
-
 use indicator::CommandLineIndicatorSymbol;
 use message::CommandLineMessage;
 

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -15,15 +15,15 @@ use crate::ui::widget::window::{
 use crate::{
   geo_rect_as, inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher,
 };
-use content::CommandLineContent;
 use indicator::{CommandLineIndicator, CommandLineIndicatorSymbol};
+use input::Input;
 use message::CommandLineMessage;
 use root::CommandLineRootContainer;
 
 use std::sync::Arc;
 
-pub mod content;
 pub mod indicator;
+pub mod input;
 pub mod message;
 pub mod root;
 
@@ -35,7 +35,7 @@ pub mod indicator_tests;
 pub enum CommandLineNode {
   CommandLineRootContainer(CommandLineRootContainer),
   CommandLineIndicator(CommandLineIndicator),
-  CommandLineContent(CommandLineContent),
+  CommandLineContent(Input),
   Cursor(Cursor),
   CommandLineMessage(CommandLineMessage),
 }
@@ -136,7 +136,7 @@ impl CommandLine {
     let input_cursor_viewport = CursorViewport::to_arc(input_cursor_viewport);
     let message_viewport = Viewport::to_arc(message_viewport);
 
-    let cmdline_content = CommandLineContent::new(
+    let cmdline_content = Input::new(
       cmdline_content_shape,
       text_contents.clone(),
       Arc::downgrade(&input_viewport),
@@ -266,7 +266,7 @@ impl CommandLine {
 // Widgets {
 impl CommandLine {
   /// Command-line content widget.
-  pub fn content(&self) -> &CommandLineContent {
+  pub fn content(&self) -> &Input {
     debug_assert!(self.base.node(self.content_id).is_some());
     debug_assert!(matches!(
       self.base.node(self.content_id).unwrap(),
@@ -283,7 +283,7 @@ impl CommandLine {
   }
 
   /// Mutable command-line content widget.
-  pub fn content_mut(&mut self) -> &mut CommandLineContent {
+  pub fn content_mut(&mut self) -> &mut Input {
     debug_assert!(self.base.node_mut(self.content_id).is_some());
     debug_assert!(matches!(
       self.base.node_mut(self.content_id).unwrap(),

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use indicator::{CommandLineIndicator, CommandLineIndicatorSymbol};
 use input::Input;
-use message::CommandLineMessage;
+use message::Message;
 use root::CommandLineRootContainer;
 
 use std::sync::Arc;
@@ -37,7 +37,7 @@ pub enum CommandLineNode {
   CommandLineIndicator(CommandLineIndicator),
   CommandLineContent(Input),
   Cursor(Cursor),
-  CommandLineMessage(CommandLineMessage),
+  CommandLineMessage(Message),
 }
 
 inode_enum_dispatcher!(
@@ -147,7 +147,7 @@ impl CommandLine {
     cmdline_content_node.set_visible(false);
     base.bounded_insert(cmdline_root_id, cmdline_content_node);
 
-    let cmdline_message = CommandLineMessage::new(
+    let cmdline_message = Message::new(
       shape,
       text_contents.clone(),
       Arc::downgrade(&message_viewport),
@@ -300,7 +300,7 @@ impl CommandLine {
   }
 
   /// Command-line message widget
-  pub fn message(&self) -> &CommandLineMessage {
+  pub fn message(&self) -> &Message {
     debug_assert!(self.base.node(self.message_id).is_some());
     debug_assert!(matches!(
       self.base.node(self.message_id).unwrap(),
@@ -317,7 +317,7 @@ impl CommandLine {
   }
 
   /// Mutable command-line message widget.
-  pub fn message_mut(&mut self) -> &mut CommandLineMessage {
+  pub fn message_mut(&mut self) -> &mut Message {
     debug_assert!(self.base.node_mut(self.message_id).is_some());
     debug_assert!(matches!(
       self.base.node_mut(self.message_id).unwrap(),

--- a/rsvim_core/src/ui/widget/command_line/indicator.rs
+++ b/rsvim_core/src/ui/widget/command_line/indicator.rs
@@ -11,49 +11,49 @@ use geo::point;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 /// The symbol for command-line indicator, i.e. the ':', '/', '?' char.
-pub enum CommandLineIndicatorSymbol {
+pub enum IndicatorSymbol {
   Empty,
   Ex,
   SearchForward,
   SearchBackard,
 }
 
-impl std::fmt::Display for CommandLineIndicatorSymbol {
+impl std::fmt::Display for IndicatorSymbol {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match *self {
-      CommandLineIndicatorSymbol::Empty => write!(f, " "),
-      CommandLineIndicatorSymbol::Ex => write!(f, ":"),
-      CommandLineIndicatorSymbol::SearchForward => write!(f, "/"),
-      CommandLineIndicatorSymbol::SearchBackard => write!(f, "?"),
+      IndicatorSymbol::Empty => write!(f, " "),
+      IndicatorSymbol::Ex => write!(f, ":"),
+      IndicatorSymbol::SearchForward => write!(f, "/"),
+      IndicatorSymbol::SearchBackard => write!(f, "?"),
     }
   }
 }
 
 #[derive(Debug, Clone)]
 /// Command-line indicator, i.e. the first char ':', '/', '?' in the commandline.
-pub struct CommandLineIndicator {
+pub struct Indicator {
   base: InodeBase,
-  symbol: CommandLineIndicatorSymbol,
+  symbol: IndicatorSymbol,
 }
 
-impl CommandLineIndicator {
-  pub fn new(shape: IRect, symbol: CommandLineIndicatorSymbol) -> Self {
+impl Indicator {
+  pub fn new(shape: IRect, symbol: IndicatorSymbol) -> Self {
     let base = InodeBase::new(shape);
-    CommandLineIndicator { base, symbol }
+    Indicator { base, symbol }
   }
 
-  pub fn symbol(&self) -> CommandLineIndicatorSymbol {
+  pub fn symbol(&self) -> IndicatorSymbol {
     self.symbol
   }
 
-  pub fn set_symbol(&mut self, symbol: CommandLineIndicatorSymbol) {
+  pub fn set_symbol(&mut self, symbol: IndicatorSymbol) {
     self.symbol = symbol;
   }
 }
 
-inode_impl!(CommandLineIndicator, base);
+inode_impl!(Indicator, base);
 
-impl Widgetable for CommandLineIndicator {
+impl Widgetable for Indicator {
   fn draw(&self, canvas: &mut Canvas) {
     let actual_shape = self.actual_shape();
     let upos: U16Pos = actual_shape.min().into();

--- a/rsvim_core/src/ui/widget/command_line/indicator_tests.rs
+++ b/rsvim_core/src/ui/widget/command_line/indicator_tests.rs
@@ -28,7 +28,7 @@ mod tests_nowrap {
 
   fn make_canvas(
     terminal_size: U16Size,
-    cmdline_indicator: &CommandLineIndicator,
+    cmdline_indicator: &Indicator,
   ) -> Canvas {
     let mut canvas = Canvas::new(terminal_size);
     cmdline_indicator.draw(&mut canvas);
@@ -76,8 +76,7 @@ mod tests_nowrap {
 
     let expect = vec![":"];
 
-    let cmdline_indicator =
-      CommandLineIndicator::new(terminal_shape, CommandLineIndicatorSymbol::Ex);
+    let cmdline_indicator = Indicator::new(terminal_shape, IndicatorSymbol::Ex);
     let actual = make_canvas(terminal_size, &cmdline_indicator);
     assert_canvas(&actual, &expect);
   }

--- a/rsvim_core/src/ui/widget/command_line/indicator_tests.rs
+++ b/rsvim_core/src/ui/widget/command_line/indicator_tests.rs
@@ -12,9 +12,7 @@ use crate::ui::canvas::Canvas;
 use crate::ui::tree::Tree;
 use crate::ui::viewport::{Viewport, ViewportArc};
 use crate::ui::widget::Widgetable;
-use crate::ui::widget::window::{
-  WindowLocalOptions, WindowLocalOptionsBuilder,
-};
+use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::ToCompactString;
 use ropey::{Rope, RopeBuilder};

--- a/rsvim_core/src/ui/widget/command_line/indicator_tests.rs
+++ b/rsvim_core/src/ui/widget/command_line/indicator_tests.rs
@@ -3,7 +3,7 @@
 use super::indicator::*;
 
 use crate::buf::BufferArc;
-use crate::buf::opt::{BufferLocalOptions, BufferLocalOptionsBuilder};
+use crate::buf::opt::{BufferOptions, BufferOptionsBuilder};
 use crate::geo_size_as;
 use crate::prelude::*;
 use crate::tests::buf::{make_buffer_from_lines, make_empty_buffer};
@@ -12,7 +12,7 @@ use crate::ui::canvas::Canvas;
 use crate::ui::tree::Tree;
 use crate::ui::viewport::{Viewport, ViewportArc};
 use crate::ui::widget::Widgetable;
-use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
+use crate::ui::widget::window::opt::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::ToCompactString;
 use ropey::{Rope, RopeBuilder};

--- a/rsvim_core/src/ui/widget/command_line/input.rs
+++ b/rsvim_core/src/ui/widget/command_line/input.rs
@@ -1,4 +1,4 @@
-//! Commandline's text content widget.
+//! Commandline's input content widget.
 
 use crate::content::TextContentsWk;
 use crate::prelude::*;
@@ -9,7 +9,7 @@ use crate::ui::widget::Widgetable;
 use crate::{inode_impl, lock};
 
 #[derive(Debug, Clone)]
-/// Commandline text content.
+/// Commandline input content.
 pub struct Input {
   base: InodeBase,
   text_contents: TextContentsWk,
@@ -17,7 +17,6 @@ pub struct Input {
 }
 
 impl Input {
-  /// Make window content.
   pub fn new(
     shape: IRect,
     text_contents: TextContentsWk,

--- a/rsvim_core/src/ui/widget/command_line/input.rs
+++ b/rsvim_core/src/ui/widget/command_line/input.rs
@@ -44,6 +44,6 @@ impl Widgetable for Input {
     let contents = lock!(contents);
     let viewport = self.viewport.upgrade().unwrap();
 
-    viewport.draw(contents.command_line_content(), actual_shape, canvas);
+    viewport.draw(contents.command_line_input(), actual_shape, canvas);
   }
 }

--- a/rsvim_core/src/ui/widget/command_line/input.rs
+++ b/rsvim_core/src/ui/widget/command_line/input.rs
@@ -10,13 +10,13 @@ use crate::{inode_impl, lock};
 
 #[derive(Debug, Clone)]
 /// Commandline text content.
-pub struct CommandLineContent {
+pub struct Input {
   base: InodeBase,
   text_contents: TextContentsWk,
   viewport: ViewportWk,
 }
 
-impl CommandLineContent {
+impl Input {
   /// Make window content.
   pub fn new(
     shape: IRect,
@@ -24,7 +24,7 @@ impl CommandLineContent {
     viewport: ViewportWk,
   ) -> Self {
     let base = InodeBase::new(shape);
-    CommandLineContent {
+    Input {
       base,
       text_contents,
       viewport,
@@ -36,9 +36,9 @@ impl CommandLineContent {
   }
 }
 
-inode_impl!(CommandLineContent, base);
+inode_impl!(Input, base);
 
-impl Widgetable for CommandLineContent {
+impl Widgetable for Input {
   fn draw(&self, canvas: &mut Canvas) {
     let actual_shape = self.actual_shape();
     let contents = self.text_contents.upgrade().unwrap();

--- a/rsvim_core/src/ui/widget/command_line/message.rs
+++ b/rsvim_core/src/ui/widget/command_line/message.rs
@@ -21,13 +21,13 @@ impl Message {
   pub fn new(
     shape: IRect,
     text_contents: TextContentsWk,
-    message_viewport: ViewportWk,
+    viewport: ViewportWk,
   ) -> Self {
     let base = InodeBase::new(shape);
     Message {
       base,
       text_contents,
-      viewport: message_viewport,
+      viewport,
     }
   }
 

--- a/rsvim_core/src/ui/widget/command_line/message.rs
+++ b/rsvim_core/src/ui/widget/command_line/message.rs
@@ -1,4 +1,4 @@
-//! Commandline's text content widget.
+//! Commandline's message widget.
 
 use crate::content::TextContentsWk;
 use crate::prelude::*;
@@ -11,37 +11,36 @@ use compact_str::CompactString;
 
 #[derive(Debug, Clone)]
 /// Commandline message.
-pub struct CommandLineMessage {
+pub struct Message {
   base: InodeBase,
-  message_contents: TextContentsWk,
-  message_viewport: ViewportWk,
+  text_contents: TextContentsWk,
+  viewport: ViewportWk,
 }
 
-impl CommandLineMessage {
-  /// Make window content.
+impl Message {
   pub fn new(
     shape: IRect,
     text_contents: TextContentsWk,
     message_viewport: ViewportWk,
   ) -> Self {
     let base = InodeBase::new(shape);
-    CommandLineMessage {
+    Message {
       base,
-      message_contents: text_contents,
-      message_viewport,
+      text_contents,
+      viewport: message_viewport,
     }
   }
 
   pub fn set_viewport(&mut self, viewport: ViewportWk) {
-    self.message_viewport = viewport;
+    self.viewport = viewport;
   }
 
   pub fn get_text_contents(&self) -> &TextContentsWk {
-    &self.message_contents
+    &self.text_contents
   }
 
   pub fn get_text_contents_mut(&mut self) -> &mut TextContentsWk {
-    &mut self.message_contents
+    &mut self.text_contents
   }
 
   pub fn set_message(&mut self, text: CompactString) {
@@ -53,14 +52,14 @@ impl CommandLineMessage {
   }
 }
 
-inode_impl!(CommandLineMessage, base);
+inode_impl!(Message, base);
 
-impl Widgetable for CommandLineMessage {
+impl Widgetable for Message {
   fn draw(&self, canvas: &mut Canvas) {
     let actual_shape = self.actual_shape();
-    let contents = self.message_contents.upgrade().unwrap();
+    let contents = self.text_contents.upgrade().unwrap();
     let contents = lock!(contents);
-    let viewport = self.message_viewport.upgrade().unwrap();
+    let viewport = self.viewport.upgrade().unwrap();
 
     viewport.draw(contents.command_line_message(), actual_shape, canvas);
   }

--- a/rsvim_core/src/ui/widget/command_line/root.rs
+++ b/rsvim_core/src/ui/widget/command_line/root.rs
@@ -7,18 +7,18 @@ use crate::ui::widget::Widgetable;
 
 #[derive(Debug, Clone, Copy)]
 /// Commandline root container.
-pub struct CommandLineRootContainer {
+pub struct RootContainer {
   base: InodeBase,
 }
 
-impl CommandLineRootContainer {
+impl RootContainer {
   pub fn new(shape: IRect) -> Self {
-    CommandLineRootContainer {
+    RootContainer {
       base: InodeBase::new(shape),
     }
   }
 }
 
-inode_impl!(CommandLineRootContainer, base);
+inode_impl!(RootContainer, base);
 
-impl Widgetable for CommandLineRootContainer {}
+impl Widgetable for RootContainer {}

--- a/rsvim_core/src/ui/widget/window.rs
+++ b/rsvim_core/src/ui/widget/window.rs
@@ -9,9 +9,9 @@ use crate::ui::viewport::{
 };
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::cursor::Cursor;
-use crate::ui::widget::window::content::WindowContent;
-use crate::ui::widget::window::root::WindowRootContainer;
 use crate::{inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher};
+use content::WindowContent;
+use root::WindowRootContainer;
 
 // Re-export
 pub use opt::*;

--- a/rsvim_core/src/ui/widget/window.rs
+++ b/rsvim_core/src/ui/widget/window.rs
@@ -53,18 +53,18 @@ pub struct Window {
 
 impl Window {
   pub fn new(opts: &WindowOptions, shape: IRect, buffer: BufferWk) -> Self {
-    let window_root = RootContainer::new(shape);
-    let window_root_id = window_root.id();
-    let window_root_node = WindowNode::RootContainer(window_root);
-    let window_root_actual_shape = window_root.actual_shape();
+    let root = RootContainer::new(shape);
+    let root_id = root.id();
+    let root_node = WindowNode::RootContainer(root);
+    let root_actual_shape = root.actual_shape();
 
-    let mut base = Itree::new(window_root_node);
+    let mut base = Itree::new(root_node);
 
     let (viewport, cursor_viewport) = {
       let buffer = buffer.upgrade().unwrap();
       let buffer = lock!(buffer);
       let viewport =
-        Viewport::view(opts, buffer.text(), window_root_actual_shape, 0, 0);
+        Viewport::view(opts, buffer.text(), root_actual_shape, 0, 0);
       let cursor_viewport =
         CursorViewport::from_top_left(&viewport, buffer.text());
       (viewport, cursor_viewport)
@@ -72,17 +72,17 @@ impl Window {
     let viewport = Viewport::to_arc(viewport);
     let cursor_viewport = CursorViewport::to_arc(cursor_viewport);
 
-    let window_content =
+    let content =
       Content::new(shape, buffer.clone(), Arc::downgrade(&viewport));
-    let window_content_id = window_content.id();
-    let window_content_node = WindowNode::Content(window_content);
+    let content_id = content.id();
+    let content_node = WindowNode::Content(content);
 
-    base.bounded_insert(window_root_id, window_content_node);
+    base.bounded_insert(root_id, content_node);
 
     Window {
       base,
       options: *opts,
-      content_id: window_content_id,
+      content_id,
       cursor_id: None,
       buffer,
       viewport,

--- a/rsvim_core/src/ui/widget/window.rs
+++ b/rsvim_core/src/ui/widget/window.rs
@@ -11,10 +11,8 @@ use crate::ui::widget::Widgetable;
 use crate::ui::widget::cursor::Cursor;
 use crate::{inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher};
 use content::WindowContent;
+use opt::*;
 use root::WindowRootContainer;
-
-// Re-export
-pub use opt::*;
 
 use std::sync::Arc;
 

--- a/rsvim_core/src/ui/widget/window.rs
+++ b/rsvim_core/src/ui/widget/window.rs
@@ -10,9 +10,9 @@ use crate::ui::viewport::{
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::cursor::Cursor;
 use crate::{inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher};
-use content::WindowContent;
+use content::Content;
 use opt::*;
-use root::WindowRootContainer;
+use root::RootContainer;
 
 use std::sync::Arc;
 
@@ -28,13 +28,13 @@ mod opt_tests;
 #[derive(Debug, Clone)]
 /// The value holder for each window widget.
 pub enum WindowNode {
-  WindowRootContainer(WindowRootContainer),
-  WindowContent(WindowContent),
+  RootContainer(RootContainer),
+  Content(Content),
   Cursor(Cursor),
 }
 
-inode_enum_dispatcher!(WindowNode, WindowRootContainer, WindowContent, Cursor);
-widget_enum_dispatcher!(WindowNode, WindowRootContainer, WindowContent, Cursor);
+inode_enum_dispatcher!(WindowNode, RootContainer, Content, Cursor);
+widget_enum_dispatcher!(WindowNode, RootContainer, Content, Cursor);
 
 #[derive(Debug, Clone)]
 /// The Vim window, it manages all descendant widget nodes, i.e. all widgets in the
@@ -53,9 +53,9 @@ pub struct Window {
 
 impl Window {
   pub fn new(opts: &WindowOptions, shape: IRect, buffer: BufferWk) -> Self {
-    let window_root = WindowRootContainer::new(shape);
+    let window_root = RootContainer::new(shape);
     let window_root_id = window_root.id();
-    let window_root_node = WindowNode::WindowRootContainer(window_root);
+    let window_root_node = WindowNode::RootContainer(window_root);
     let window_root_actual_shape = window_root.actual_shape();
 
     let mut base = Itree::new(window_root_node);
@@ -73,9 +73,9 @@ impl Window {
     let cursor_viewport = CursorViewport::to_arc(cursor_viewport);
 
     let window_content =
-      WindowContent::new(shape, buffer.clone(), Arc::downgrade(&viewport));
+      Content::new(shape, buffer.clone(), Arc::downgrade(&viewport));
     let window_content_id = window_content.id();
-    let window_content_node = WindowNode::WindowContent(window_content);
+    let window_content_node = WindowNode::Content(window_content);
 
     base.bounded_insert(window_root_id, window_content_node);
 
@@ -122,7 +122,7 @@ impl Window {
   /// Set viewport.
   pub fn set_viewport(&mut self, viewport: ViewportArc) {
     self.viewport = viewport.clone();
-    if let Some(WindowNode::WindowContent(content)) =
+    if let Some(WindowNode::Content(content)) =
       self.base.node_mut(self.content_id)
     {
       content.set_viewport(Arc::downgrade(&viewport));
@@ -158,14 +158,14 @@ impl Window {
 // Viewport {
 impl Window {
   /// Window content widget.
-  pub fn content(&self) -> &WindowContent {
+  pub fn content(&self) -> &Content {
     debug_assert!(self.base.node(self.content_id).is_some());
     debug_assert!(matches!(
       self.base.node(self.content_id).unwrap(),
-      WindowNode::WindowContent(_)
+      WindowNode::Content(_)
     ));
     match self.base.node(self.content_id).unwrap() {
-      WindowNode::WindowContent(w) => {
+      WindowNode::Content(w) => {
         debug_assert_eq!(w.id(), self.content_id);
         w
       }
@@ -174,14 +174,14 @@ impl Window {
   }
 
   /// Mutable window content widget.
-  pub fn content_mut(&mut self) -> &mut WindowContent {
+  pub fn content_mut(&mut self) -> &mut Content {
     debug_assert!(self.base.node_mut(self.content_id).is_some());
     debug_assert!(matches!(
       self.base.node_mut(self.content_id).unwrap(),
-      WindowNode::WindowContent(_)
+      WindowNode::Content(_)
     ));
     match self.base.node_mut(self.content_id).unwrap() {
-      WindowNode::WindowContent(w) => {
+      WindowNode::Content(w) => {
         debug_assert_eq!(w.id(), self.content_id);
         w
       }

--- a/rsvim_core/src/ui/widget/window.rs
+++ b/rsvim_core/src/ui/widget/window.rs
@@ -43,7 +43,7 @@ widget_enum_dispatcher!(WindowNode, WindowRootContainer, WindowContent, Cursor);
 /// [`crate::ui::widget::window`] module.
 pub struct Window {
   base: Itree<WindowNode>,
-  options: WindowLocalOptions,
+  options: WindowOptions,
 
   content_id: TreeNodeId,
   cursor_id: Option<TreeNodeId>,
@@ -54,11 +54,7 @@ pub struct Window {
 }
 
 impl Window {
-  pub fn new(
-    opts: &WindowLocalOptions,
-    shape: IRect,
-    buffer: BufferWk,
-  ) -> Self {
+  pub fn new(opts: &WindowOptions, shape: IRect, buffer: BufferWk) -> Self {
     let window_root = WindowRootContainer::new(shape);
     let window_root_id = window_root.id();
     let window_root_node = WindowNode::WindowRootContainer(window_root);
@@ -111,12 +107,12 @@ impl Widgetable for Window {
 // Attributes
 impl Window {
   /// Get window local options.
-  pub fn options(&self) -> &WindowLocalOptions {
+  pub fn options(&self) -> &WindowOptions {
     &self.options
   }
 
   /// Set window local options.
-  pub fn set_options(&mut self, options: &WindowLocalOptions) {
+  pub fn set_options(&mut self, options: &WindowOptions) {
     self.options = *options;
   }
 

--- a/rsvim_core/src/ui/widget/window/content.rs
+++ b/rsvim_core/src/ui/widget/window/content.rs
@@ -10,7 +10,7 @@ use crate::ui::widget::Widgetable;
 
 #[derive(Debug, Clone)]
 /// The widget contains text contents for Vim window.
-pub struct WindowContent {
+pub struct Content {
   base: InodeBase,
 
   // Buffer.
@@ -20,11 +20,11 @@ pub struct WindowContent {
   viewport: ViewportWk,
 }
 
-impl WindowContent {
+impl Content {
   /// Make window content.
   pub fn new(shape: IRect, buffer: BufferWk, viewport: ViewportWk) -> Self {
     let base = InodeBase::new(shape);
-    WindowContent {
+    Content {
       base,
       buffer,
       viewport,
@@ -36,9 +36,9 @@ impl WindowContent {
   }
 }
 
-inode_impl!(WindowContent, base);
+inode_impl!(Content, base);
 
-impl Widgetable for WindowContent {
+impl Widgetable for Content {
   fn draw(&self, canvas: &mut Canvas) {
     let actual_shape = self.actual_shape();
     let buffer = self.buffer.upgrade().unwrap();

--- a/rsvim_core/src/ui/widget/window/content_tests.rs
+++ b/rsvim_core/src/ui/widget/window/content_tests.rs
@@ -14,9 +14,7 @@ use crate::ui::canvas::Canvas;
 use crate::ui::tree::Tree;
 use crate::ui::viewport::{Viewport, ViewportArc};
 use crate::ui::widget::Widgetable;
-use crate::ui::widget::window::{
-  WindowLocalOptions, WindowLocalOptionsBuilder,
-};
+use crate::ui::widget::window::{WindowOptions, WindowOptionsBuilder};
 
 use compact_str::ToCompactString;
 use ropey::{Rope, RopeBuilder};
@@ -26,7 +24,7 @@ use std::sync::Arc;
 
 pub fn make_viewport(
   terminal_size: U16Size,
-  window_options: WindowLocalOptions,
+  window_options: WindowOptions,
   buffer: BufferArc,
   start_line_idx: usize,
   start_column_idx: usize,
@@ -45,7 +43,7 @@ pub fn make_viewport(
 
 pub fn make_canvas(
   terminal_size: U16Size,
-  window_options: WindowLocalOptions,
+  window_options: WindowOptions,
   buffer: BufferArc,
   viewport: ViewportArc,
 ) -> Canvas {
@@ -104,10 +102,7 @@ mod tests_nowrap {
 
     let terminal_size = U16Size::new(10, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -146,10 +141,7 @@ mod tests_nowrap {
 
     let terminal_size = U16Size::new(35, 6);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -185,10 +177,7 @@ mod tests_nowrap {
 
     let terminal_size = U16Size::new(33, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -228,10 +217,7 @@ mod tests_nowrap {
 
     let terminal_size = U16Size::new(31, 20);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -281,10 +267,7 @@ mod tests_nowrap {
 
     let terminal_size = U16Size::new(31, 20);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_empty_buffer(terminal_size, buf_opts);
     let expect = vec![
@@ -321,10 +304,7 @@ mod tests_nowrap {
 
     let terminal_size = U16Size::new(13, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -363,10 +343,7 @@ mod tests_nowrap {
 
     let terminal_size = U16Size::new(21, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -432,10 +409,7 @@ mod tests_nowrap_eol {
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -468,10 +442,7 @@ mod tests_nowrap_eol {
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -504,10 +475,7 @@ mod tests_nowrap_eol {
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -546,10 +514,7 @@ mod tests_nowrap_eol {
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -590,10 +555,7 @@ mod tests_nowrap_startcol {
 
     let terminal_size = U16Size::new(10, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -632,10 +594,7 @@ mod tests_nowrap_startcol {
 
     let terminal_size = U16Size::new(35, 6);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -672,10 +631,7 @@ mod tests_nowrap_startcol {
 
     let terminal_size = U16Size::new(33, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -716,10 +672,7 @@ mod tests_nowrap_startcol {
 
     let terminal_size = U16Size::new(31, 20);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -769,10 +722,7 @@ mod tests_nowrap_startcol {
 
     let terminal_size = U16Size::new(21, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(false)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -835,10 +785,7 @@ mod tests_wrap_nolinebreak {
 
     let terminal_size = U16Size::new(10, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -877,10 +824,7 @@ mod tests_wrap_nolinebreak {
 
     let terminal_size = U16Size::new(27, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -913,10 +857,7 @@ mod tests_wrap_nolinebreak {
 
     let terminal_size = U16Size::new(20, 9);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_empty_buffer(terminal_size, buf_opts);
     let expect = vec![
@@ -942,10 +883,7 @@ mod tests_wrap_nolinebreak {
 
     let terminal_size = U16Size::new(19, 30);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -1004,10 +942,7 @@ mod tests_wrap_nolinebreak {
 
     let terminal_size = U16Size::new(19, 27);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -1063,7 +998,7 @@ mod tests_wrap_nolinebreak {
 
     let terminal_size = U16Size::new(19, 15);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -1133,7 +1068,7 @@ mod tests_wrap_nolinebreak {
 
     let terminal_size = U16Size::new(19, 15);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -1181,7 +1116,7 @@ mod tests_wrap_nolinebreak {
 
     let terminal_size = U16Size::new(19, 15);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -1237,10 +1172,7 @@ mod tests_wrap_nolinebreak_eol {
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -1282,10 +1214,7 @@ mod tests_wrap_nolinebreak_eol {
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -1329,10 +1258,7 @@ mod tests_wrap_nolinebreak_startcol {
 
     let terminal_size = U16Size::new(10, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -1372,10 +1298,7 @@ mod tests_wrap_nolinebreak_startcol {
 
     let terminal_size = U16Size::new(27, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -1409,10 +1332,7 @@ mod tests_wrap_nolinebreak_startcol {
 
     let terminal_size = U16Size::new(20, 9);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_empty_buffer(terminal_size, buf_opts);
     let expect = vec![
@@ -1438,10 +1358,7 @@ mod tests_wrap_nolinebreak_startcol {
 
     let terminal_size = U16Size::new(19, 30);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
-      .wrap(true)
-      .build()
-      .unwrap();
+    let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
       terminal_size,
@@ -1500,7 +1417,7 @@ mod tests_wrap_nolinebreak_startcol {
 
     let terminal_size = U16Size::new(19, 15);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -1570,7 +1487,7 @@ mod tests_wrap_nolinebreak_startcol {
 
     let terminal_size = U16Size::new(19, 15);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -1619,7 +1536,7 @@ mod tests_wrap_nolinebreak_startcol {
 
     let terminal_size = U16Size::new(19, 15);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
       .build()
@@ -1672,7 +1589,7 @@ mod tests_wrap_linebreak {
 
     let terminal_size = U16Size::new(10, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -1715,7 +1632,7 @@ mod tests_wrap_linebreak {
 
     let terminal_size = U16Size::new(27, 15);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -1763,7 +1680,7 @@ mod tests_wrap_linebreak {
 
     let terminal_size = U16Size::new(20, 8);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -1792,7 +1709,7 @@ mod tests_wrap_linebreak {
 
     let terminal_size = U16Size::new(13, 31);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -1856,7 +1773,7 @@ mod tests_wrap_linebreak {
 
     let terminal_size = U16Size::new(10, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -1899,7 +1816,7 @@ mod tests_wrap_linebreak {
 
     let terminal_size = U16Size::new(10, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -1965,7 +1882,7 @@ mod tests_wrap_linebreak_startcol {
 
     let terminal_size = U16Size::new(10, 10);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -2008,7 +1925,7 @@ mod tests_wrap_linebreak_startcol {
 
     let terminal_size = U16Size::new(27, 15);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -2057,7 +1974,7 @@ mod tests_wrap_linebreak_startcol {
 
     let terminal_size = U16Size::new(20, 8);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()
@@ -2086,7 +2003,7 @@ mod tests_wrap_linebreak_startcol {
 
     let terminal_size = U16Size::new(13, 31);
     let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
-    let win_opts = WindowLocalOptionsBuilder::default()
+    let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
       .build()

--- a/rsvim_core/src/ui/widget/window/content_tests.rs
+++ b/rsvim_core/src/ui/widget/window/content_tests.rs
@@ -3,9 +3,7 @@
 use super::content::*;
 
 use crate::buf::BufferArc;
-use crate::buf::opt::{
-  BufferLocalOptions, BufferLocalOptionsBuilder, FileFormatOption,
-};
+use crate::buf::opt::{BufferOptions, BufferOptionsBuilder, FileFormatOption};
 use crate::geo_size_into_rect;
 use crate::prelude::*;
 use crate::tests::buf::{make_buffer_from_lines, make_empty_buffer};
@@ -101,7 +99,7 @@ mod tests_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -140,7 +138,7 @@ mod tests_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(35, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -176,7 +174,7 @@ mod tests_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(33, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -216,7 +214,7 @@ mod tests_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 20);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -266,7 +264,7 @@ mod tests_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 20);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_empty_buffer(terminal_size, buf_opts);
@@ -303,7 +301,7 @@ mod tests_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -342,7 +340,7 @@ mod tests_nowrap {
     test_log_init();
 
     let terminal_size = U16Size::new(21, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -405,7 +403,7 @@ mod tests_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -438,7 +436,7 @@ mod tests_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 5);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -471,7 +469,7 @@ mod tests_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(35, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -510,7 +508,7 @@ mod tests_nowrap_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(35, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -554,7 +552,7 @@ mod tests_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -593,7 +591,7 @@ mod tests_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(35, 6);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -630,7 +628,7 @@ mod tests_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(33, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -671,7 +669,7 @@ mod tests_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(31, 20);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -721,7 +719,7 @@ mod tests_nowrap_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(21, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(false).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -784,7 +782,7 @@ mod tests_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -823,7 +821,7 @@ mod tests_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(27, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -856,7 +854,7 @@ mod tests_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(20, 9);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_empty_buffer(terminal_size, buf_opts);
@@ -882,7 +880,7 @@ mod tests_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(19, 30);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -941,7 +939,7 @@ mod tests_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(19, 27);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -997,7 +995,7 @@ mod tests_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(19, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
@@ -1067,7 +1065,7 @@ mod tests_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(19, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
@@ -1115,7 +1113,7 @@ mod tests_wrap_nolinebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(19, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
@@ -1168,7 +1166,7 @@ mod tests_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Dos)
       .build()
       .unwrap();
@@ -1210,7 +1208,7 @@ mod tests_wrap_nolinebreak_eol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default()
+    let buf_opts = BufferOptionsBuilder::default()
       .file_format(FileFormatOption::Mac)
       .build()
       .unwrap();
@@ -1257,7 +1255,7 @@ mod tests_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -1297,7 +1295,7 @@ mod tests_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(27, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -1331,7 +1329,7 @@ mod tests_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(20, 9);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_empty_buffer(terminal_size, buf_opts);
@@ -1357,7 +1355,7 @@ mod tests_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(19, 30);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default().wrap(true).build().unwrap();
 
     let buffer = make_buffer_from_lines(
@@ -1416,7 +1414,7 @@ mod tests_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(19, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
@@ -1486,7 +1484,7 @@ mod tests_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(19, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
@@ -1535,7 +1533,7 @@ mod tests_wrap_nolinebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(19, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(false)
@@ -1588,7 +1586,7 @@ mod tests_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
@@ -1631,7 +1629,7 @@ mod tests_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(27, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
@@ -1679,7 +1677,7 @@ mod tests_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(20, 8);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
@@ -1708,7 +1706,7 @@ mod tests_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 31);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
@@ -1772,7 +1770,7 @@ mod tests_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
@@ -1815,7 +1813,7 @@ mod tests_wrap_linebreak {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
@@ -1881,7 +1879,7 @@ mod tests_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(10, 10);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
@@ -1924,7 +1922,7 @@ mod tests_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(27, 15);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
@@ -1973,7 +1971,7 @@ mod tests_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(20, 8);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)
@@ -2002,7 +2000,7 @@ mod tests_wrap_linebreak_startcol {
     test_log_init();
 
     let terminal_size = U16Size::new(13, 31);
-    let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+    let buf_opts = BufferOptionsBuilder::default().build().unwrap();
     let win_opts = WindowOptionsBuilder::default()
       .wrap(true)
       .line_break(true)

--- a/rsvim_core/src/ui/widget/window/content_tests.rs
+++ b/rsvim_core/src/ui/widget/window/content_tests.rs
@@ -54,11 +54,8 @@ pub fn make_canvas(
       terminal_size.height() as isize,
     ),
   );
-  let window_content = WindowContent::new(
-    shape,
-    Arc::downgrade(&buffer),
-    Arc::downgrade(&viewport),
-  );
+  let window_content =
+    Content::new(shape, Arc::downgrade(&buffer), Arc::downgrade(&viewport));
   let mut canvas = Canvas::new(terminal_size);
   window_content.draw(&mut canvas);
   canvas

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -1,4 +1,4 @@
-//! Window local options.
+//! Window options.
 
 use crate::defaults;
 
@@ -6,7 +6,7 @@ use derive_builder::Builder;
 
 #[derive(Debug, Copy, Clone, Builder)]
 /// Window local options.
-pub struct WindowLocalOptions {
+pub struct WindowOptions {
   #[builder(default = defaults::win::WRAP)]
   wrap: bool,
 
@@ -17,7 +17,7 @@ pub struct WindowLocalOptions {
   scroll_off: u16,
 }
 
-impl WindowLocalOptions {
+impl WindowOptions {
   /// The 'wrap' option, also known as 'line-wrap', default to `true`.
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27wrap%27>.

--- a/rsvim_core/src/ui/widget/window/opt_tests.rs
+++ b/rsvim_core/src/ui/widget/window/opt_tests.rs
@@ -4,7 +4,7 @@ use crate::defaults;
 
 #[test]
 pub fn options1() {
-  let opt1 = WindowLocalOptionsBuilder::default()
+  let opt1 = WindowOptionsBuilder::default()
     .wrap(true)
     .line_break(true)
     .scroll_off(3)
@@ -14,7 +14,7 @@ pub fn options1() {
   assert!(opt1.line_break());
   assert_eq!(opt1.scroll_off(), 3);
 
-  let opt2 = WindowLocalOptionsBuilder::default().build().unwrap();
+  let opt2 = WindowOptionsBuilder::default().build().unwrap();
   assert_eq!(opt2.wrap(), defaults::win::WRAP);
   assert_eq!(opt2.line_break(), defaults::win::LINE_BREAK);
   assert_eq!(opt2.scroll_off(), defaults::win::SCROLL_OFF);

--- a/rsvim_core/src/ui/widget/window/root.rs
+++ b/rsvim_core/src/ui/widget/window/root.rs
@@ -7,18 +7,18 @@ use crate::ui::widget::Widgetable;
 
 #[derive(Debug, Clone, Copy)]
 /// Window root container.
-pub struct WindowRootContainer {
+pub struct RootContainer {
   base: InodeBase,
 }
 
-impl WindowRootContainer {
+impl RootContainer {
   pub fn new(shape: IRect) -> Self {
-    WindowRootContainer {
+    RootContainer {
       base: InodeBase::new(shape),
     }
   }
 }
 
-inode_impl!(WindowRootContainer, base);
+inode_impl!(RootContainer, base);
 
-impl Widgetable for WindowRootContainer {}
+impl Widgetable for RootContainer {}

--- a/rsvim_core/src/ui/widget/window_tests.rs
+++ b/rsvim_core/src/ui/widget/window_tests.rs
@@ -10,6 +10,7 @@ use crate::tests::log::init as test_log_init;
 use crate::ui::canvas::Canvas;
 use crate::ui::tree::Tree;
 use crate::ui::widget::Widgetable;
+use crate::ui::widget::window::opt::*;
 
 use compact_str::ToCompactString;
 use ropey::{Rope, RopeBuilder};

--- a/rsvim_core/src/ui/widget/window_tests.rs
+++ b/rsvim_core/src/ui/widget/window_tests.rs
@@ -22,7 +22,7 @@ use std::sync::Once;
 fn make_window_from_size(
   terminal_size: U16Size,
   buffer: BufferArc,
-  window_options: &WindowLocalOptions,
+  window_options: &WindowOptions,
 ) -> Window {
   let mut tree = Tree::new(terminal_size);
   tree.set_global_local_options(window_options);
@@ -98,10 +98,8 @@ fn draw_after_init1() {
     "          ",
   ];
 
-  let window_local_options = WindowLocalOptionsBuilder::default()
-    .wrap(false)
-    .build()
-    .unwrap();
+  let window_local_options =
+    WindowOptionsBuilder::default().wrap(false).build().unwrap();
   let window =
     make_window_from_size(terminal_size, buf.clone(), &window_local_options);
   let mut actual = Canvas::new(terminal_size);

--- a/rsvim_core/src/ui/widget/window_tests.rs
+++ b/rsvim_core/src/ui/widget/window_tests.rs
@@ -2,7 +2,7 @@
 
 use super::window::*;
 
-use crate::buf::opt::{BufferLocalOptions, BufferLocalOptionsBuilder};
+use crate::buf::opt::{BufferOptions, BufferOptionsBuilder};
 use crate::buf::{Buffer, BufferArc};
 use crate::prelude::*;
 use crate::tests::buf::{make_buffer_from_lines, make_empty_buffer};
@@ -71,7 +71,7 @@ fn draw_after_init1() {
   test_log_init();
 
   let terminal_size = U16Size::new(10, 10);
-  let buf_opts = BufferLocalOptionsBuilder::default().build().unwrap();
+  let buf_opts = BufferOptionsBuilder::default().build().unwrap();
   let buf = make_buffer_from_lines(
     terminal_size,
     buf_opts,


### PR DESCRIPTION
In `widget::{window, commandline}`, the structure/variable names are just too long 