### PR TITLE
Don't Merge: refactor booleans with bitflags to reduce memory footprint

### DIFF
--- a/rsvim_core/Cargo.toml
+++ b/rsvim_core/Cargo.toml
@@ -26,6 +26,7 @@ unicode_lines = ["ropey/unicode_lines"]
 
 [dependencies]
 crossterm = { workspace = true, features = ["event-stream"] }
+bitflags = { workspace = true }
 lexopt = { workspace = true }
 jiff = { workspace = true, features = ["tzdb-bundle-always"] }
 log = { workspace = true, features = [
@@ -108,7 +109,6 @@ timezone_provider = { workspace = true }
 unicode-width = { workspace = true }
 # unicode-segmentation = { workspace = true }
 assert_fs = { workspace = true }
-bitflags = { workspace = true }
 # tracing = { workspace = true, features = [
 #   "max_level_trace",
 #   "release_max_level_error",

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -63,22 +63,16 @@ pub struct BufferOptions {
 
 impl BufferOptionsBuilder {
   fn expand_tab(&mut self, value: bool) {
-    match self.flags {
-      Some(flags) => {
-        if value {
-          self.flags = Some(flags | OptFlags::EXPAND_TAB);
-        } else {
-          self.flags = Some(flags & !OptFlags::EXPAND_TAB);
-        }
-      }
-      None => {
-        if value {
-          self.flags = Some(OPT_FLAGS | OptFlags::EXPAND_TAB);
-        } else {
-          self.flags = Some(OPT_FLAGS & !OptFlags::EXPAND_TAB);
-        }
-      }
+    let mut flags = match self.flags {
+      Some(flags) => flags,
+      None => OPT_FLAGS,
+    };
+    if value {
+      flags.insert(OptFlags::EXPAND_TAB);
+    } else {
+      flags.remove(OptFlags::EXPAND_TAB);
     }
+    self.flags = Some(flags);
   }
 }
 
@@ -98,11 +92,15 @@ impl BufferOptions {
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27expandtab%27>.
   pub fn expand_tab(&self) -> bool {
-    self.expand_tab
+    self.flags.contains(OptFlags::EXPAND_TAB)
   }
 
   pub fn set_expand_tab(&mut self, value: bool) {
-    self.expand_tab = value;
+    if value {
+      self.flags.insert(OptFlags::EXPAND_TAB);
+    } else {
+      self.flags.remove(OptFlags::EXPAND_TAB);
+    }
   }
 
   /// Buffer 'shift-width' option.

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -39,7 +39,7 @@ impl Debug for OptFlags {
 }
 
 #[allow(dead_code)]
-// expand_tab
+// expand_tab=false
 const OPT_FLAGS: OptFlags = OptFlags::empty();
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -40,12 +40,12 @@ impl Debug for Flags {
 
 #[allow(dead_code)]
 // expand_tab=false
-const OPT_FLAGS: Flags = Flags::empty();
+const FLAGS: Flags = Flags::empty();
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Local buffer options.
 pub struct BufferOptions {
-  #[builder(default = OPT_FLAGS)]
+  #[builder(default = FLAGS)]
   #[builder(setter(custom))]
   // expand_tab
   flags: Flags,
@@ -68,7 +68,7 @@ impl BufferOptionsBuilder {
   pub fn expand_tab(&mut self, value: bool) -> &mut Self {
     let mut flags = match self.flags {
       Some(flags) => flags,
-      None => OPT_FLAGS,
+      None => FLAGS,
     };
     if value {
       flags.insert(Flags::EXPAND_TAB);

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -32,7 +32,7 @@ bitflags! {
 
 impl Debug for Flags {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("OptFlags")
+    f.debug_struct("Flags")
       .field("bits", &format!("{:b}", self.bits()))
       .finish()
   }

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -64,7 +64,7 @@ pub struct BufferOptions {
 
 impl BufferOptionsBuilder {
   #[allow(dead_code)]
-  pub fn expand_tab(&mut self, value: bool) {
+  pub fn expand_tab(&mut self, value: bool) -> &mut Self {
     let mut flags = match self.flags {
       Some(flags) => flags,
       None => OPT_FLAGS,
@@ -75,6 +75,7 @@ impl BufferOptionsBuilder {
       flags.remove(OptFlags::EXPAND_TAB);
     }
     self.flags = Some(flags);
+    self
   }
 }
 

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -38,6 +38,7 @@ impl Debug for OptFlags {
   }
 }
 
+#[allow(dead_code)]
 // expand_tab
 const OPT_FLAGS: OptFlags = OptFlags::empty();
 
@@ -62,7 +63,8 @@ pub struct BufferOptions {
 }
 
 impl BufferOptionsBuilder {
-  fn expand_tab(&mut self, value: bool) {
+  #[allow(dead_code)]
+  pub fn expand_tab(&mut self, value: bool) {
     let mut flags = match self.flags {
       Some(flags) => flags,
       None => OPT_FLAGS,

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -48,6 +48,7 @@ pub struct BufferOptions {
   #[builder(default = TAB_STOP)]
   tab_stop: u8,
 
+  #[builder(default = OPT_FLAGS)]
   #[builder(setter(custom))]
   // expand_tab
   flags: OptFlags,

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -25,12 +25,12 @@ pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Unix;
 
 bitflags! {
   #[derive(Copy, Clone)]
-  struct OptFlags: u8 {
+  struct Flags: u8 {
     const EXPAND_TAB = 1;
   }
 }
 
-impl Debug for OptFlags {
+impl Debug for Flags {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("OptFlags")
       .field("bits", &format!("{:b}", self.bits()))
@@ -40,18 +40,18 @@ impl Debug for OptFlags {
 
 #[allow(dead_code)]
 // expand_tab=false
-const OPT_FLAGS: OptFlags = OptFlags::empty();
+const OPT_FLAGS: Flags = Flags::empty();
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Local buffer options.
 pub struct BufferOptions {
-  #[builder(default = TAB_STOP)]
-  tab_stop: u8,
-
   #[builder(default = OPT_FLAGS)]
   #[builder(setter(custom))]
   // expand_tab
-  flags: OptFlags,
+  flags: Flags,
+
+  #[builder(default = TAB_STOP)]
+  tab_stop: u8,
 
   #[builder(default = SHIFT_WIDTH)]
   shift_width: u8,
@@ -71,9 +71,9 @@ impl BufferOptionsBuilder {
       None => OPT_FLAGS,
     };
     if value {
-      flags.insert(OptFlags::EXPAND_TAB);
+      flags.insert(Flags::EXPAND_TAB);
     } else {
-      flags.remove(OptFlags::EXPAND_TAB);
+      flags.remove(Flags::EXPAND_TAB);
     }
     self.flags = Some(flags);
     self
@@ -96,14 +96,14 @@ impl BufferOptions {
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27expandtab%27>.
   pub fn expand_tab(&self) -> bool {
-    self.flags.contains(OptFlags::EXPAND_TAB)
+    self.flags.contains(Flags::EXPAND_TAB)
   }
 
   pub fn set_expand_tab(&mut self, value: bool) {
     if value {
-      self.flags.insert(OptFlags::EXPAND_TAB);
+      self.flags.insert(Flags::EXPAND_TAB);
     } else {
-      self.flags.remove(OptFlags::EXPAND_TAB);
+      self.flags.remove(Flags::EXPAND_TAB);
     }
   }
 

--- a/rsvim_core/src/cli.rs
+++ b/rsvim_core/src/cli.rs
@@ -8,14 +8,14 @@ use std::path::PathBuf;
 
 bitflags! {
   #[derive(Copy, Clone, PartialEq, Eq)]
-  struct SpecialOptFlags : u8{
+  struct SpecialFlags : u8{
     const VERSION = 1;
     const SHORT_HELP = 1 << 1;
     const LONG_HELP = 1 << 2;
   }
 }
 
-impl Debug for SpecialOptFlags {
+impl Debug for SpecialFlags {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("SpecialOptFlags")
       .field("bits", &format!("{:b}", self.bits()))
@@ -28,52 +28,52 @@ pub struct CliSpecialOptions {
   // version
   // short_help
   // long_help
-  flags: SpecialOptFlags,
+  flags: SpecialFlags,
 }
 
 impl CliSpecialOptions {
   pub fn new(version: bool, short_help: bool, long_help: bool) -> Self {
-    let mut flags = SpecialOptFlags::empty();
+    let mut flags = SpecialFlags::empty();
     if version {
-      flags.insert(SpecialOptFlags::VERSION);
+      flags.insert(SpecialFlags::VERSION);
     }
     if short_help {
-      flags.insert(SpecialOptFlags::SHORT_HELP);
+      flags.insert(SpecialFlags::SHORT_HELP);
     }
     if long_help {
-      flags.insert(SpecialOptFlags::LONG_HELP);
+      flags.insert(SpecialFlags::LONG_HELP);
     }
     Self { flags }
   }
 
   pub fn version(&self) -> bool {
-    self.flags.contains(SpecialOptFlags::VERSION)
+    self.flags.contains(SpecialFlags::VERSION)
   }
 
   pub fn short_help(&self) -> bool {
-    self.flags.contains(SpecialOptFlags::SHORT_HELP)
+    self.flags.contains(SpecialFlags::SHORT_HELP)
   }
 
   pub fn long_help(&self) -> bool {
-    self.flags.contains(SpecialOptFlags::LONG_HELP)
+    self.flags.contains(SpecialFlags::LONG_HELP)
   }
 
   #[cfg(test)]
   pub fn empty() -> Self {
     Self {
-      flags: SpecialOptFlags::empty(),
+      flags: SpecialFlags::empty(),
     }
   }
 }
 
 bitflags! {
   #[derive(Copy, Clone)]
-  struct OptFlags : u8{
+  struct Flags : u8{
     const HEADLESS = 1;
   }
 }
 
-impl Debug for OptFlags {
+impl Debug for Flags {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("OptFlags")
       .field("bits", &format!("{:b}", self.bits()))
@@ -88,7 +88,7 @@ pub struct CliOptions {
   special_opts: CliSpecialOptions,
 
   // headless
-  flags: OptFlags,
+  flags: Flags,
 
   // Normal opts
   file: Vec<PathBuf>,
@@ -100,7 +100,7 @@ fn parse(mut parser: lexopt::Parser) -> Result<CliOptions, lexopt::Error> {
   let mut version: bool = false;
   let mut short_help: bool = false;
   let mut long_help: bool = false;
-  let mut flags: OptFlags = OptFlags::empty();
+  let mut flags: Flags = Flags::empty();
   let mut file: Vec<PathBuf> = vec![];
 
   while let Some(arg) = parser.next()? {
@@ -115,7 +115,7 @@ fn parse(mut parser: lexopt::Parser) -> Result<CliOptions, lexopt::Error> {
         version = true;
       }
       Long("headless") => {
-        flags.insert(OptFlags::HEADLESS);
+        flags.insert(Flags::HEADLESS);
       }
       Value(filename) => {
         file.push(Path::new(&filename).to_path_buf());
@@ -162,7 +162,7 @@ impl CliOptions {
 
   /// Headless mode.
   pub fn headless(&self) -> bool {
-    self.flags.contains(OptFlags::HEADLESS)
+    self.flags.contains(Flags::HEADLESS)
   }
 
   #[cfg(test)]
@@ -171,9 +171,9 @@ impl CliOptions {
     file: Vec<PathBuf>,
     headless: bool,
   ) -> Self {
-    let mut flags: OptFlags = OptFlags::empty();
+    let mut flags: Flags = Flags::empty();
     if headless {
-      flags.insert(OptFlags::HEADLESS);
+      flags.insert(Flags::HEADLESS);
     }
     Self {
       special_opts,
@@ -184,7 +184,7 @@ impl CliOptions {
 
   #[cfg(test)]
   pub fn empty() -> Self {
-    let flags: OptFlags = OptFlags::HEADLESS;
+    let flags: Flags = Flags::HEADLESS;
     Self {
       special_opts: CliSpecialOptions::empty(),
       flags,

--- a/rsvim_core/src/cli.rs
+++ b/rsvim_core/src/cli.rs
@@ -17,7 +17,7 @@ bitflags! {
 
 impl Debug for SpecialFlags {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("SpecialOptFlags")
+    f.debug_struct("SpecialFlags")
       .field("bits", &format!("{:b}", self.bits()))
       .finish()
   }
@@ -75,7 +75,7 @@ bitflags! {
 
 impl Debug for Flags {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("OptFlags")
+    f.debug_struct("Flags")
       .field("bits", &format!("{:b}", self.bits()))
       .finish()
   }

--- a/rsvim_core/src/cli.rs
+++ b/rsvim_core/src/cli.rs
@@ -11,7 +11,7 @@ bitflags! {
   struct SpecialOptFlags : u8{
     const VERSION = 1;
     const SHORT_HELP = 1 << 1;
-    const LONG_HELP = 1 << 1;
+    const LONG_HELP = 1 << 2;
   }
 }
 

--- a/rsvim_core/src/cli.rs
+++ b/rsvim_core/src/cli.rs
@@ -68,7 +68,7 @@ impl CliSpecialOptions {
 
 bitflags! {
   #[derive(Copy, Clone)]
-  struct Flags : u8{
+  struct Flags: u8 {
     const HEADLESS = 1;
   }
 }

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -691,8 +691,8 @@ impl EventLoop {
           trace!("Recv TimeoutReq:{:?}", req.timer_id);
           let jsrt_forwarder_tx = self.jsrt_forwarder_tx.clone();
           self.detached_tracker.spawn(async move {
-            let expire_at =
-              req.start_at + tokio::time::Duration::from_millis(req.delay);
+            let expire_at = req.start_at
+              + tokio::time::Duration::from_millis(req.delay as u64);
             tokio::time::sleep_until(expire_at).await;
             let _ = jsrt_forwarder_tx
               .send(JsMessage::TimeoutResp(msg::TimeoutResp {

--- a/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
@@ -341,8 +341,8 @@ setTimeout(() => {
     assert_eq!(command_def.name, "write");
     assert!(!command_def.attributes.bang());
     assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
-    assert!(command_def.options.force);
-    assert_eq!(command_def.options.alias, None);
+    assert!(command_def.options.force());
+    assert_eq!(command_def.options.alias(), &None);
   }
 
   Ok(())
@@ -404,8 +404,8 @@ setTimeout(() => {
       assert_eq!(name, def.name);
       assert!(!def.attributes.bang());
       assert_eq!(def.attributes.nargs(), Nargs::Zero);
-      assert!(!def.options.force);
-      assert_eq!(def.options.alias, None);
+      assert!(!def.options.force());
+      assert_eq!(def.options.alias(), &None);
     }
   }
 
@@ -474,8 +474,8 @@ setTimeout(() => {
     assert_eq!(command_def.name, "write");
     assert!(!command_def.attributes.bang());
     assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
-    assert!(!command_def.options.force);
-    assert_eq!(command_def.options.alias, Some("w".to_compact_string()));
+    assert!(!command_def.options.force());
+    assert_eq!(command_def.options.alias(), &Some("w".to_compact_string()));
   }
 
   Ok(())

--- a/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
@@ -270,8 +270,8 @@ Rsvim.cmd.echo(`Previous command:${prev}`);
     assert_eq!(command_def.name, "write");
     assert!(!command_def.attributes.bang());
     assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
-    assert!(command_def.options.force);
-    assert_eq!(command_def.options.alias, None);
+    assert!(command_def.options.force());
+    assert_eq!(command_def.options.alias(), &None);
   }
 
   Ok(())
@@ -543,8 +543,8 @@ setTimeout(() => {
     assert_eq!(command_def.name, "write");
     assert!(!command_def.attributes.bang());
     assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
-    assert!(!command_def.options.force);
-    assert_eq!(command_def.options.alias, Some("w".to_compact_string()));
+    assert!(!command_def.options.force());
+    assert_eq!(command_def.options.alias(), &Some("w".to_compact_string()));
   }
 
   Ok(())
@@ -605,8 +605,8 @@ Rsvim.cmd.list().forEach((name) => {
     assert_eq!(command_def.name, "write");
     assert!(!command_def.attributes.bang());
     assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
-    assert!(command_def.options.force);
-    assert_eq!(command_def.options.alias, None);
+    assert!(command_def.options.force());
+    assert_eq!(command_def.options.alias(), &None);
   }
 
   Ok(())
@@ -666,8 +666,8 @@ Rsvim.cmd.echo(`name:${def.name}`);
     assert_eq!(command_def.name, "write");
     assert!(!command_def.attributes.bang());
     assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
-    assert!(command_def.options.force);
-    assert_eq!(command_def.options.alias, None);
+    assert!(command_def.options.force());
+    assert_eq!(command_def.options.alias(), &None);
   }
 
   Ok(())
@@ -727,8 +727,8 @@ Rsvim.cmd.echo(`name:${def}`);
     assert_eq!(command_def.name, "write");
     assert!(!command_def.attributes.bang());
     assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
-    assert!(command_def.options.force);
-    assert_eq!(command_def.options.alias, None);
+    assert!(command_def.options.force());
+    assert_eq!(command_def.options.alias(), &None);
   }
 
   Ok(())
@@ -832,8 +832,8 @@ Rsvim.cmd.echo(`${prev}`);
     assert_eq!(command_def.name, "write");
     assert!(!command_def.attributes.bang());
     assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
-    assert!(command_def.options.force);
-    assert_eq!(command_def.options.alias, None);
+    assert!(command_def.options.force());
+    assert_eq!(command_def.options.alias(), &None);
   }
 
   Ok(())

--- a/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
@@ -268,8 +268,8 @@ Rsvim.cmd.echo(`Previous command:${prev}`);
     let (command_name, command_def) = first_command.unwrap();
     assert_eq!(command_name, "write");
     assert_eq!(command_def.name, "write");
-    assert!(!command_def.attributes.bang);
-    assert_eq!(command_def.attributes.nargs, Nargs::Zero);
+    assert!(!command_def.attributes.bang());
+    assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
     assert!(command_def.options.force);
     assert_eq!(command_def.options.alias, None);
   }
@@ -339,8 +339,8 @@ setTimeout(() => {
     let (command_name, command_def) = first_command.unwrap();
     assert_eq!(command_name, "write");
     assert_eq!(command_def.name, "write");
-    assert!(!command_def.attributes.bang);
-    assert_eq!(command_def.attributes.nargs, Nargs::Zero);
+    assert!(!command_def.attributes.bang());
+    assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
     assert!(command_def.options.force);
     assert_eq!(command_def.options.alias, None);
   }
@@ -402,8 +402,8 @@ setTimeout(() => {
     for (name, def) in commands.iter() {
       assert!(name == "write" || name == "writeSync");
       assert_eq!(name, def.name);
-      assert!(!def.attributes.bang);
-      assert_eq!(def.attributes.nargs, Nargs::Zero);
+      assert!(!def.attributes.bang());
+      assert_eq!(def.attributes.nargs(), Nargs::Zero);
       assert!(!def.options.force);
       assert_eq!(def.options.alias, None);
     }
@@ -472,8 +472,8 @@ setTimeout(() => {
     let (command_name, command_def) = first_command.unwrap();
     assert_eq!(command_name, "write");
     assert_eq!(command_def.name, "write");
-    assert!(!command_def.attributes.bang);
-    assert_eq!(command_def.attributes.nargs, Nargs::Zero);
+    assert!(!command_def.attributes.bang());
+    assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
     assert!(!command_def.options.force);
     assert_eq!(command_def.options.alias, Some("w".to_compact_string()));
   }
@@ -541,8 +541,8 @@ setTimeout(() => {
     let (command_name, command_def) = first_command.unwrap();
     assert_eq!(command_name, "write");
     assert_eq!(command_def.name, "write");
-    assert!(!command_def.attributes.bang);
-    assert_eq!(command_def.attributes.nargs, Nargs::Zero);
+    assert!(!command_def.attributes.bang());
+    assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
     assert!(!command_def.options.force);
     assert_eq!(command_def.options.alias, Some("w".to_compact_string()));
   }
@@ -603,8 +603,8 @@ Rsvim.cmd.list().forEach((name) => {
     let (command_name, command_def) = first_command.unwrap();
     assert_eq!(command_name, "write");
     assert_eq!(command_def.name, "write");
-    assert!(!command_def.attributes.bang);
-    assert_eq!(command_def.attributes.nargs, Nargs::Zero);
+    assert!(!command_def.attributes.bang());
+    assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
     assert!(command_def.options.force);
     assert_eq!(command_def.options.alias, None);
   }
@@ -664,8 +664,8 @@ Rsvim.cmd.echo(`name:${def.name}`);
     let (command_name, command_def) = first_command.unwrap();
     assert_eq!(command_name, "write");
     assert_eq!(command_def.name, "write");
-    assert!(!command_def.attributes.bang);
-    assert_eq!(command_def.attributes.nargs, Nargs::Zero);
+    assert!(!command_def.attributes.bang());
+    assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
     assert!(command_def.options.force);
     assert_eq!(command_def.options.alias, None);
   }
@@ -725,8 +725,8 @@ Rsvim.cmd.echo(`name:${def}`);
     let (command_name, command_def) = first_command.unwrap();
     assert_eq!(command_name, "write");
     assert_eq!(command_def.name, "write");
-    assert!(!command_def.attributes.bang);
-    assert_eq!(command_def.attributes.nargs, Nargs::Zero);
+    assert!(!command_def.attributes.bang());
+    assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
     assert!(command_def.options.force);
     assert_eq!(command_def.options.alias, None);
   }
@@ -830,8 +830,8 @@ Rsvim.cmd.echo(`${prev}`);
     let (command_name, command_def) = first_command.unwrap();
     assert_eq!(command_name, "write");
     assert_eq!(command_def.name, "write");
-    assert!(!command_def.attributes.bang);
-    assert_eq!(command_def.attributes.nargs, Nargs::Zero);
+    assert!(!command_def.attributes.bang());
+    assert_eq!(command_def.attributes.nargs(), Nargs::Zero);
     assert!(command_def.options.force);
     assert_eq!(command_def.options.alias, None);
   }

--- a/rsvim_core/src/js/binding/global_this/timeout.rs
+++ b/rsvim_core/src/js/binding/global_this/timeout.rs
@@ -98,7 +98,7 @@ pub fn create_timer<'s>(
   pending::create_timer(
     &mut state,
     timer_id,
-    delay as u64,
+    delay,
     repeated,
     Box::new(timer_cb),
   );

--- a/rsvim_core/src/js/command.rs
+++ b/rsvim_core/src/js/command.rs
@@ -96,9 +96,9 @@ impl CommandsManager {
     name: CompactString,
     definition: CommandDefinitionRc,
   ) -> TheResult<Option<CommandDefinitionRc>> {
-    let alias = definition.options.alias.clone();
+    let alias = definition.options.alias().clone();
 
-    if !definition.options.force {
+    if !definition.options.force() {
       if self.commands.contains_key(&name) {
         bail!(TheErr::CommandNameAlreadyExist(name));
       }

--- a/rsvim_core/src/js/command/attr.rs
+++ b/rsvim_core/src/js/command/attr.rs
@@ -150,7 +150,7 @@ impl ToV8 for CommandAttributes {
 
     // bang
     let bang_field = to_v8(scope, BANG);
-    let bang_value = to_v8(scope, self.bang);
+    let bang_value = to_v8(scope, self.bang());
     obj.set(scope, bang_field, bang_value);
 
     // nargs

--- a/rsvim_core/src/js/command/attr.rs
+++ b/rsvim_core/src/js/command/attr.rs
@@ -1,7 +1,6 @@
 //! Ex command attributes.
 
 use crate::js::converter::*;
-use bitflags::Flag;
 use bitflags::bitflags;
 use compact_str::CompactString;
 use compact_str::ToCompactString;

--- a/rsvim_core/src/js/command/opt.rs
+++ b/rsvim_core/src/js/command/opt.rs
@@ -39,7 +39,7 @@ pub struct CommandOptions {
   flags: Flags,
 
   #[builder(default = ALIAS_DEFAULT)]
-  pub alias: Option<CompactString>,
+  alias: Option<CompactString>,
 }
 
 impl CommandOptionsBuilder {
@@ -55,6 +55,28 @@ impl CommandOptionsBuilder {
     }
     self.flags = Some(flags);
     self
+  }
+}
+
+impl CommandOptions {
+  pub fn force(&self) -> bool {
+    self.flags.contains(Flags::FORCE)
+  }
+
+  pub fn set_force(&mut self, value: bool) {
+    if value {
+      self.flags.insert(Flags::FORCE);
+    } else {
+      self.flags.remove(Flags::FORCE);
+    }
+  }
+
+  pub fn alias(&self) -> &Option<CompactString> {
+    &self.alias
+  }
+
+  pub fn set_alias(&mut self, value: Option<CompactString>) {
+    self.alias = value;
   }
 }
 
@@ -95,7 +117,7 @@ impl ToV8 for CommandOptions {
 
     // force
     let force_field = to_v8(scope, FORCE);
-    let force_value = to_v8(scope, self.force);
+    let force_value = to_v8(scope, self.force());
     obj.set(scope, force_field, force_value);
 
     // alias

--- a/rsvim_core/src/js/pending.rs
+++ b/rsvim_core/src/js/pending.rs
@@ -14,7 +14,7 @@ pub type TaskCallback = Box<dyn FnMut(Option<TheResult<Vec<u8>>>) + 'static>;
 pub fn create_timer(
   state: &mut JsRuntimeState,
   timer_id: JsTimerId,
-  delay: u64,
+  delay: u32,
   repeated: bool,
   cb: TimerCallback,
 ) {

--- a/rsvim_core/src/msg/jsrt.rs
+++ b/rsvim_core/src/msg/jsrt.rs
@@ -28,7 +28,7 @@ pub enum JsMessage {
 pub struct TimeoutResp {
   pub timer_id: JsTimerId,
   pub expire_at: Instant,
-  pub delay: u64,
+  pub delay: u32,
   pub repeated: bool,
 }
 

--- a/rsvim_core/src/msg/master.rs
+++ b/rsvim_core/src/msg/master.rs
@@ -40,7 +40,7 @@ pub struct PrintReq {
 pub struct TimeoutReq {
   pub timer_id: JsTimerId,
   pub start_at: Instant,
-  pub delay: u64,
+  pub delay: u32,
   pub repeated: bool,
 }
 

--- a/rsvim_core/src/ui/canvas/frame/cursor.rs
+++ b/rsvim_core/src/ui/canvas/frame/cursor.rs
@@ -67,8 +67,8 @@ impl Cursor {
   }
 
   /// Set blinking.
-  pub fn set_blinking(&mut self, blinking: bool) {
-    if blinking {
+  pub fn set_blinking(&mut self, value: bool) {
+    if value {
       self.flags.insert(Flags::BLINKING);
     } else {
       self.flags.remove(Flags::BLINKING);
@@ -81,8 +81,8 @@ impl Cursor {
   }
 
   /// Set hidden.
-  pub fn set_hidden(&mut self, hidden: bool) {
-    if hidden {
+  pub fn set_hidden(&mut self, value: bool) {
+    if value {
       self.flags.insert(Flags::HIDDEN);
     } else {
       self.flags.remove(Flags::HIDDEN);

--- a/rsvim_core/src/ui/canvas/frame/cursor.rs
+++ b/rsvim_core/src/ui/canvas/frame/cursor.rs
@@ -1,9 +1,16 @@
 //! Cursor of canvas frame.
 
 use crate::prelude::*;
+use bitflags::bitflags;
 use geo::point;
 
 pub type CursorStyle = crossterm::cursor::SetCursorStyle;
+
+bitflags! {
+  struct Flags {
+
+  }
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// Terminal cursor.

--- a/rsvim_core/src/ui/canvas/frame/cursor.rs
+++ b/rsvim_core/src/ui/canvas/frame/cursor.rs
@@ -9,7 +9,7 @@ pub type CursorStyle = crossterm::cursor::SetCursorStyle;
 
 bitflags! {
   #[derive(Copy, Clone, PartialEq, Eq)]
-  struct Flags: u8{
+  struct Flags: u8 {
     const BLINKING = 1;
     const HIDDEN = 1 << 1;
   }

--- a/rsvim_core/src/ui/canvas/frame/cursor.rs
+++ b/rsvim_core/src/ui/canvas/frame/cursor.rs
@@ -48,7 +48,7 @@ impl Cursor {
     if hidden {
       flags.insert(Flags::HIDDEN);
     }
-    Cursor { pos, flags, style }
+    Cursor { pos, style, flags }
   }
 
   /// Get position.
@@ -108,8 +108,8 @@ impl Default for Cursor {
     let flags = Flags::empty();
     Cursor {
       pos: point! {x:0_u16, y:0_u16},
-      flags,
       style: CursorStyle::SteadyBlock,
+      flags,
     }
   }
 }

--- a/rsvim_core/src/ui/tree/internal/inode.rs
+++ b/rsvim_core/src/ui/tree/internal/inode.rs
@@ -346,8 +346,8 @@ impl Debug for BaseFlags {
   }
 }
 
-// enabled
-// visible
+// enabled=true
+// visible=true
 const BASE_FLAGS: BaseFlags = BaseFlags::all();
 
 #[derive(Debug, Clone, Copy)]

--- a/rsvim_core/src/ui/tree/internal/inode.rs
+++ b/rsvim_core/src/ui/tree/internal/inode.rs
@@ -332,13 +332,13 @@ const VISIBLE: bool = true;
 
 bitflags! {
   #[derive(Copy, Clone)]
-  struct BaseFlags: u8 {
+  struct Flags: u8 {
     const ENABLED = 1;
     const VISIBLE = 1 << 1;
   }
 }
 
-impl Debug for BaseFlags {
+impl Debug for Flags {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("Flags")
       .field("bits", &format!("{:b}", self.bits()))
@@ -348,7 +348,7 @@ impl Debug for BaseFlags {
 
 // enabled=true
 // visible=true
-const BASE_FLAGS: BaseFlags = BaseFlags::all();
+const FLAGS: Flags = Flags::all();
 
 #[derive(Debug, Clone, Copy)]
 /// The internal tree node, it's both a container for the widgets and common attributes.
@@ -361,7 +361,7 @@ pub struct InodeBase {
 
   // enabled
   // visible
-  flags: BaseFlags,
+  flags: Flags,
 }
 
 impl InodeBase {
@@ -373,7 +373,7 @@ impl InodeBase {
       shape,
       actual_shape,
       zindex: 0,
-      flags: BASE_FLAGS,
+      flags: FLAGS,
     }
   }
 
@@ -414,26 +414,26 @@ impl InodeBase {
   }
 
   pub fn enabled(&self) -> bool {
-    self.flags.contains(BaseFlags::ENABLED)
+    self.flags.contains(Flags::ENABLED)
   }
 
   pub fn set_enabled(&mut self, enabled: bool) {
     if enabled {
-      self.flags.insert(BaseFlags::ENABLED);
+      self.flags.insert(Flags::ENABLED);
     } else {
-      self.flags.remove(BaseFlags::ENABLED);
+      self.flags.remove(Flags::ENABLED);
     }
   }
 
   pub fn visible(&self) -> bool {
-    self.flags.contains(BaseFlags::VISIBLE)
+    self.flags.contains(Flags::VISIBLE)
   }
 
   pub fn set_visible(&mut self, visible: bool) {
     if visible {
-      self.flags.insert(BaseFlags::VISIBLE);
+      self.flags.insert(Flags::VISIBLE);
     } else {
-      self.flags.remove(BaseFlags::VISIBLE);
+      self.flags.remove(Flags::VISIBLE);
     }
   }
 }

--- a/rsvim_core/src/ui/tree/internal/inode.rs
+++ b/rsvim_core/src/ui/tree/internal/inode.rs
@@ -325,7 +325,9 @@ pub fn next_node_id() -> TreeNodeId {
   VALUE.fetch_add(1, Ordering::Relaxed)
 }
 
+#[allow(dead_code)]
 const ENABLED: bool = true;
+#[allow(dead_code)]
 const VISIBLE: bool = true;
 
 bitflags! {

--- a/rsvim_core/src/ui/widget/cursor.rs
+++ b/rsvim_core/src/ui/widget/cursor.rs
@@ -114,8 +114,8 @@ impl Widgetable for Cursor {
 
     canvas.frame_mut().set_cursor(canvas::Cursor::new(
       pos,
-      self.blinking,
-      self.hidden,
+      self.blinking(),
+      self.hidden(),
       self.style,
     ));
   }

--- a/rsvim_core/src/ui/widget/cursor.rs
+++ b/rsvim_core/src/ui/widget/cursor.rs
@@ -7,15 +7,33 @@ use crate::ui::canvas::Canvas;
 use crate::ui::canvas::CursorStyle;
 use crate::ui::tree::*;
 use crate::ui::widget::Widgetable;
+use bitflags::bitflags;
 use std::fmt::Debug;
+
+bitflags! {
+  #[derive(Copy, Clone)]
+  struct Flags: u8{
+    const BLINKING = 1;
+    const HIDDEN = 1 << 1;
+  }
+}
+
+impl Debug for Flags {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("Flags")
+      .field("bits", &format!("{:b}", self.bits()))
+      .finish()
+  }
+}
 
 #[derive(Debug, Clone, Copy)]
 /// Cursor widget.
 pub struct Cursor {
   base: InodeBase,
-  blinking: bool,
-  hidden: bool,
   style: CursorStyle,
+  // blinking
+  // hidden
+  flags: Flags,
 }
 
 impl Cursor {
@@ -25,37 +43,53 @@ impl Cursor {
     hidden: bool,
     style: CursorStyle,
   ) -> Self {
+    let mut flags = Flags::empty();
+    if blinking {
+      flags.insert(Flags::BLINKING);
+    }
+    if hidden {
+      flags.insert(Flags::HIDDEN);
+    }
     Cursor {
       base: InodeBase::new(shape),
-      blinking,
-      hidden,
       style,
+      flags,
     }
   }
 
   pub fn default(shape: IRect) -> Self {
+    // blinking=false
+    // hidden=false
+    let flags = Flags::empty();
     Cursor {
       base: InodeBase::new(shape),
-      blinking: false,
-      hidden: false,
       style: CursorStyle::SteadyBlock,
+      flags,
     }
   }
 
   pub fn blinking(&self) -> bool {
-    self.blinking
+    self.flags.contains(Flags::BLINKING)
   }
 
   pub fn set_blinking(&mut self, value: bool) {
-    self.blinking = value;
+    if value {
+      self.flags.insert(Flags::BLINKING);
+    } else {
+      self.flags.remove(Flags::BLINKING);
+    }
   }
 
   pub fn hidden(&self) -> bool {
-    self.hidden
+    self.flags.contains(Flags::HIDDEN)
   }
 
   pub fn set_hidden(&mut self, value: bool) {
-    self.hidden = value;
+    if value {
+      self.flags.insert(Flags::HIDDEN);
+    } else {
+      self.flags.remove(Flags::HIDDEN);
+    }
   }
 
   pub fn style(&self) -> &CursorStyle {

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -31,6 +31,7 @@ const OPT_FLAGS: OptFlags = OptFlags::WRAP;
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Window local options.
 pub struct WindowOptions {
+  #[builder(default = OPT_FLAGS)]
   #[builder(setter(custom))]
   // wrap
   // line_break

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -24,8 +24,8 @@ impl Debug for OptFlags {
 }
 
 #[allow(dead_code)]
-// wrap
-// line_break
+// wrap=true
+// line_break=false
 const OPT_FLAGS: OptFlags = OptFlags::WRAP;
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -1,8 +1,31 @@
 //! Window options.
 
+use bitflags::bitflags;
+use std::fmt::Debug;
+
 pub const WRAP: bool = true;
 pub const LINE_BREAK: bool = false;
 pub const SCROLL_OFF: u8 = 0;
+
+bitflags! {
+  #[derive(Copy, Clone)]
+  struct OptFlags: u8 {
+    const WRAP = 1;
+    const LINE_BREAK = 1 << 1;
+  }
+}
+
+impl Debug for OptFlags {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("OptFlags")
+      .field("bits", &format!("{:b}", self.bits()))
+      .finish()
+  }
+}
+
+#[allow(dead_code)]
+// expand_tab
+const OPT_FLAGS: OptFlags = OptFlags::WRAP;
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Window local options.

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -9,13 +9,13 @@ pub const SCROLL_OFF: u8 = 0;
 
 bitflags! {
   #[derive(Copy, Clone)]
-  struct OptFlags: u8 {
+  struct Flags: u8 {
     const WRAP = 1;
     const LINE_BREAK = 1 << 1;
   }
 }
 
-impl Debug for OptFlags {
+impl Debug for Flags {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("OptFlags")
       .field("bits", &format!("{:b}", self.bits()))
@@ -26,16 +26,16 @@ impl Debug for OptFlags {
 #[allow(dead_code)]
 // wrap=true
 // line_break=false
-const OPT_FLAGS: OptFlags = OptFlags::WRAP;
+const FLAGS: Flags = Flags::WRAP;
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Window local options.
 pub struct WindowOptions {
-  #[builder(default = OPT_FLAGS)]
+  #[builder(default = FLAGS)]
   #[builder(setter(custom))]
   // wrap
   // line_break
-  flags: OptFlags,
+  flags: Flags,
 
   #[builder(default = SCROLL_OFF)]
   scroll_off: u8,
@@ -45,12 +45,12 @@ impl WindowOptionsBuilder {
   pub fn wrap(&mut self, value: bool) -> &mut Self {
     let mut flags = match self.flags {
       Some(flags) => flags,
-      None => OPT_FLAGS,
+      None => FLAGS,
     };
     if value {
-      flags.insert(OptFlags::WRAP);
+      flags.insert(Flags::WRAP);
     } else {
-      flags.remove(OptFlags::WRAP);
+      flags.remove(Flags::WRAP);
     }
     self.flags = Some(flags);
     self
@@ -59,12 +59,12 @@ impl WindowOptionsBuilder {
   pub fn line_break(&mut self, value: bool) -> &mut Self {
     let mut flags = match self.flags {
       Some(flags) => flags,
-      None => OPT_FLAGS,
+      None => FLAGS,
     };
     if value {
-      flags.insert(OptFlags::LINE_BREAK);
+      flags.insert(Flags::LINE_BREAK);
     } else {
-      flags.remove(OptFlags::LINE_BREAK);
+      flags.remove(Flags::LINE_BREAK);
     }
     self.flags = Some(flags);
     self
@@ -76,14 +76,14 @@ impl WindowOptions {
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27wrap%27>.
   pub fn wrap(&self) -> bool {
-    self.flags.contains(OptFlags::WRAP)
+    self.flags.contains(Flags::WRAP)
   }
 
   pub fn set_wrap(&mut self, value: bool) {
     if value {
-      self.flags.insert(OptFlags::WRAP);
+      self.flags.insert(Flags::WRAP);
     } else {
-      self.flags.remove(OptFlags::WRAP);
+      self.flags.remove(Flags::WRAP);
     }
   }
 
@@ -91,14 +91,14 @@ impl WindowOptions {
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27linebreak%27>.
   pub fn line_break(&self) -> bool {
-    self.flags.contains(OptFlags::LINE_BREAK)
+    self.flags.contains(Flags::LINE_BREAK)
   }
 
   pub fn set_line_break(&mut self, value: bool) {
     if value {
-      self.flags.insert(OptFlags::LINE_BREAK);
+      self.flags.insert(Flags::LINE_BREAK);
     } else {
-      self.flags.remove(OptFlags::LINE_BREAK);
+      self.flags.remove(Flags::LINE_BREAK);
     }
   }
 

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -41,7 +41,7 @@ pub struct WindowOptions {
 }
 
 impl WindowOptionsBuilder {
-  pub fn wrap(&mut self, value: bool) {
+  pub fn wrap(&mut self, value: bool) -> &mut Self {
     let mut flags = match self.flags {
       Some(flags) => flags,
       None => OPT_FLAGS,
@@ -52,9 +52,10 @@ impl WindowOptionsBuilder {
       flags.remove(OptFlags::WRAP);
     }
     self.flags = Some(flags);
+    self
   }
 
-  pub fn line_break(&mut self, value: bool) {
+  pub fn line_break(&mut self, value: bool) -> &mut Self {
     let mut flags = match self.flags {
       Some(flags) => flags,
       None => OPT_FLAGS,
@@ -65,6 +66,7 @@ impl WindowOptionsBuilder {
       flags.remove(OptFlags::LINE_BREAK);
     }
     self.flags = Some(flags);
+    self
   }
 }
 

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -17,7 +17,7 @@ bitflags! {
 
 impl Debug for Flags {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("OptFlags")
+    f.debug_struct("Flags")
       .field("bits", &format!("{:b}", self.bits()))
       .finish()
   }

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -24,20 +24,48 @@ impl Debug for OptFlags {
 }
 
 #[allow(dead_code)]
-// expand_tab
+// wrap
+// line_break
 const OPT_FLAGS: OptFlags = OptFlags::WRAP;
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
 /// Window local options.
 pub struct WindowOptions {
-  #[builder(default = WRAP)]
-  wrap: bool,
-
-  #[builder(default = LINE_BREAK)]
-  line_break: bool,
+  #[builder(setter(custom))]
+  // wrap
+  // line_break
+  flags: OptFlags,
 
   #[builder(default = SCROLL_OFF)]
   scroll_off: u8,
+}
+
+impl WindowOptionsBuilder {
+  pub fn wrap(&mut self, value: bool) {
+    let mut flags = match self.flags {
+      Some(flags) => flags,
+      None => OPT_FLAGS,
+    };
+    if value {
+      flags.insert(OptFlags::WRAP);
+    } else {
+      flags.remove(OptFlags::WRAP);
+    }
+    self.flags = Some(flags);
+  }
+
+  pub fn line_break(&mut self, value: bool) {
+    let mut flags = match self.flags {
+      Some(flags) => flags,
+      None => OPT_FLAGS,
+    };
+    if value {
+      flags.insert(OptFlags::LINE_BREAK);
+    } else {
+      flags.remove(OptFlags::LINE_BREAK);
+    }
+    self.flags = Some(flags);
+  }
 }
 
 impl WindowOptions {
@@ -45,22 +73,30 @@ impl WindowOptions {
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27wrap%27>.
   pub fn wrap(&self) -> bool {
-    self.wrap
+    self.flags.contains(OptFlags::WRAP)
   }
 
   pub fn set_wrap(&mut self, value: bool) {
-    self.wrap = value;
+    if value {
+      self.flags.insert(OptFlags::WRAP);
+    } else {
+      self.flags.remove(OptFlags::WRAP);
+    }
   }
 
   /// The 'line-break' option, also known as 'word-wrap', default to `false`.
   ///
   /// See: <https://vimhelp.org/options.txt.html#%27linebreak%27>.
   pub fn line_break(&self) -> bool {
-    self.line_break
+    self.flags.contains(OptFlags::LINE_BREAK)
   }
 
   pub fn set_line_break(&mut self, value: bool) {
-    self.line_break = value;
+    if value {
+      self.flags.insert(OptFlags::LINE_BREAK);
+    } else {
+      self.flags.remove(OptFlags::LINE_BREAK);
+    }
   }
 
   /// The 'scroll-off' option, default to `0`.


### PR DESCRIPTION
Related issue: #700 

Use "bitflags" instead of multiple booleans to reduce memory footprint, but this brings complexity for the code base, I actually doubt how much memory it would save compared with its tech debt. 