### PR TITLE
refactor(viewport): create new "EditableWidgetable" trait to drop duplicated matchings

### DIFF
--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -285,8 +285,6 @@ impl NormalStateful {
     data_access: &StatefulDataAccess,
     op: Operation,
   ) {
-    use crate::ui::viewport::ViewportEditable;
-
     let tree = data_access.tree.clone();
     let mut tree = lock!(tree);
 
@@ -302,13 +300,8 @@ impl NormalStateful {
     let (target_cursor_char, target_cursor_line, _search_direction) =
       self._target_cursor_exclude_eol(&cursor_viewport, buffer.text(), op);
 
-    let vnode: &mut dyn ViewportEditable =
-      match tree.node_mut(current_window_id).unwrap() {
-        TreeNode::Window(window) => window,
-        TreeNode::CommandLine(cmdline) => cmdline,
-        _ => unreachable!(),
-      };
-
+    let vnode =
+      cursor_ops::viewport_editable_tree_node_mut(&mut tree, current_window_id);
     let new_cursor_viewport = cursor_ops::raw_cursor_viewport_move_to(
       vnode,
       &viewport,
@@ -328,8 +321,6 @@ impl NormalStateful {
     data_access: &StatefulDataAccess,
     op: Operation,
   ) {
-    use crate::ui::viewport::ViewportEditable;
-
     let tree = data_access.tree.clone();
     let mut tree = lock!(tree);
     let (buffer, viewport, current_window_id) = {
@@ -346,13 +337,8 @@ impl NormalStateful {
       viewport.start_line_idx(),
     );
 
-    let vnode: &mut dyn ViewportEditable =
-      match tree.node_mut(current_window_id).unwrap() {
-        TreeNode::Window(window) => window,
-        TreeNode::CommandLine(cmdline) => cmdline,
-        _ => unreachable!(),
-      };
-
+    let vnode =
+      cursor_ops::viewport_editable_tree_node_mut(&mut tree, current_window_id);
     cursor_ops::raw_viewport_scroll_to(
       vnode,
       &viewport,

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -301,7 +301,7 @@ impl NormalStateful {
       self._target_cursor_exclude_eol(&cursor_viewport, buffer.text(), op);
 
     let vnode =
-      cursor_ops::viewport_editable_tree_node_mut(&mut tree, current_window_id);
+      cursor_ops::editable_widget_tree_node_mut(&mut tree, current_window_id);
     let new_cursor_viewport = cursor_ops::raw_cursor_viewport_move_to(
       vnode,
       &viewport,
@@ -338,7 +338,7 @@ impl NormalStateful {
     );
 
     let vnode =
-      cursor_ops::viewport_editable_tree_node_mut(&mut tree, current_window_id);
+      cursor_ops::editable_widget_tree_node_mut(&mut tree, current_window_id);
     cursor_ops::raw_viewport_scroll_to(
       vnode,
       &viewport,

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -322,26 +322,26 @@ impl NormalStateful {
   ) {
     let tree = data_access.tree.clone();
     let mut tree = lock!(tree);
-    let current_window = tree.current_window_mut().unwrap();
-    let buffer = current_window.buffer().upgrade().unwrap();
+    let (buffer, viewport, current_window_id) = {
+      let current_window = tree.current_window_mut().unwrap();
+      let buffer = current_window.buffer().upgrade().unwrap();
+      let viewport = current_window.viewport();
+      (buffer, viewport, current_window.id())
+    };
     let buffer = lock!(buffer);
-    let viewport = current_window.viewport();
 
     let (start_column, start_line) = cursor_ops::normalize_to_window_scroll_to(
       op,
       viewport.start_column_idx(),
       viewport.start_line_idx(),
     );
-    let maybe_new_viewport_arc = cursor_ops::raw_viewport_scroll_to(
+    cursor_ops::raw_viewport_scroll_to(
+      &mut tree,
+      current_window_id,
       &viewport,
-      current_window.actual_shape(),
-      current_window.options(),
       buffer.text(),
       Operation::WindowScrollTo((start_column, start_line)),
     );
-    if let Some(new_viewport_arc) = maybe_new_viewport_arc.clone() {
-      current_window.set_viewport(new_viewport_arc.clone());
-    }
   }
 
   pub fn editor_quit(

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -285,6 +285,8 @@ impl NormalStateful {
     data_access: &StatefulDataAccess,
     op: Operation,
   ) {
+    use crate::ui::viewport::ViewportEditable;
+
     let tree = data_access.tree.clone();
     let mut tree = lock!(tree);
 
@@ -300,9 +302,15 @@ impl NormalStateful {
     let (target_cursor_char, target_cursor_line, _search_direction) =
       self._target_cursor_exclude_eol(&cursor_viewport, buffer.text(), op);
 
+    let vnode: &mut dyn ViewportEditable =
+      match tree.node_mut(current_window_id).unwrap() {
+        TreeNode::Window(window) => window,
+        TreeNode::CommandLine(cmdline) => cmdline,
+        _ => unreachable!(),
+      };
+
     let new_cursor_viewport = cursor_ops::raw_cursor_viewport_move_to(
-      &mut tree,
-      current_window_id,
+      vnode,
       &viewport,
       buffer.text(),
       Operation::CursorMoveTo((target_cursor_char, target_cursor_line)),

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -301,7 +301,7 @@ impl NormalStateful {
       self._target_cursor_exclude_eol(&cursor_viewport, buffer.text(), op);
 
     let vnode =
-      cursor_ops::editable_widget_tree_node_mut(&mut tree, current_window_id);
+      cursor_ops::editable_tree_node_mut(&mut tree, current_window_id);
     let new_cursor_viewport = cursor_ops::raw_cursor_viewport_move_to(
       vnode,
       &viewport,
@@ -338,7 +338,7 @@ impl NormalStateful {
     );
 
     let vnode =
-      cursor_ops::editable_widget_tree_node_mut(&mut tree, current_window_id);
+      cursor_ops::editable_tree_node_mut(&mut tree, current_window_id);
     cursor_ops::raw_viewport_scroll_to(
       vnode,
       &viewport,

--- a/rsvim_core/src/state/fsm/normal.rs
+++ b/rsvim_core/src/state/fsm/normal.rs
@@ -328,6 +328,8 @@ impl NormalStateful {
     data_access: &StatefulDataAccess,
     op: Operation,
   ) {
+    use crate::ui::viewport::ViewportEditable;
+
     let tree = data_access.tree.clone();
     let mut tree = lock!(tree);
     let (buffer, viewport, current_window_id) = {
@@ -343,9 +345,16 @@ impl NormalStateful {
       viewport.start_column_idx(),
       viewport.start_line_idx(),
     );
+
+    let vnode: &mut dyn ViewportEditable =
+      match tree.node_mut(current_window_id).unwrap() {
+        TreeNode::Window(window) => window,
+        TreeNode::CommandLine(cmdline) => cmdline,
+        _ => unreachable!(),
+      };
+
     cursor_ops::raw_viewport_scroll_to(
-      &mut tree,
-      current_window_id,
+      vnode,
       &viewport,
       buffer.text(),
       Operation::WindowScrollTo((start_column, start_line)),

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -226,10 +226,22 @@ pub fn normalize_to_window_scroll_to(
   }
 }
 
+pub fn viewport_editable_tree_node_mut(
+  tree: &mut Tree,
+  id: TreeNodeId,
+) -> &mut dyn ViewportEditable {
+  debug_assert!(tree.node_mut(id).is_some());
+  match tree.node_mut(id).unwrap() {
+    TreeNode::Window(window) => window,
+    TreeNode::CommandLine(cmdline) => cmdline,
+    _ => unreachable!(),
+  }
+}
+
 // NOTE: This API can be used on "window" and "cmdline-input" widgets, but not
 // on "cmdline-message", since the formers have cursor inside and can be
 // editing, while the ladder doesn't.
-pub fn _update_viewport(
+fn _update_viewport(
   vnode: &mut dyn ViewportEditable,
   text: &Text,
   start_line: usize,
@@ -251,7 +263,7 @@ pub fn _update_viewport(
 // NOTE: This API can be used on "window" and "cmdline-input" widgets, but not
 // on "cmdline-message", since the formers have cursor inside and can be
 // editing, while the ladder doesn't.
-pub fn _update_cursor_viewport(
+fn _update_cursor_viewport(
   vnode: &mut dyn ViewportEditable,
   viewport: &Viewport,
   text: &Text,
@@ -416,12 +428,7 @@ fn _update_viewport_after_text_changed(
   id: TreeNodeId,
   text: &Text,
 ) {
-  debug_assert!(tree.node_mut(id).is_some());
-  let vnode: &mut dyn ViewportEditable = match tree.node_mut(id).unwrap() {
-    TreeNode::Window(window) => window,
-    TreeNode::CommandLine(cmdline) => cmdline,
-    _ => unreachable!(),
-  };
+  let vnode = viewport_editable_tree_node_mut(tree, id);
 
   let viewport = vnode.editable_viewport();
   let cursor_viewport = vnode.editable_cursor_viewport();
@@ -474,14 +481,7 @@ pub fn cursor_move(
   op: Operation,
   include_eol: bool,
 ) {
-  debug_assert!(tree.node_mut(id).is_some());
-
-  let vnode: &mut dyn ViewportEditable = match tree.node_mut(id).unwrap() {
-    TreeNode::Window(window) => window,
-    TreeNode::CommandLine(cmdline) => cmdline,
-    _ => unreachable!(),
-  };
-
+  let vnode = viewport_editable_tree_node_mut(tree, id);
   let viewport = vnode.editable_viewport();
   let cursor_viewport = vnode.editable_cursor_viewport();
 

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -1,7 +1,6 @@
 //! Cursor operations.
 
 use crate::buf::text::Text;
-use crate::coord::U16Rect;
 use crate::prelude::*;
 use crate::state::ops::Operation;
 use crate::ui::tree::*;
@@ -9,7 +8,6 @@ use crate::ui::viewport::{
   CursorViewport, CursorViewportArc, Viewport, ViewportArc,
   ViewportSearchDirection,
 };
-use crate::ui::widget::window::opt::WindowOptions;
 
 use compact_str::CompactString;
 

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -5,9 +5,10 @@ use crate::prelude::*;
 use crate::state::ops::Operation;
 use crate::ui::tree::*;
 use crate::ui::viewport::{
-  CursorViewport, CursorViewportArc, Viewport, ViewportArc, ViewportEditable,
+  CursorViewport, CursorViewportArc, Viewport, ViewportArc,
   ViewportSearchDirection,
 };
+use crate::ui::widget::EditableWidgetable;
 
 use compact_str::CompactString;
 
@@ -229,7 +230,7 @@ pub fn normalize_to_window_scroll_to(
 pub fn viewport_editable_tree_node_mut(
   tree: &mut Tree,
   id: TreeNodeId,
-) -> &mut dyn ViewportEditable {
+) -> &mut dyn EditableWidgetable {
   debug_assert!(tree.node_mut(id).is_some());
   match tree.node_mut(id).unwrap() {
     TreeNode::Window(window) => window,
@@ -242,7 +243,7 @@ pub fn viewport_editable_tree_node_mut(
 // on "cmdline-message", since the formers have cursor inside and can be
 // editing, while the ladder doesn't.
 fn _update_viewport(
-  vnode: &mut dyn ViewportEditable,
+  vnode: &mut dyn EditableWidgetable,
   text: &Text,
   start_line: usize,
   start_column: usize,
@@ -264,7 +265,7 @@ fn _update_viewport(
 // on "cmdline-message", since the formers have cursor inside and can be
 // editing, while the ladder doesn't.
 fn _update_cursor_viewport(
-  vnode: &mut dyn ViewportEditable,
+  vnode: &mut dyn EditableWidgetable,
   viewport: &Viewport,
   text: &Text,
   cursor_line: usize,
@@ -295,7 +296,7 @@ fn _update_cursor_viewport(
 ///
 /// It panics if the operation is not a `Operation::CursorMove*` operation.
 pub fn raw_cursor_viewport_move_to(
-  vnode: &mut dyn ViewportEditable,
+  vnode: &mut dyn EditableWidgetable,
   viewport: &Viewport,
   text: &Text,
   cursor_move_to_op: Operation,
@@ -348,7 +349,7 @@ pub fn raw_cursor_viewport_move_to(
 ///
 /// It panics if the operation is not a `Operation::WindowScroll*` operation.
 pub fn raw_viewport_scroll_to(
-  vnode: &mut dyn ViewportEditable,
+  vnode: &mut dyn EditableWidgetable,
   viewport: &Viewport,
   text: &Text,
   window_scroll_to_op: Operation,

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -227,7 +227,7 @@ pub fn normalize_to_window_scroll_to(
   }
 }
 
-pub fn editable_widget_tree_node_mut(
+pub fn editable_tree_node_mut(
   tree: &mut Tree,
   id: TreeNodeId,
 ) -> &mut dyn EditableWidgetable {
@@ -429,7 +429,7 @@ fn _update_viewport_after_text_changed(
   id: TreeNodeId,
   text: &Text,
 ) {
-  let vnode = editable_widget_tree_node_mut(tree, id);
+  let vnode = editable_tree_node_mut(tree, id);
 
   let viewport = vnode.editable_viewport();
   let cursor_viewport = vnode.editable_cursor_viewport();
@@ -482,7 +482,7 @@ pub fn cursor_move(
   op: Operation,
   include_eol: bool,
 ) {
-  let vnode = editable_widget_tree_node_mut(tree, id);
+  let vnode = editable_tree_node_mut(tree, id);
   let viewport = vnode.editable_viewport();
   let cursor_viewport = vnode.editable_cursor_viewport();
 

--- a/rsvim_core/src/state/ops/cursor_ops.rs
+++ b/rsvim_core/src/state/ops/cursor_ops.rs
@@ -227,7 +227,7 @@ pub fn normalize_to_window_scroll_to(
   }
 }
 
-pub fn viewport_editable_tree_node_mut(
+pub fn editable_widget_tree_node_mut(
   tree: &mut Tree,
   id: TreeNodeId,
 ) -> &mut dyn EditableWidgetable {
@@ -429,7 +429,7 @@ fn _update_viewport_after_text_changed(
   id: TreeNodeId,
   text: &Text,
 ) {
-  let vnode = viewport_editable_tree_node_mut(tree, id);
+  let vnode = editable_widget_tree_node_mut(tree, id);
 
   let viewport = vnode.editable_viewport();
   let cursor_viewport = vnode.editable_cursor_viewport();
@@ -482,7 +482,7 @@ pub fn cursor_move(
   op: Operation,
   include_eol: bool,
 ) {
-  let vnode = viewport_editable_tree_node_mut(tree, id);
+  let vnode = editable_widget_tree_node_mut(tree, id);
   let viewport = vnode.editable_viewport();
   let cursor_viewport = vnode.editable_cursor_viewport();
 

--- a/rsvim_core/src/ui/viewport.rs
+++ b/rsvim_core/src/ui/viewport.rs
@@ -720,3 +720,22 @@ impl Viewport {
     draw::draw(self, text, actual_shape, canvas);
   }
 }
+
+pub trait ViewportEditable {
+  /// Get editable viewport.
+  fn editable_viewport(&self) -> ViewportArc;
+
+  /// Set editable viewport.
+  fn set_editable_viewport(&mut self, viewport: ViewportArc);
+
+  /// Get editable cursor viewport.
+  fn editable_cursor_viewport(&self) -> CursorViewportArc;
+
+  /// Set editable cursor viewport.
+  fn set_editable_cursor_viewport(
+    &mut self,
+    cursor_viewport: CursorViewportArc,
+  );
+
+  fn editable_options(&self) -> &WindowOptions;
+}

--- a/rsvim_core/src/ui/viewport.rs
+++ b/rsvim_core/src/ui/viewport.rs
@@ -3,7 +3,6 @@
 use crate::buf::text::Text;
 use crate::prelude::*;
 use crate::ui::canvas::Canvas;
-use crate::ui::tree::TreeNodeId;
 use crate::ui::widget::window::opt::WindowOptions;
 
 use litemap::LiteMap;
@@ -720,25 +719,4 @@ impl Viewport {
   pub fn draw(&self, text: &Text, actual_shape: &U16Rect, canvas: &mut Canvas) {
     draw::draw(self, text, actual_shape, canvas);
   }
-}
-
-pub trait ViewportEditable {
-  fn editable_viewport(&self) -> ViewportArc;
-
-  fn set_editable_viewport(&mut self, viewport: ViewportArc);
-
-  fn editable_cursor_viewport(&self) -> CursorViewportArc;
-
-  fn set_editable_cursor_viewport(
-    &mut self,
-    cursor_viewport: CursorViewportArc,
-  );
-
-  fn editable_options(&self) -> &WindowOptions;
-
-  fn editable_actual_shape(&self) -> &U16Rect;
-
-  fn move_editable_cursor_to(&mut self, x: isize, y: isize) -> Option<IRect>;
-
-  fn editable_cursor_id(&self) -> Option<TreeNodeId>;
 }

--- a/rsvim_core/src/ui/viewport.rs
+++ b/rsvim_core/src/ui/viewport.rs
@@ -3,6 +3,7 @@
 use crate::buf::text::Text;
 use crate::prelude::*;
 use crate::ui::canvas::Canvas;
+use crate::ui::tree::TreeNodeId;
 use crate::ui::widget::window::opt::WindowOptions;
 
 use litemap::LiteMap;
@@ -722,20 +723,22 @@ impl Viewport {
 }
 
 pub trait ViewportEditable {
-  /// Get editable viewport.
   fn editable_viewport(&self) -> ViewportArc;
 
-  /// Set editable viewport.
   fn set_editable_viewport(&mut self, viewport: ViewportArc);
 
-  /// Get editable cursor viewport.
   fn editable_cursor_viewport(&self) -> CursorViewportArc;
 
-  /// Set editable cursor viewport.
   fn set_editable_cursor_viewport(
     &mut self,
     cursor_viewport: CursorViewportArc,
   );
 
   fn editable_options(&self) -> &WindowOptions;
+
+  fn editable_actual_shape(&self) -> &U16Rect;
+
+  fn move_editable_cursor_to(&mut self, x: isize, y: isize) -> Option<IRect>;
+
+  fn editable_cursor_id(&self) -> Option<TreeNodeId>;
 }

--- a/rsvim_core/src/ui/widget.rs
+++ b/rsvim_core/src/ui/widget.rs
@@ -1,6 +1,10 @@
 //! Basic atom of all UI components.
 
+use crate::prelude::*;
 use crate::ui::canvas::Canvas;
+use crate::ui::tree::TreeNodeId;
+use crate::ui::viewport::{CursorViewportArc, ViewportArc};
+use crate::ui::widget::window::opt::WindowOptions;
 
 pub mod command_line;
 pub mod cursor;
@@ -33,4 +37,25 @@ macro_rules! widget_enum_dispatcher {
       }
     }
   }
+}
+
+pub trait EditableWidgetable {
+  fn editable_viewport(&self) -> ViewportArc;
+
+  fn set_editable_viewport(&mut self, viewport: ViewportArc);
+
+  fn editable_cursor_viewport(&self) -> CursorViewportArc;
+
+  fn set_editable_cursor_viewport(
+    &mut self,
+    cursor_viewport: CursorViewportArc,
+  );
+
+  fn editable_options(&self) -> &WindowOptions;
+
+  fn editable_actual_shape(&self) -> &U16Rect;
+
+  fn move_editable_cursor_to(&mut self, x: isize, y: isize) -> Option<IRect>;
+
+  fn editable_cursor_id(&self) -> Option<TreeNodeId>;
 }

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::ui::canvas::Canvas;
 use crate::ui::tree::*;
 use crate::ui::viewport::{
-  CursorViewport, CursorViewportArc, Viewport, ViewportArc,
+  CursorViewport, CursorViewportArc, Viewport, ViewportArc, ViewportEditable,
 };
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::cursor::Cursor;
@@ -190,6 +190,29 @@ impl CommandLine {
     self.options = *options;
   }
 
+  /// Cursor widget ID.
+  pub fn cursor_id(&self) -> Option<TreeNodeId> {
+    self.cursor_id
+  }
+
+  /// Command-line indicator widget ID.
+  pub fn indicator_id(&self) -> TreeNodeId {
+    self.indicator_id
+  }
+
+  /// Command-line input widget ID.
+  pub fn input_id(&self) -> TreeNodeId {
+    self.input_id
+  }
+
+  /// Command-line message widget ID.
+  pub fn message_id(&self) -> TreeNodeId {
+    self.message_id
+  }
+}
+
+// Viewport {
+impl CommandLine {
   /// Get input viewport.
   pub fn input_viewport(&self) -> ViewportArc {
     self.input_viewport.clone()
@@ -232,27 +255,35 @@ impl CommandLine {
   ) {
     self.input_cursor_viewport = cursor_viewport;
   }
+}
+// Viewport }
 
-  /// Cursor widget ID.
-  pub fn cursor_id(&self) -> Option<TreeNodeId> {
-    self.cursor_id
+// Editable Viewport {
+impl ViewportEditable for CommandLine {
+  fn editable_viewport(&self) -> ViewportArc {
+    self.input_viewport()
   }
 
-  /// Command-line indicator widget ID.
-  pub fn indicator_id(&self) -> TreeNodeId {
-    self.indicator_id
+  fn set_editable_viewport(&mut self, viewport: ViewportArc) {
+    self.set_input_viewport(viewport);
   }
 
-  /// Command-line input widget ID.
-  pub fn input_id(&self) -> TreeNodeId {
-    self.input_id
+  fn editable_cursor_viewport(&self) -> CursorViewportArc {
+    self.input_cursor_viewport()
   }
 
-  /// Command-line message widget ID.
-  pub fn message_id(&self) -> TreeNodeId {
-    self.message_id
+  fn set_editable_cursor_viewport(
+    &mut self,
+    cursor_viewport: CursorViewportArc,
+  ) {
+    self.set_input_cursor_viewport(cursor_viewport);
+  }
+
+  fn editable_options(&self) -> &WindowOptions {
+    self.options()
   }
 }
+// Editable Viewport }
 
 // Show/Hide switch {
 impl CommandLine {

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -5,11 +5,11 @@ use crate::prelude::*;
 use crate::ui::canvas::Canvas;
 use crate::ui::tree::*;
 use crate::ui::viewport::{
-  CursorViewport, CursorViewportArc, Viewport, ViewportArc, ViewportEditable,
+  CursorViewport, CursorViewportArc, Viewport, ViewportArc,
 };
-use crate::ui::widget::Widgetable;
 use crate::ui::widget::cursor::Cursor;
 use crate::ui::widget::window::opt::{WindowOptions, WindowOptionsBuilder};
+use crate::ui::widget::{EditableWidgetable, Widgetable};
 use crate::{
   geo_rect_as, inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher,
 };
@@ -259,7 +259,7 @@ impl CommandLine {
 // Viewport }
 
 // Editable Viewport {
-impl ViewportEditable for CommandLine {
+impl EditableWidgetable for CommandLine {
   fn editable_viewport(&self) -> ViewportArc {
     self.input_viewport()
   }

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -282,6 +282,18 @@ impl ViewportEditable for CommandLine {
   fn editable_options(&self) -> &WindowOptions {
     self.options()
   }
+
+  fn editable_actual_shape(&self) -> &U16Rect {
+    self.input().actual_shape()
+  }
+
+  fn move_editable_cursor_to(&mut self, x: isize, y: isize) -> Option<IRect> {
+    self.move_cursor_to(x, y)
+  }
+
+  fn editable_cursor_id(&self) -> Option<TreeNodeId> {
+    self.cursor_id()
+  }
 }
 // Editable Viewport }
 

--- a/rsvim_core/src/ui/widget/window.rs
+++ b/rsvim_core/src/ui/widget/window.rs
@@ -183,6 +183,18 @@ impl ViewportEditable for Window {
   fn editable_options(&self) -> &WindowOptions {
     self.options()
   }
+
+  fn editable_actual_shape(&self) -> &U16Rect {
+    self.content().actual_shape()
+  }
+
+  fn move_editable_cursor_to(&mut self, x: isize, y: isize) -> Option<IRect> {
+    self.move_cursor_to(x, y)
+  }
+
+  fn editable_cursor_id(&self) -> Option<TreeNodeId> {
+    self.cursor_id()
+  }
 }
 // Editable Viewport }
 

--- a/rsvim_core/src/ui/widget/window.rs
+++ b/rsvim_core/src/ui/widget/window.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::ui::canvas::Canvas;
 use crate::ui::tree::*;
 use crate::ui::viewport::{
-  CursorViewport, CursorViewportArc, Viewport, ViewportArc,
+  CursorViewport, CursorViewportArc, Viewport, ViewportArc, ViewportEditable,
 };
 use crate::ui::widget::Widgetable;
 use crate::ui::widget::cursor::Cursor;
@@ -158,6 +158,33 @@ impl Window {
   }
 }
 // Viewport }
+
+// Editable Viewport {
+impl ViewportEditable for Window {
+  fn editable_viewport(&self) -> ViewportArc {
+    self.viewport()
+  }
+
+  fn set_editable_viewport(&mut self, viewport: ViewportArc) {
+    self.set_viewport(viewport);
+  }
+
+  fn editable_cursor_viewport(&self) -> CursorViewportArc {
+    self.cursor_viewport()
+  }
+
+  fn set_editable_cursor_viewport(
+    &mut self,
+    cursor_viewport: CursorViewportArc,
+  ) {
+    self.set_cursor_viewport(cursor_viewport);
+  }
+
+  fn editable_options(&self) -> &WindowOptions {
+    self.options()
+  }
+}
+// Editable Viewport }
 
 // Sub-Widgets {
 impl Window {

--- a/rsvim_core/src/ui/widget/window.rs
+++ b/rsvim_core/src/ui/widget/window.rs
@@ -5,10 +5,10 @@ use crate::prelude::*;
 use crate::ui::canvas::Canvas;
 use crate::ui::tree::*;
 use crate::ui::viewport::{
-  CursorViewport, CursorViewportArc, Viewport, ViewportArc, ViewportEditable,
+  CursorViewport, CursorViewportArc, Viewport, ViewportArc,
 };
-use crate::ui::widget::Widgetable;
 use crate::ui::widget::cursor::Cursor;
+use crate::ui::widget::{EditableWidgetable, Widgetable};
 use crate::{inode_enum_dispatcher, inode_itree_impl, widget_enum_dispatcher};
 use content::Content;
 use opt::*;
@@ -160,7 +160,7 @@ impl Window {
 // Viewport }
 
 // Editable Viewport {
-impl ViewportEditable for Window {
+impl EditableWidgetable for Window {
   fn editable_viewport(&self) -> ViewportArc {
     self.viewport()
   }


### PR DESCRIPTION
This PR refactors the viewport calculation by:
1. Create new "EditableWidgetable" trait, which contains all the necessary methods for an editable widget (i.e. Window and Command-line Input)
2. Wrap "Window" and "Command-line Input" widgets with this new trait
3. Drop duplicated code logic in `cursor_ops` module, replace them with new `&mut dyn EditableWidgetable` type.