### PR TITLE
refactor(cmd): refactor `Rsvim.cmd.list` and add `Rsvim.cmd.get`

### DIFF
--- a/rsvim_core/src/js/binding.rs
+++ b/rsvim_core/src/js/binding.rs
@@ -102,6 +102,7 @@ pub fn create_new_context<'s, 'b>(
     set_function_to(scope, vim, "cmd_create", global_rsvim::cmd::create);
     set_function_to(scope, vim, "cmd_echo", global_rsvim::cmd::echo);
     set_function_to(scope, vim, "cmd_list", global_rsvim::cmd::list);
+    set_function_to(scope, vim, "cmd_get", global_rsvim::cmd::get);
     set_function_to(scope, vim, "cmd_remove", global_rsvim::cmd::remove);
   }
 

--- a/rsvim_core/src/js/binding/global_rsvim/cmd.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd.rs
@@ -85,7 +85,7 @@ pub fn list(
   let commands = to_v8::<Vec<CommandDefinition>>(
     scope,
     commands
-      .values()
+      .keys()
       .map(|def| Rc::unwrap_or_clone(def.clone()))
       .collect(),
   );

--- a/rsvim_core/src/js/binding/global_rsvim/cmd.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd.rs
@@ -82,13 +82,8 @@ pub fn list(
   let state = state_rc.borrow_mut();
   let commands = lock!(state.commands);
 
-  let commands = to_v8::<Vec<CommandDefinition>>(
-    scope,
-    commands
-      .keys()
-      .map(|def| Rc::unwrap_or_clone(def.clone()))
-      .collect(),
-  );
+  let commands =
+    to_v8::<Vec<CompactString>>(scope, commands.keys().cloned().collect());
 
   rv.set(commands);
 }

--- a/rsvim_core/src/js/binding/global_rsvim/cmd.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd.rs
@@ -89,14 +89,14 @@ pub fn list(
 }
 
 /// `Rsvim.cmd.get` API.
-pub fn get(
-  scope: &mut v8::PinScope,
-  args: v8::FunctionCallbackArguments,
+pub fn get<'s>(
+  scope: &mut v8::PinScope<'s, '_>,
+  args: v8::FunctionCallbackArguments<'s>,
   mut rv: v8::ReturnValue,
 ) {
   debug_assert!(args.length() == 1);
   let name = from_v8::<CompactString>(scope, args.get(0));
-  trace!("Rsvim.cmd.get");
+  trace!("Rsvim.cmd.get:{:?}", name);
 
   let state_rc = JsRuntime::state(scope);
   let state = state_rc.borrow_mut();

--- a/rsvim_core/src/js/binding/global_rsvim/cmd.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd.rs
@@ -88,6 +88,27 @@ pub fn list(
   rv.set(commands);
 }
 
+/// `Rsvim.cmd.get` API.
+pub fn get(
+  scope: &mut v8::PinScope,
+  args: v8::FunctionCallbackArguments,
+  mut rv: v8::ReturnValue,
+) {
+  debug_assert!(args.length() == 1);
+  let name = from_v8::<CompactString>(scope, args.get(0));
+  trace!("Rsvim.cmd.get");
+
+  let state_rc = JsRuntime::state(scope);
+  let state = state_rc.borrow_mut();
+
+  let commands = lock!(state.commands);
+
+  let commands =
+    to_v8::<Vec<CompactString>>(scope, commands.keys().cloned().collect());
+
+  rv.set(commands);
+}
+
 /// `Rsvim.cmd.remove` API.
 pub fn remove<'s>(
   scope: &mut v8::PinScope<'s, '_>,

--- a/rsvim_core/src/js/binding/global_rsvim/cmd.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd.rs
@@ -100,13 +100,14 @@ pub fn get<'s>(
 
   let state_rc = JsRuntime::state(scope);
   let state = state_rc.borrow_mut();
-
   let commands = lock!(state.commands);
-
-  let commands =
-    to_v8::<Vec<CompactString>>(scope, commands.keys().cloned().collect());
-
-  rv.set(commands);
+  match commands.get(&name) {
+    Some(def) => {
+      let def = to_v8(scope, Rc::unwrap_or_clone(def));
+      rv.set(def);
+    }
+    None => rv.set_undefined(),
+  }
 }
 
 /// `Rsvim.cmd.remove` API.

--- a/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
@@ -562,12 +562,8 @@ async fn test_list1() -> IoResult<()> {
 
   let src: &str = r#"
 Rsvim.cmd.create("write", () => {});
-Rsvim.cmd.list().forEach((cmd_def) => {
-  Rsvim.cmd.echo(`name:${cmd_def.name}`);
-  Rsvim.cmd.echo(`attributes.bang:${cmd_def.attributes.bang}`);
-  Rsvim.cmd.echo(`attributes.nargs:${cmd_def.attributes.nargs}`);
-  Rsvim.cmd.echo(`options.force:${cmd_def.options.force}`);
-  Rsvim.cmd.echo(`options.alias:${cmd_def.options.alias}`);
+Rsvim.cmd.list().forEach((name) => {
+  Rsvim.cmd.echo(`name:${name}`);
 });
     "#;
 
@@ -589,13 +585,7 @@ Rsvim.cmd.list().forEach((cmd_def) => {
     let n = contents.command_line_message_history().occupied_len();
     assert_eq!(n, 5);
 
-    let expects = [
-      "name:write",
-      "attributes.bang:false",
-      "attributes.nargs:0",
-      "options.alias:undefined",
-      "options.force:true",
-    ];
+    let expects = ["name:write"];
 
     for i in 0..n {
       let actual = contents.command_line_message_history_mut().try_pop();

--- a/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
@@ -583,7 +583,7 @@ Rsvim.cmd.list().forEach((name) => {
   {
     let mut contents = lock!(event_loop.contents);
     let n = contents.command_line_message_history().occupied_len();
-    assert_eq!(n, 5);
+    assert_eq!(n, 1);
 
     let expects = ["name:write"];
 

--- a/rsvim_core/src/js/binding/global_this/timeout_tests.rs
+++ b/rsvim_core/src/js/binding/global_this/timeout_tests.rs
@@ -418,9 +418,11 @@ async fn test_interval3() -> IoResult<()> {
   {
     let mut contents = lock!(event_loop.contents);
     let n = contents.command_line_message_history().occupied_len();
+    info!("n:{}", n);
     assert!(n >= 2);
     for i in 0..n {
       let actual = contents.command_line_message_history_mut().try_pop();
+      info!("actual-{}:{:?}", i, actual);
       assert!(actual.is_some());
       let actual = actual.unwrap();
       if i < n - 1 {

--- a/rsvim_core/src/js/binding/global_this/timeout_tests.rs
+++ b/rsvim_core/src/js/binding/global_this/timeout_tests.rs
@@ -334,7 +334,7 @@ async fn test_interval2() -> IoResult<()> {
   let terminal_cols = 10_u16;
   let terminal_rows = 10_u16;
 
-  let mocked_events = vec![MockEvent::SleepFor(Duration::from_millis(20))];
+  let mocked_events = vec![MockEvent::SleepFor(Duration::from_millis(50))];
   let src: &str = r#"
   var n = 0;
   const timerId = setInterval(() => {
@@ -364,9 +364,11 @@ async fn test_interval2() -> IoResult<()> {
   {
     let mut contents = lock!(event_loop.contents);
     let n = contents.command_line_message_history().occupied_len();
+    info!("n:{}", n);
     assert!(n >= 2);
     for i in 0..n {
       let actual = contents.command_line_message_history_mut().try_pop();
+      info!("actual-{}:{:?}", i, actual);
       assert!(actual.is_some());
       let actual = actual.unwrap();
       if i < n - 1 {
@@ -388,7 +390,7 @@ async fn test_interval3() -> IoResult<()> {
   let terminal_cols = 10_u16;
   let terminal_rows = 10_u16;
 
-  let mocked_events = vec![MockEvent::SleepFor(Duration::from_millis(20))];
+  let mocked_events = vec![MockEvent::SleepFor(Duration::from_millis(50))];
   let src: &str = r#"
   var n = 0;
   const timerId = setInterval(() => {

--- a/rsvim_core/src/js/runtime/01__rsvim.d.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.d.ts
@@ -12,7 +12,8 @@ export interface RsvimBuf {
 export interface RsvimCmd {
     create(name: string, callback: RsvimCmd.CommandCallback, attributes?: RsvimCmd.CommandAttributes, options?: RsvimCmd.CommandOptions): RsvimCmd.CommandDefinition | undefined;
     echo(message: any): void;
-    list(): RsvimCmd.CommandDefinition[];
+    list(): string[];
+    get(name: string): RsvimCmd.CommandDefinition | undefined;
     remove(name: string): RsvimCmd.CommandDefinition | undefined;
 }
 export declare namespace RsvimCmd {

--- a/rsvim_core/src/js/runtime/01__rsvim.js
+++ b/rsvim_core/src/js/runtime/01__rsvim.js
@@ -109,7 +109,8 @@ class RsvimCmdImpl {
         return __InternalRsvimGlobalObject.cmd_list();
     }
     get(name) {
-        return __InternalRsvimGlobalObject.cmd_get();
+        checkIsString(name, `"Rsvim.cmd.get" name`);
+        return __InternalRsvimGlobalObject.cmd_get(name);
     }
     remove(name) {
         checkIsString(name, `"Rsvim.cmd.remove" name`);

--- a/rsvim_core/src/js/runtime/01__rsvim.js
+++ b/rsvim_core/src/js/runtime/01__rsvim.js
@@ -108,6 +108,9 @@ class RsvimCmdImpl {
     list() {
         return __InternalRsvimGlobalObject.cmd_list();
     }
+    get(name) {
+        return __InternalRsvimGlobalObject.cmd_get();
+    }
     remove(name) {
         checkIsString(name, `"Rsvim.cmd.remove" name`);
         return __InternalRsvimGlobalObject.cmd_remove(name);

--- a/rsvim_core/src/js/runtime/01__rsvim.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.ts
@@ -306,7 +306,7 @@ export interface RsvimCmd {
    * The builtin `js` command cannot be get.
    * :::
    *
-   * @returns {RsvimCmd.CommandDefinition | undefined} Returns command definition by its name, except the `js` command.
+   * @returns {(RsvimCmd.CommandDefinition | undefined)} Returns command definition by its name, except the `js` command.
    *
    * @example
    * ```javascript
@@ -324,7 +324,7 @@ export interface RsvimCmd {
    * :::
    *
    * @param {string} name - The command name to be removed.
-   * @returns {RsvimCmd.CommandDefinition | undefined} Returns the removed {@link RsvimCmd.CommandDefinition}, or `undefined` if no command is been removed.
+   * @returns {(RsvimCmd.CommandDefinition | undefined)} Returns the removed {@link RsvimCmd.CommandDefinition}, or `undefined` if no command is been removed.
    *
    * @throws Throws {@link !TypeError} if name is not a string.
    *
@@ -406,7 +406,7 @@ class RsvimCmdImpl implements RsvimCmd {
 
   get(name: string): RsvimCmd.CommandDefinition | undefined {
     // @ts-ignore Ignore warning
-    return __InternalRsvimGlobalObject.cmd_get();
+    return __InternalRsvimGlobalObject.cmd_get(name);
   }
 
   remove(name: string): RsvimCmd.CommandDefinition | undefined {

--- a/rsvim_core/src/js/runtime/01__rsvim.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.ts
@@ -223,12 +223,6 @@ class RsvimBufImpl implements RsvimBuf {
 /**
  * The `Rsvim.cmd` global object for Ex commands.
  *
- * :::tip
- * The "ex command" mostly describes the product function, i.e. when user types ":" in normal mode,
- * user can move cursor to command-line and input commands. Rather than referring to the
- * ["ex commands"](https://vimhelp.org/intro.txt.html#Ex-mode) in Vim editor.
- * :::
- *
  * @example
  * ```javascript
  * // Create a alias to 'Rsvim.cmd'.

--- a/rsvim_core/src/js/runtime/01__rsvim.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.ts
@@ -147,7 +147,7 @@ export interface RsvimBuf {
    * the valid buffer ID.
    * :::
    *
-   * @returns {number | undefined} It returns a valid buffer ID if the editor is initialized.
+   * @returns {(number | undefined)} It returns a valid buffer ID if the editor is initialized.
    * Otherwise it returns `undefined` if the editor is not initialized.
    *
    * @example
@@ -249,9 +249,11 @@ export interface RsvimCmd {
    * @param {RsvimCmd.CommandCallback} callback - The backend logic that implements the command. It accepts an `ctx` parameter that contains all the information when user is running it. See {@link RsvimCmd.CommandCallback}.
    * @param {RsvimCmd.CommandAttributes} attributes - Attributes that control the command behavior. This parameter can be omitted, it will use the default attributes, see {@link RsvimCmd.CommandAttributes}.
    * @param {RsvimCmd.CommandOptions} options - Options that control how the command is created. This parameter can be omitted, it will use the default options, see {@link RsvimCmd.CommandOptions}.
-   * @returns {undefined | RsvimCmd.CommandDefinition} It returns `undefined` is the command is newly created, or a command definition that was defined previously.
+   * @returns {(RsvimCmd.CommandDefinition | undefined)} - It returns `undefined` is the command is newly created.
+   *                                                     - Or it returns a command definition that was defined previously.
    *
-   * @throws Throws {@link !TypeError} if any parameters are invalid. Throws {@link Error} if command name or alias already exists, but `force` option is not set to override existing command forcibly.
+   * @throws - Throws {@link !TypeError} if any parameters are invalid.
+   *         - Throws {@link Error} if command name or alias already exists, but `force` option is not set to override existing command forcibly.
    *
    * @example
    * ```javascript

--- a/rsvim_core/src/js/runtime/01__rsvim.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.ts
@@ -405,6 +405,8 @@ class RsvimCmdImpl implements RsvimCmd {
   }
 
   get(name: string): RsvimCmd.CommandDefinition | undefined {
+    checkIsString(name, `"Rsvim.cmd.get" name`);
+
     // @ts-ignore Ignore warning
     return __InternalRsvimGlobalObject.cmd_get(name);
   }

--- a/rsvim_core/src/js/runtime/01__rsvim.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.ts
@@ -288,22 +288,22 @@ export interface RsvimCmd {
   echo(message: any): void;
 
   /**
-   * List all registered ex commands.
+   * List all registered ex command names.
    *
    * :::warning
    * The builtin `js` command will not be listed here.
    * :::
    *
-   * @returns {RsvimCmd.CommandDefinition[]} Returns all registered ex commands, except the `js` command.
+   * @returns {string[]} Returns all registered ex command names, except the `js` command.
    *
    * @example
    * ```javascript
-   * Rsvim.cmd.list().forEach((cmd) => {
-   *   Rsvim.cmd.echo(`Command: ${cmd.name}`);
+   * Rsvim.cmd.list().forEach((name) => {
+   *   Rsvim.cmd.echo(`Command: ${name}`);
    * });
    * ```
    */
-  list(): RsvimCmd.CommandDefinition[];
+  list(): string[];
 
   /**
    * Remove an ex command by name.
@@ -388,7 +388,7 @@ class RsvimCmdImpl implements RsvimCmd {
     __InternalRsvimGlobalObject.cmd_echo(message);
   }
 
-  list(): RsvimCmd.CommandDefinition[] {
+  list(): string[] {
     // @ts-ignore Ignore warning
     return __InternalRsvimGlobalObject.cmd_list();
   }

--- a/rsvim_core/src/js/runtime/01__rsvim.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.ts
@@ -306,6 +306,24 @@ export interface RsvimCmd {
   list(): string[];
 
   /**
+   * Get ex command definition by name.
+   *
+   * :::warning
+   * The builtin `js` command cannot be get.
+   * :::
+   *
+   * @returns {RsvimCmd.CommandDefinition | undefined} Returns command definition by its name, except the `js` command.
+   *
+   * @example
+   * ```javascript
+   * Rsvim.cmd.list().forEach((name) => {
+   *   const cdef = Rsvim.cmd.get(name);
+   *   Rsvim.cmd.echo(`Command: ${cdef.name}`);
+   * });
+   * ```
+   */
+
+  /**
    * Remove an ex command by name.
    *
    * :::warning

--- a/rsvim_core/src/js/runtime/01__rsvim.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.ts
@@ -249,11 +249,9 @@ export interface RsvimCmd {
    * @param {RsvimCmd.CommandCallback} callback - The backend logic that implements the command. It accepts an `ctx` parameter that contains all the information when user is running it. See {@link RsvimCmd.CommandCallback}.
    * @param {RsvimCmd.CommandAttributes} attributes - Attributes that control the command behavior. This parameter can be omitted, it will use the default attributes, see {@link RsvimCmd.CommandAttributes}.
    * @param {RsvimCmd.CommandOptions} options - Options that control how the command is created. This parameter can be omitted, it will use the default options, see {@link RsvimCmd.CommandOptions}.
-   * @returns {(RsvimCmd.CommandDefinition | undefined)} - It returns `undefined` is the command is newly created.
-   *                                                     - Or it returns a command definition that was defined previously.
+   * @returns {(RsvimCmd.CommandDefinition | undefined)} It returns `undefined` is the command is newly created. Or it returns a command definition that was defined previously.
    *
-   * @throws - Throws {@link !TypeError} if any parameters are invalid.
-   *         - Throws {@link Error} if command name or alias already exists, but `force` option is not set to override existing command forcibly.
+   * @throws Throws {@link !TypeError} if any parameters are invalid. Or throws {@link Error} if command name or alias already exists, but `force` option is not set to override existing command forcibly.
    *
    * @example
    * ```javascript

--- a/rsvim_core/src/js/runtime/01__rsvim.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.ts
@@ -320,6 +320,7 @@ export interface RsvimCmd {
    * Rsvim.cmd.echo(`Command: ${def.name}`);
    * ```
    */
+  get(name: string): RsvimCmd.CommandDefinition | undefined;
 
   /**
    * Remove an ex command by name.
@@ -407,6 +408,11 @@ class RsvimCmdImpl implements RsvimCmd {
   list(): string[] {
     // @ts-ignore Ignore warning
     return __InternalRsvimGlobalObject.cmd_list();
+  }
+
+  get(name: string): RsvimCmd.CommandDefinition | undefined {
+    // @ts-ignore Ignore warning
+    return __InternalRsvimGlobalObject.cmd_get();
   }
 
   remove(name: string): RsvimCmd.CommandDefinition | undefined {

--- a/rsvim_core/src/js/runtime/01__rsvim.ts
+++ b/rsvim_core/src/js/runtime/01__rsvim.ts
@@ -316,10 +316,8 @@ export interface RsvimCmd {
    *
    * @example
    * ```javascript
-   * Rsvim.cmd.list().forEach((name) => {
-   *   const cdef = Rsvim.cmd.get(name);
-   *   Rsvim.cmd.echo(`Command: ${cdef.name}`);
-   * });
+   * const def = Rsvim.cmd.get("write");
+   * Rsvim.cmd.echo(`Command: ${def.name}`);
    * ```
    */
 

--- a/rsvim_core/src/tests/evloop.rs
+++ b/rsvim_core/src/tests/evloop.rs
@@ -95,8 +95,6 @@ pub fn make_event_loop(
   EventLoop::mock_new(terminal_cols, terminal_rows, cli_opts).unwrap()
 }
 
-const INTERVAL_MILLIS: Duration = Duration::from_millis(2);
-
 #[derive(Debug)]
 struct SharedWaker {
   pub waker: Option<Waker>,
@@ -138,7 +136,6 @@ impl MockEventReader {
 
         match event {
           MockEvent::Event(e) => {
-            std::thread::sleep(INTERVAL_MILLIS);
             tx.send(Ok(e.clone())).unwrap();
           }
           MockEvent::SleepFor(d) => {
@@ -162,7 +159,6 @@ impl MockEventReader {
       }
 
       trace!("Send final mock event[{}]: CTRL+D {CTRL_D:?}", events.len());
-      std::thread::sleep(INTERVAL_MILLIS);
       tx.send(Ok(CTRL_D.clone())).unwrap();
 
       let mut thread_shared_waker = cloned_shared_waker.lock();
@@ -227,7 +223,6 @@ impl MockOperationReader {
 
         match op {
           MockOperation::Operation(op) => {
-            std::thread::sleep(INTERVAL_MILLIS);
             tx.send(Ok(MockOperation::Operation(op.clone()))).unwrap();
           }
           MockOperation::SleepFor(d) => {
@@ -243,7 +238,6 @@ impl MockOperationReader {
             }
           }
           MockOperation::Exit => {
-            std::thread::sleep(INTERVAL_MILLIS);
             tx.send(Ok(MockOperation::Exit)).unwrap();
           }
         }
@@ -259,7 +253,6 @@ impl MockOperationReader {
         operations.len(),
         EXIT
       );
-      std::thread::sleep(INTERVAL_MILLIS);
       tx.send(Ok(EXIT.clone())).unwrap();
 
       let mut thread_shared_waker = cloned_shared_waker.lock();

--- a/rsvim_core/src/tests/evloop.rs
+++ b/rsvim_core/src/tests/evloop.rs
@@ -95,6 +95,8 @@ pub fn make_event_loop(
   EventLoop::mock_new(terminal_cols, terminal_rows, cli_opts).unwrap()
 }
 
+const INTERVAL_MILLIS: Duration = Duration::from_micros(1);
+
 #[derive(Debug)]
 struct SharedWaker {
   pub waker: Option<Waker>,
@@ -107,9 +109,6 @@ pub enum MockEvent {
 
   /// Sleep for a specific amount of time.
   SleepFor(Duration),
-
-  /// Sleep until a specific time point.
-  SleepUntil(Zoned),
 }
 
 const CTRL_D: Event = Event::Key(KeyEvent::new_with_kind(
@@ -136,19 +135,11 @@ impl MockEventReader {
 
         match event {
           MockEvent::Event(e) => {
+            std::thread::sleep(INTERVAL_MILLIS);
             tx.send(Ok(e.clone())).unwrap();
           }
           MockEvent::SleepFor(d) => {
             std::thread::sleep(*d);
-          }
-          MockEvent::SleepUntil(ts) => {
-            let now = Zoned::now();
-            let d = ts.duration_since(&now);
-            let d = d.as_millis();
-            if d > 0 {
-              let d = Duration::from_millis(d as u64);
-              std::thread::sleep(d);
-            }
           }
         }
 
@@ -159,6 +150,7 @@ impl MockEventReader {
       }
 
       trace!("Send final mock event[{}]: CTRL+D {CTRL_D:?}", events.len());
+      std::thread::sleep(INTERVAL_MILLIS);
       tx.send(Ok(CTRL_D.clone())).unwrap();
 
       let mut thread_shared_waker = cloned_shared_waker.lock();
@@ -197,9 +189,6 @@ pub enum MockOperation {
   /// Sleep for a specific amount of time.
   SleepFor(Duration),
 
-  /// Sleep until a specific time point.
-  SleepUntil(Zoned),
-
   Exit,
 }
 
@@ -223,21 +212,14 @@ impl MockOperationReader {
 
         match op {
           MockOperation::Operation(op) => {
+            std::thread::sleep(INTERVAL_MILLIS);
             tx.send(Ok(MockOperation::Operation(op.clone()))).unwrap();
           }
           MockOperation::SleepFor(d) => {
             std::thread::sleep(*d);
           }
-          MockOperation::SleepUntil(ts) => {
-            let now = Zoned::now();
-            let d = ts.duration_since(&now);
-            let d = d.as_millis();
-            if d > 0 {
-              let d = Duration::from_millis(d as u64);
-              std::thread::sleep(d);
-            }
-          }
           MockOperation::Exit => {
+            std::thread::sleep(INTERVAL_MILLIS);
             tx.send(Ok(MockOperation::Exit)).unwrap();
           }
         }
@@ -253,6 +235,7 @@ impl MockOperationReader {
         operations.len(),
         EXIT
       );
+      std::thread::sleep(INTERVAL_MILLIS);
       tx.send(Ok(EXIT.clone())).unwrap();
 
       let mut thread_shared_waker = cloned_shared_waker.lock();

--- a/rsvim_core/src/tests/evloop.rs
+++ b/rsvim_core/src/tests/evloop.rs
@@ -9,7 +9,6 @@ use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
 use crossterm::event::KeyModifiers;
-use jiff::Zoned;
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::path::Path;
@@ -95,7 +94,7 @@ pub fn make_event_loop(
   EventLoop::mock_new(terminal_cols, terminal_rows, cli_opts).unwrap()
 }
 
-const INTERVAL_MILLIS: Duration = Duration::from_micros(1);
+const INTERVAL: Duration = Duration::from_micros(1);
 
 #[derive(Debug)]
 struct SharedWaker {
@@ -135,7 +134,7 @@ impl MockEventReader {
 
         match event {
           MockEvent::Event(e) => {
-            std::thread::sleep(INTERVAL_MILLIS);
+            std::thread::sleep(INTERVAL);
             tx.send(Ok(e.clone())).unwrap();
           }
           MockEvent::SleepFor(d) => {
@@ -150,7 +149,7 @@ impl MockEventReader {
       }
 
       trace!("Send final mock event[{}]: CTRL+D {CTRL_D:?}", events.len());
-      std::thread::sleep(INTERVAL_MILLIS);
+      std::thread::sleep(INTERVAL);
       tx.send(Ok(CTRL_D.clone())).unwrap();
 
       let mut thread_shared_waker = cloned_shared_waker.lock();
@@ -212,14 +211,14 @@ impl MockOperationReader {
 
         match op {
           MockOperation::Operation(op) => {
-            std::thread::sleep(INTERVAL_MILLIS);
+            std::thread::sleep(INTERVAL);
             tx.send(Ok(MockOperation::Operation(op.clone()))).unwrap();
           }
           MockOperation::SleepFor(d) => {
             std::thread::sleep(*d);
           }
           MockOperation::Exit => {
-            std::thread::sleep(INTERVAL_MILLIS);
+            std::thread::sleep(INTERVAL);
             tx.send(Ok(MockOperation::Exit)).unwrap();
           }
         }
@@ -235,7 +234,7 @@ impl MockOperationReader {
         operations.len(),
         EXIT
       );
-      std::thread::sleep(INTERVAL_MILLIS);
+      std::thread::sleep(INTERVAL);
       tx.send(Ok(EXIT.clone())).unwrap();
 
       let mut thread_shared_waker = cloned_shared_waker.lock();

--- a/rsvim_core/src/tests/evloop.rs
+++ b/rsvim_core/src/tests/evloop.rs
@@ -94,7 +94,7 @@ pub fn make_event_loop(
   EventLoop::mock_new(terminal_cols, terminal_rows, cli_opts).unwrap()
 }
 
-const INTERVAL: Duration = Duration::from_micros(1);
+// const INTERVAL: Duration = Duration::from_micros(1);
 
 #[derive(Debug)]
 struct SharedWaker {
@@ -134,7 +134,7 @@ impl MockEventReader {
 
         match event {
           MockEvent::Event(e) => {
-            std::thread::sleep(INTERVAL);
+            // std::thread::sleep(INTERVAL);
             tx.send(Ok(e.clone())).unwrap();
           }
           MockEvent::SleepFor(d) => {
@@ -149,7 +149,7 @@ impl MockEventReader {
       }
 
       trace!("Send final mock event[{}]: CTRL+D {CTRL_D:?}", events.len());
-      std::thread::sleep(INTERVAL);
+      // std::thread::sleep(INTERVAL);
       tx.send(Ok(CTRL_D.clone())).unwrap();
 
       let mut thread_shared_waker = cloned_shared_waker.lock();
@@ -211,14 +211,14 @@ impl MockOperationReader {
 
         match op {
           MockOperation::Operation(op) => {
-            std::thread::sleep(INTERVAL);
+            // std::thread::sleep(INTERVAL);
             tx.send(Ok(MockOperation::Operation(op.clone()))).unwrap();
           }
           MockOperation::SleepFor(d) => {
             std::thread::sleep(*d);
           }
           MockOperation::Exit => {
-            std::thread::sleep(INTERVAL);
+            // std::thread::sleep(INTERVAL);
             tx.send(Ok(MockOperation::Exit)).unwrap();
           }
         }
@@ -234,7 +234,7 @@ impl MockOperationReader {
         operations.len(),
         EXIT
       );
-      std::thread::sleep(INTERVAL);
+      // std::thread::sleep(INTERVAL);
       tx.send(Ok(EXIT.clone())).unwrap();
 
       let mut thread_shared_waker = cloned_shared_waker.lock();


### PR DESCRIPTION
Close #701 

- Refactors `Rsvim.cmd.list`, it now returns command names instead of full definitions.
- Add `Rsvim.cmd.get`, it gets a full definition by its name.