### PR TITLE
ci(mac): drop macos-13 and intel x64 chip support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,14 @@ jobs:
     name: Unit Test
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, macos-13, windows-2022]
+        os:
+          [
+            ubuntu-22.04,
+            ubuntu-22.04-arm,
+            macos-14,
+            macos-14-large,
+            windows-2022,
+          ]
     runs-on: ${{ matrix.os }}
     env:
       RUSTC_WRAPPER: "sccache"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,11 @@ jobs:
     name: Unit Test
     strategy:
       matrix:
-        os:
-          [
+        os: [
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-14,
-            macos-14-large,
+            # macos-14-large,
             windows-2022,
           ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,8 +57,8 @@ jobs:
           #   os: ubuntu-22.04
           - target: aarch64-apple-darwin
             os: macos-14
-          - target: x86_64-apple-darwin
-            os: macos-14-large
+          # - target: x86_64-apple-darwin
+          #   os: macos-14-large
           - target: x86_64-pc-windows-msvc
             os: windows-2022
             # - target: aarch64-pc-windows-msvc

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,7 +58,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-14
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14-large
           - target: x86_64-pc-windows-msvc
             os: windows-2022
             # - target: aarch64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-14
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14-large
           - target: x86_64-pc-windows-msvc
             os: windows-2022
             # - target: aarch64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
             #   os: ubuntu-22.04
           - target: aarch64-apple-darwin
             os: macos-14
-          - target: x86_64-apple-darwin
-            os: macos-14-large
+          # - target: x86_64-apple-darwin
+          #   os: macos-14-large
           - target: x86_64-pc-windows-msvc
             os: windows-2022
             # - target: aarch64-pc-windows-msvc


### PR DESCRIPTION
GitHub has deprecated macos-13, the "macos-14-large" becomes the only machine with Intel x64 chip, which is not available for free plan. Have to drop support on this.