### PR TITLE
perf(opts): reduce internal options data types

### DIFF
--- a/rsvim_core/Cargo.toml
+++ b/rsvim_core/Cargo.toml
@@ -26,7 +26,6 @@ unicode_lines = ["ropey/unicode_lines"]
 
 [dependencies]
 crossterm = { workspace = true, features = ["event-stream"] }
-bitflags = { workspace = true }
 lexopt = { workspace = true }
 jiff = { workspace = true, features = ["tzdb-bundle-always"] }
 log = { workspace = true, features = [
@@ -109,6 +108,7 @@ timezone_provider = { workspace = true }
 unicode-width = { workspace = true }
 # unicode-segmentation = { workspace = true }
 assert_fs = { workspace = true }
+bitflags = { workspace = true }
 # tracing = { workspace = true, features = [
 #   "max_level_trace",
 #   "release_max_level_error",

--- a/rsvim_core/Cargo.toml
+++ b/rsvim_core/Cargo.toml
@@ -26,6 +26,7 @@ unicode_lines = ["ropey/unicode_lines"]
 
 [dependencies]
 crossterm = { workspace = true, features = ["event-stream"] }
+bitflags = { workspace = true }
 lexopt = { workspace = true }
 jiff = { workspace = true, features = ["tzdb-bundle-always"] }
 log = { workspace = true, features = [
@@ -108,7 +109,6 @@ timezone_provider = { workspace = true }
 unicode-width = { workspace = true }
 # unicode-segmentation = { workspace = true }
 assert_fs = { workspace = true }
-bitflags = { workspace = true }
 # tracing = { workspace = true, features = [
 #   "max_level_trace",
 #   "release_max_level_error",

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -16,7 +16,7 @@ pub use file_format::*;
 
 bitflags! {
   #[derive(Copy, Clone)]
-  struct BufferOptionFlags :u8 {
+  pub struct BufferOptionFlags :u8 {
     const EXPAND_TAB = 1;
   }
 }

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -12,7 +12,7 @@ pub use file_encoding::*;
 pub use file_format::*;
 
 /// Buffer default options.
-pub const TAB_STOP: u16 = 8;
+pub const TAB_STOP: u8 = 8;
 pub const EXPAND_TAB: bool = false;
 pub const SHIFT_WIDTH: u16 = 8;
 pub const FILE_ENCODING: FileEncodingOption = FileEncodingOption::Utf8;
@@ -25,7 +25,7 @@ pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Unix;
 /// Local buffer options.
 pub struct BufferOptions {
   #[builder(default = TAB_STOP)]
-  tab_stop: u16,
+  tab_stop: u8,
 
   #[builder(default = EXPAND_TAB)]
   expand_tab: bool,

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -8,11 +8,10 @@ mod file_encoding_tests;
 #[cfg(test)]
 mod file_format_tests;
 
-use std::fmt::Debug;
-
 use bitflags::bitflags;
 pub use file_encoding::*;
 pub use file_format::*;
+use std::fmt::Debug;
 
 bitflags! {
   #[derive(Copy, Clone)]

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -81,9 +81,9 @@ impl BufferOptions {
 
   pub fn set_expand_tab(&mut self, value: bool) {
     if value {
-      self.flags.insert(BufferOptionFlags::EXPAND_TAB)
+      self.flags.insert(BufferOptionFlags::EXPAND_TAB);
     } else {
-      self.flags.remove(BufferOptionFlags::EXPAND_TAB)
+      self.flags.remove(BufferOptionFlags::EXPAND_TAB);
     }
   }
 

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -8,28 +8,10 @@ mod file_encoding_tests;
 #[cfg(test)]
 mod file_format_tests;
 
-use bitflags::bitflags;
 pub use file_encoding::*;
 pub use file_format::*;
-use std::fmt::Debug;
-
-bitflags! {
-  #[derive(Copy, Clone)]
-  pub struct BufferOptionFlags :u8 {
-    const EXPAND_TAB = 1;
-  }
-}
-
-impl Debug for BufferOptionFlags {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("BufferOptionFlags")
-      .field("bits", &format!("{:b}", self.bits()))
-      .finish()
-  }
-}
 
 // Buffer default options.
-pub const BUFFER_OPTION_FLAGS: BufferOptionFlags = BufferOptionFlags::empty();
 pub const TAB_STOP: u8 = 8;
 pub const EXPAND_TAB: bool = false;
 pub const SHIFT_WIDTH: u8 = 8;
@@ -45,9 +27,8 @@ pub struct BufferOptions {
   #[builder(default = TAB_STOP)]
   tab_stop: u8,
 
-  #[builder(default = BUFFER_OPTION_FLAGS)]
-  // expand_tab
-  flags: BufferOptionFlags,
+  #[builder(default = EXPAND_TAB)]
+  expand_tab: bool,
 
   #[builder(default = SHIFT_WIDTH)]
   shift_width: u8,
@@ -75,15 +56,11 @@ impl BufferOptions {
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27expandtab%27>.
   pub fn expand_tab(&self) -> bool {
-    self.flags.contains(BufferOptionFlags::EXPAND_TAB)
+    self.expand_tab
   }
 
   pub fn set_expand_tab(&mut self, value: bool) {
-    if value {
-      self.flags.insert(BufferOptionFlags::EXPAND_TAB);
-    } else {
-      self.flags.remove(BufferOptionFlags::EXPAND_TAB);
-    }
+    self.expand_tab = value;
   }
 
   /// Buffer 'shift-width' option.

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -29,10 +29,9 @@ impl Debug for BufferOptionFlags {
 }
 
 // Buffer default options.
+pub const BUFFER_OPTION_FLAGS: BufferOptionFlags = BufferOptionFlags::empty();
 pub const TAB_STOP: u8 = 8;
 pub const EXPAND_TAB: bool = false;
-/// expand_tab=true
-pub const BUFFER_OPTION_FLAGS: BufferOptionFlags = BufferOptionFlags::empty();
 pub const SHIFT_WIDTH: u8 = 8;
 pub const FILE_ENCODING: FileEncodingOption = FileEncodingOption::Utf8;
 #[cfg(target_os = "windows")]

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -28,9 +28,10 @@ impl Debug for BufferOptionFlags {
   }
 }
 
-/// Buffer default options.
+// Buffer default options.
 pub const TAB_STOP: u8 = 8;
 pub const EXPAND_TAB: bool = false;
+/// expand_tab=true
 pub const BUFFER_OPTION_FLAGS: BufferOptionFlags = BufferOptionFlags::empty();
 pub const SHIFT_WIDTH: u8 = 8;
 pub const FILE_ENCODING: FileEncodingOption = FileEncodingOption::Utf8;
@@ -45,8 +46,8 @@ pub struct BufferOptions {
   #[builder(default = TAB_STOP)]
   tab_stop: u8,
 
-  // expand_tab
   #[builder(default = BUFFER_OPTION_FLAGS)]
+  // expand_tab
   flags: BufferOptionFlags,
 
   #[builder(default = SHIFT_WIDTH)]

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -32,8 +32,7 @@ impl Debug for BufferOptionFlags {
 /// Buffer default options.
 pub const TAB_STOP: u8 = 8;
 pub const EXPAND_TAB: bool = false;
-pub const BUFFER_OPTION_FLAGS: BufferOptionFlags =
-  BufferOptionFlags::EXPAND_TAB;
+pub const BUFFER_OPTION_FLAGS: BufferOptionFlags = BufferOptionFlags::empty();
 pub const SHIFT_WIDTH: u16 = 8;
 pub const FILE_ENCODING: FileEncodingOption = FileEncodingOption::Utf8;
 #[cfg(target_os = "windows")]

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -32,7 +32,7 @@ impl Debug for BufferOptionFlags {
 pub const TAB_STOP: u8 = 8;
 pub const EXPAND_TAB: bool = false;
 pub const BUFFER_OPTION_FLAGS: BufferOptionFlags = BufferOptionFlags::empty();
-pub const SHIFT_WIDTH: u16 = 8;
+pub const SHIFT_WIDTH: u8 = 8;
 pub const FILE_ENCODING: FileEncodingOption = FileEncodingOption::Utf8;
 #[cfg(target_os = "windows")]
 pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Dos;
@@ -50,7 +50,7 @@ pub struct BufferOptions {
   flags: BufferOptionFlags,
 
   #[builder(default = SHIFT_WIDTH)]
-  shift_width: u16,
+  shift_width: u8,
 
   #[builder(default = FILE_ENCODING)]
   file_encoding: FileEncodingOption,
@@ -89,11 +89,11 @@ impl BufferOptions {
   /// Buffer 'shift-width' option.
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27shiftwidth%27>.
-  pub fn shift_width(&self) -> u16 {
+  pub fn shift_width(&self) -> u8 {
     self.shift_width
   }
 
-  pub fn set_shift_width(&mut self, value: u16) {
+  pub fn set_shift_width(&mut self, value: u8) {
     self.shift_width = value;
   }
 

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -44,11 +44,11 @@ impl BufferOptions {
   /// Buffer 'tab-stop' option.
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27tabstop%27>.
-  pub fn tab_stop(&self) -> u16 {
+  pub fn tab_stop(&self) -> u8 {
     self.tab_stop
   }
 
-  pub fn set_tab_stop(&mut self, value: u16) {
+  pub fn set_tab_stop(&mut self, value: u8) {
     self.tab_stop = value;
   }
 

--- a/rsvim_core/src/js/binding/global_rsvim/opt.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/opt.rs
@@ -145,7 +145,7 @@ pub fn get_shift_width(
   let buffers = lock!(buffers);
   let value = buffers.global_local_options().shift_width();
   trace!("get_shift_width: {:?}", value);
-  rv.set_int32(value as i32);
+  rv.set_uint32(value as u32);
 }
 
 /// Set the _shift-width_ option.

--- a/rsvim_core/src/js/binding/global_rsvim/opt.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/opt.rs
@@ -98,7 +98,7 @@ pub fn set_tab_stop<'s>(
   let buffers = state_rc.borrow().buffers.clone();
   let mut buffers = lock!(buffers);
 
-  let value = num_traits::clamp(value, 0, u8::MAX as u32) as u16;
+  let value = num_traits::clamp(value, 0, u8::MAX as u32) as u8;
   buffers.global_local_options_mut().set_tab_stop(value);
 }
 

--- a/rsvim_core/src/js/binding/global_rsvim/opt.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/opt.rs
@@ -161,7 +161,7 @@ pub fn set_shift_width<'s>(
   let buffers = state_rc.borrow().buffers.clone();
   let mut buffers = lock!(buffers);
 
-  let value = num_traits::clamp(value, 0, u8::MAX as u32) as u16;
+  let value = num_traits::clamp(value, 0, u8::MAX as u32) as u8;
   buffers.global_local_options_mut().set_shift_width(value);
 }
 

--- a/rsvim_core/src/js/binding/global_rsvim/opt.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/opt.rs
@@ -82,7 +82,7 @@ pub fn get_tab_stop(
   let buffers = lock!(buffers);
   let value = buffers.global_local_options().tab_stop();
   trace!("get_tab_stop: {:?}", value);
-  rv.set_int32(value as i32);
+  rv.set_uint32(value as u32);
 }
 
 /// Set the _tab-stop_ option.

--- a/rsvim_core/src/ui/widget/command_line.rs
+++ b/rsvim_core/src/ui/widget/command_line.rs
@@ -82,7 +82,7 @@ impl CommandLine {
     let options = WindowOptionsBuilder::default()
       .wrap(false)
       .line_break(false)
-      .scroll_off(0_u16)
+      .scroll_off(0)
       .build()
       .unwrap();
 

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -50,6 +50,20 @@ impl WindowOptionsBuilder {
     };
     new
   }
+  pub fn line_break(&mut self, value: bool) -> &mut Self {
+    let new = self;
+    new.flags = match new.flags {
+      Some(flags) => {
+        if value {
+          Some(flags | WindowOptionFlags::LINE_BREAK)
+        } else {
+          Some(flags | !WindowOptionFlags::LINE_BREAK)
+        }
+      }
+      None => Some(WINDOW_OPTION_FLAGS),
+    };
+    new
+  }
 }
 
 impl WindowOptions {

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -2,7 +2,7 @@
 
 pub const WRAP: bool = true;
 pub const LINE_BREAK: bool = false;
-pub const SCROLL_OFF: u16 = 0_u16;
+pub const SCROLL_OFF: u8 = 0;
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Window local options.
@@ -14,7 +14,7 @@ pub struct WindowOptions {
   line_break: bool,
 
   #[builder(default = SCROLL_OFF)]
-  scroll_off: u16,
+  scroll_off: u8,
 }
 
 impl WindowOptions {
@@ -43,11 +43,11 @@ impl WindowOptions {
   /// The 'scroll-off' option, default to `0`.
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27scrolloff%27>.
-  pub fn scroll_off(&self) -> u16 {
+  pub fn scroll_off(&self) -> u8 {
     self.scroll_off
   }
 
-  pub fn set_scroll_off(&mut self, value: u16) {
+  pub fn set_scroll_off(&mut self, value: u8) {
     self.scroll_off = value;
   }
 }

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -1,6 +1,24 @@
 //! Window options.
 
+use bitflags::bitflags;
 use derive_builder::Builder;
+use std::fmt::Debug;
+
+bitflags! {
+  #[derive(Copy, Clone)]
+  pub struct WindowOptionFlags :u8 {
+    const WRAP = 1;
+    const LINE_BREAK = 1 << 1;
+  }
+}
+
+impl Debug for WindowOptionFlags {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("WindowOptionFlags")
+      .field("bits", &format!("{:b}", self.bits()))
+      .finish()
+  }
+}
 
 /// Default window options.
 pub const WRAP: bool = true;

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -1,7 +1,6 @@
 //! Window options.
 
 use bitflags::bitflags;
-use derive_builder::Builder;
 use std::fmt::Debug;
 
 bitflags! {
@@ -24,7 +23,7 @@ impl Debug for WindowOptionFlags {
 pub const WINDOW_OPTION_FLAGS: WindowOptionFlags = WindowOptionFlags::WRAP;
 pub const SCROLL_OFF: u16 = 0_u16;
 
-#[derive(Debug, Copy, Clone, Builder)]
+#[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Window local options.
 pub struct WindowOptions {
   #[builder(default = WINDOW_OPTION_FLAGS)]
@@ -79,6 +78,6 @@ impl WindowOptions {
   }
 }
 
-#[derive(Debug, Copy, Clone, Builder)]
+#[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Global window options.
 pub struct WindowGlobalOptions {}

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -41,11 +41,15 @@ impl WindowOptions {
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27wrap%27>.
   pub fn wrap(&self) -> bool {
-    self.wrap
+    self.flags.contains(WindowOptionFlags::WRAP)
   }
 
   pub fn set_wrap(&mut self, value: bool) {
-    self.wrap = value;
+    if value {
+      self.flags.insert(WindowOptionFlags::WRAP);
+    } else {
+      self.flags.remove(WindowOptionFlags::WRAP);
+    }
   }
 
   /// The 'line-break' option, also known as 'word-wrap', default to `false`.

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -19,8 +19,9 @@ impl Debug for WindowOptionFlags {
   }
 }
 
-/// wrap=true,line_break=false
 pub const WINDOW_OPTION_FLAGS: WindowOptionFlags = WindowOptionFlags::WRAP;
+pub const WRAP: bool = true;
+pub const LINE_BREAK: bool = false;
 pub const SCROLL_OFF: u16 = 0_u16;
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -37,7 +37,7 @@ impl WindowOptions {
   }
 
   pub fn set_line_break(&mut self, value: bool) {
-    self.line_break
+    self.line_break = value;
   }
 
   /// The 'scroll-off' option, default to `0`.

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -43,7 +43,7 @@ impl WindowOptionsBuilder {
         if value {
           Some(flags | WindowOptionFlags::WRAP)
         } else {
-          Some(flags)
+          Some(flags | !WindowOptionFlags::WRAP)
         }
       }
       None => Some(WINDOW_OPTION_FLAGS),

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -20,19 +20,17 @@ impl Debug for WindowOptionFlags {
   }
 }
 
-/// Default window options.
-pub const WRAP: bool = true;
-pub const LINE_BREAK: bool = false;
+/// wrap=true,line_break=false
+pub const WINDOW_OPTION_FLAGS: WindowOptionFlags = WindowOptionFlags::WRAP;
 pub const SCROLL_OFF: u16 = 0_u16;
 
 #[derive(Debug, Copy, Clone, Builder)]
 /// Window local options.
 pub struct WindowOptions {
-  #[builder(default = WRAP)]
-  wrap: bool,
-
-  #[builder(default = LINE_BREAK)]
-  line_break: bool,
+  #[builder(default = WINDOW_OPTION_FLAGS)]
+  // wrap
+  // line_break
+  flags: WindowOptionFlags,
 
   #[builder(default = SCROLL_OFF)]
   scroll_off: u16,

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -26,13 +26,30 @@ pub const SCROLL_OFF: u16 = 0_u16;
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Window local options.
 pub struct WindowOptions {
-  #[builder(default = WINDOW_OPTION_FLAGS)]
+  #[builder(setter(custom))]
   // wrap
   // line_break
   flags: WindowOptionFlags,
 
   #[builder(default = SCROLL_OFF)]
   scroll_off: u16,
+}
+
+impl WindowOptionsBuilder {
+  pub fn wrap(&mut self, value: bool) -> &mut Self {
+    let new = self;
+    new.flags = match new.flags {
+      Some(flags) => {
+        if value {
+          Some(flags | WindowOptionFlags::WRAP)
+        } else {
+          Some(flags)
+        }
+      }
+      None => Some(WINDOW_OPTION_FLAGS),
+    };
+    new
+  }
 }
 
 impl WindowOptions {

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -1,25 +1,5 @@
 //! Window options.
 
-use bitflags::bitflags;
-use std::fmt::Debug;
-
-bitflags! {
-  #[derive(Copy, Clone)]
-  pub struct WindowOptionFlags :u8 {
-    const WRAP = 1;
-    const LINE_BREAK = 1 << 1;
-  }
-}
-
-impl Debug for WindowOptionFlags {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("WindowOptionFlags")
-      .field("bits", &format!("{:b}", self.bits()))
-      .finish()
-  }
-}
-
-pub const WINDOW_OPTION_FLAGS: WindowOptionFlags = WindowOptionFlags::WRAP;
 pub const WRAP: bool = true;
 pub const LINE_BREAK: bool = false;
 pub const SCROLL_OFF: u16 = 0_u16;
@@ -27,44 +7,14 @@ pub const SCROLL_OFF: u16 = 0_u16;
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Window local options.
 pub struct WindowOptions {
-  #[builder(setter(custom))]
-  // wrap
-  // line_break
-  flags: WindowOptionFlags,
+  #[builder(default = WRAP)]
+  wrap: bool,
+
+  #[builder(default = LINE_BREAK)]
+  line_break: bool,
 
   #[builder(default = SCROLL_OFF)]
   scroll_off: u16,
-}
-
-impl WindowOptionsBuilder {
-  pub fn wrap(&mut self, value: bool) -> &mut Self {
-    let new = self;
-    new.flags = match new.flags {
-      Some(flags) => {
-        if value {
-          Some(flags | WindowOptionFlags::WRAP)
-        } else {
-          Some(flags | !WindowOptionFlags::WRAP)
-        }
-      }
-      None => Some(WINDOW_OPTION_FLAGS),
-    };
-    new
-  }
-  pub fn line_break(&mut self, value: bool) -> &mut Self {
-    let new = self;
-    new.flags = match new.flags {
-      Some(flags) => {
-        if value {
-          Some(flags | WindowOptionFlags::LINE_BREAK)
-        } else {
-          Some(flags | !WindowOptionFlags::LINE_BREAK)
-        }
-      }
-      None => Some(WINDOW_OPTION_FLAGS),
-    };
-    new
-  }
 }
 
 impl WindowOptions {
@@ -72,30 +22,22 @@ impl WindowOptions {
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27wrap%27>.
   pub fn wrap(&self) -> bool {
-    self.flags.contains(WindowOptionFlags::WRAP)
+    self.wrap
   }
 
   pub fn set_wrap(&mut self, value: bool) {
-    if value {
-      self.flags.insert(WindowOptionFlags::WRAP);
-    } else {
-      self.flags.remove(WindowOptionFlags::WRAP);
-    }
+    self.wrap = value;
   }
 
   /// The 'line-break' option, also known as 'word-wrap', default to `false`.
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27linebreak%27>.
   pub fn line_break(&self) -> bool {
-    self.flags.contains(WindowOptionFlags::LINE_BREAK)
+    self.line_break
   }
 
   pub fn set_line_break(&mut self, value: bool) {
-    if value {
-      self.flags.insert(WindowOptionFlags::LINE_BREAK);
-    } else {
-      self.flags.remove(WindowOptionFlags::LINE_BREAK);
-    }
+    self.line_break
   }
 
   /// The 'scroll-off' option, default to `0`.

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -56,11 +56,15 @@ impl WindowOptions {
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27linebreak%27>.
   pub fn line_break(&self) -> bool {
-    self.line_break
+    self.flags.contains(WindowOptionFlags::LINE_BREAK)
   }
 
   pub fn set_line_break(&mut self, value: bool) {
-    self.line_break = value;
+    if value {
+      self.flags.insert(WindowOptionFlags::LINE_BREAK);
+    } else {
+      self.flags.remove(WindowOptionFlags::LINE_BREAK);
+    }
   }
 
   /// The 'scroll-off' option, default to `0`.


### PR DESCRIPTION
Close #700 

Use smaller data types to reduce memory usage, i.e. use `u8` instead of `u16`.