### PR TITLE
fix(canvas): avoid cursor twinkling while flushing canvas shaders for windows terminal

### DIFF
--- a/rsvim_core/src/ui/canvas.rs
+++ b/rsvim_core/src/ui/canvas.rs
@@ -111,7 +111,7 @@ impl Canvas {
     // cursor twinkling/jumping while refreshing the TUI screen.
     // So here let's hide cursor before flushing shaders, and restore the
     // cursor after flushing is done.
-    if cfg!(target_os = "windows") && !self.cursor().hidden() {
+    if !self.cursor().hidden() {
       shader.push(ShaderCommand::CursorHide(crossterm::cursor::Hide));
     }
 
@@ -121,7 +121,7 @@ impl Canvas {
       saved_cursor_pos.y(),
     )));
 
-    if cfg!(target_os = "windows") && !self.cursor().hidden() {
+    if !self.cursor().hidden() {
       shader.push(ShaderCommand::CursorShow(crossterm::cursor::Show));
     }
 


### PR DESCRIPTION
For windows terminal, current shaders are flushing without hiding the cursor, this causes the cursor twinkling/jumping on the TUI screen (I can see it with my eyes, but here I didn't provide any screen recordings). This PR will first hide the cursors, then flush the shaders, finally restore (show) the cursor back.
This issue seems never happens on mac/linux, but still I apply the logic to all OS (just simplify the code logic).