### PR TITLE
refactor(opts): use paste! lower/upper/camel to reduce duplicated macro arguments

### DIFF
--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -49,13 +49,7 @@ pub struct BufferOptions {
   file_format: FileFormatOption,
 }
 
-flags_builder_impl!(
-  BufferOptionsBuilder,
-  flags,
-  FLAGS,
-  expand_tab,
-  Flags::EXPAND_TAB
-);
+flags_builder_impl!(BufferOptionsBuilder, flags, Flags, expand_tab);
 
 impl BufferOptions {
   /// Buffer 'tab-stop' option.

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -49,7 +49,7 @@ pub struct BufferOptions {
   file_format: FileFormatOption,
 }
 
-flags_builder_impl!(BufferOptionsBuilder, flags, Flags, expand_tab);
+flags_builder_impl!(BufferOptionsBuilder, flags, expand_tab);
 
 impl BufferOptions {
   /// Buffer 'tab-stop' option.

--- a/rsvim_core/src/js/command/attr.rs
+++ b/rsvim_core/src/js/command/attr.rs
@@ -65,7 +65,7 @@ pub struct CommandAttributes {
   nargs: Nargs,
 }
 
-flags_builder_impl!(CommandAttributesBuilder, flags, FLAGS, bang, Flags::BANG);
+flags_builder_impl!(CommandAttributesBuilder, flags, bang);
 
 impl CommandAttributes {
   pub fn bang(&self) -> bool {

--- a/rsvim_core/src/js/command/opt.rs
+++ b/rsvim_core/src/js/command/opt.rs
@@ -29,7 +29,7 @@ pub struct CommandOptions {
   alias: Option<CompactString>,
 }
 
-flags_builder_impl!(CommandOptionsBuilder, flags, FLAGS, force, Flags::FORCE);
+flags_builder_impl!(CommandOptionsBuilder, flags, force);
 
 impl CommandOptions {
   pub fn force(&self) -> bool {

--- a/rsvim_core/src/ui/widget/window/opt.rs
+++ b/rsvim_core/src/ui/widget/window/opt.rs
@@ -26,15 +26,7 @@ pub struct WindowOptions {
   scroll_off: u8,
 }
 
-flags_builder_impl!(
-  WindowOptionsBuilder,
-  flags,
-  FLAGS,
-  wrap,
-  Flags::WRAP,
-  line_break,
-  Flags::LINE_BREAK
-);
+flags_builder_impl!(WindowOptionsBuilder, flags, wrap, line_break);
 
 impl WindowOptions {
   /// The 'wrap' option, also known as 'line-wrap', default to `true`.

--- a/rsvim_core/src/util/flag.rs
+++ b/rsvim_core/src/util/flag.rs
@@ -32,14 +32,14 @@ macro_rules! flags_impl {
 
 #[macro_export]
 macro_rules! flags_builder_impl {
-  ($builder:ident,$member:ident,$flags:ident,$($field:ident),+) => {
+  ($builder:ident,$flags:tt,$($field:ident),+) => {
     paste::paste! {
       impl $builder {
         $(
           pub fn $field(&mut self, value: bool) -> &mut Self {
-            let mut flags = self.$member.unwrap_or( [< $member:upper >] );
-            flags.set( [<  $flags :: $field:upper >] , value);
-            self.$member = Some(flags);
+            let mut flags = self.$flags.unwrap_or( [< $flags:upper >] );
+            flags.set( [< $flags:camel >]::[<  $field:upper >] , value);
+            self.$flags = Some(flags);
             self
           }
         )+

--- a/rsvim_core/src/util/flag.rs
+++ b/rsvim_core/src/util/flag.rs
@@ -32,7 +32,7 @@ macro_rules! flags_impl {
 
 #[macro_export]
 macro_rules! flags_builder_impl {
-  ($builder:ident,$flags:tt,$($field:ident),+) => {
+  ($builder:ident,$flags:ident,$($field:ident),+) => {
     paste::paste! {
       impl $builder {
         $(

--- a/rsvim_core/src/util/flag.rs
+++ b/rsvim_core/src/util/flag.rs
@@ -32,16 +32,18 @@ macro_rules! flags_impl {
 
 #[macro_export]
 macro_rules! flags_builder_impl {
-  ($builder:ident,$field:ident,$default:expr,$($lower:tt,$upper:path),+) => {
-    impl $builder {
-      $(
-        pub fn $lower(&mut self, value: bool) -> &mut Self {
-          let mut flags = self.$field.unwrap_or($default);
-          flags.set($upper, value);
-          self.$field = Some(flags);
-          self
-        }
-      )+
+  ($builder:ident,$member:ident,$flags:ident,$($field:ident),+) => {
+    paste::paste! {
+      impl $builder {
+        $(
+          pub fn $field(&mut self, value: bool) -> &mut Self {
+            let mut flags = self.$member.unwrap_or( [< $member:upper >] );
+            flags.set( [<  $flags :: $field:upper >] , value);
+            self.$member = Some(flags);
+            self
+          }
+        )+
+      }
     }
   }
 }


### PR DESCRIPTION
Follow up of #723 