### PR TITLE
perf(js): avoid duplicate loop tick when waiting for dynamic import loaders

### DIFF
--- a/rsvim_core/src/js.rs
+++ b/rsvim_core/src/js.rs
@@ -604,7 +604,7 @@ pub mod boost {
       );
       if self.has_promise_rejections()
         || self.isolate.has_pending_background_tasks()
-        || (self.has_pending_imports() && !self.has_pending_import_loaders())
+        || (self.pending_imports_count() > self.pending_import_loaders_count())
       {
         msg::sync_send_to_master(
           self.get_state().borrow().master_tx.clone(),

--- a/rsvim_core/src/js/hook.rs
+++ b/rsvim_core/src/js/hook.rs
@@ -265,7 +265,7 @@ pub fn host_import_module_dynamically_cb<'s>(
       state.pending_futures.insert(0, Box::new(fut));
     }
   };
-  pending::create_loader(&mut state, &specifier, Box::new(loader_cb));
+  pending::create_import_loader(&mut state, &specifier, Box::new(loader_cb));
 
   Some(promise)
 }

--- a/rsvim_core/src/js/loader/fs_loader.rs
+++ b/rsvim_core/src/js/loader/fs_loader.rs
@@ -92,9 +92,14 @@ mod sync_resolve {
       for pkg in PACKAGE_FILES {
         let pkg_path = path.join(pkg);
         if pkg_path.is_file() {
-          match std::fs::read_to_string(pkg_path) {
-            Ok(pkg_src) => {
-              match serde_json::from_str::<serde_json::Value>(&pkg_src) {
+          match std::fs::File::open(pkg_path) {
+            Ok(pkg_fp) => {
+              let pkg_reader = std::io::BufReader::new(pkg_fp);
+              match serde_json::from_reader::<
+                std::io::BufReader<std::fs::File>,
+                serde_json::Value,
+              >(pkg_reader)
+              {
                 Ok(pkg_json) => {
                   for field in ["exports", "main"] {
                     match pkg_json.get(field) {

--- a/rsvim_core/src/js/module/es_module.rs
+++ b/rsvim_core/src/js/module/es_module.rs
@@ -306,7 +306,11 @@ impl JsFuture for EsModuleFuture {
             state.pending_futures.insert(0, Box::new(fut));
           }
         };
-        pending::create_loader(&mut state, &specifier, Box::new(loader_cb));
+        pending::create_import_loader(
+          &mut state,
+          &specifier,
+          Box::new(loader_cb),
+        );
 
         state.module_map.seen.insert(specifier.clone(), status);
         trace!(

--- a/rsvim_core/src/js/pending.rs
+++ b/rsvim_core/src/js/pending.rs
@@ -37,13 +37,13 @@ pub fn remove_timer(
   state.pending_timers.remove(&timer_id).map(|_| timer_id)
 }
 
-pub fn create_loader(
+pub fn create_import_loader(
   state: &mut JsRuntimeState,
   specifier: &str,
   cb: TaskCallback,
 ) -> JsTaskId {
   let task_id = next_task_id();
-  state.pending_imports.insert(task_id, cb);
+  state.pending_import_loaders.insert(task_id, cb);
   msg::sync_send_to_master(
     state.master_tx.clone(),
     MasterMessage::LoadImportReq(msg::LoadImportReq {


### PR DESCRIPTION
This PR is a follow up of #631 , it avoids some duplicated event loop ticks in dynamic import stage. In previous implementation, it always requires another tick if "module_map.pending" is not empty. In this PR, it only requires tick when "module_map.pending.len() > pending_imports.len()". Because the "async loader" is handled by tokio runtime, and it actually doesn't need an event loop tick to run.

BTW, #651 is also a follow up of #631 , it rewrites the "JsFuture" and messages between tokio runtime and js runtime event loop, to make the code base cleaner.