### PR TITLE
build(win): remove "symbol-mangling-version=v0" for windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,17 +1,10 @@
 [target.x86_64-pc-windows-msvc]
-rustflags = [
-  "-C",
-  "target-feature=+crt-static",
-  "-C",
-  "symbol-mangling-version=v0",
-]
+rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.'cfg(all(windows, debug_assertions))']
 rustflags = [
   "-C",
   "target-feature=+crt-static",
-  "-C",
-  "symbol-mangling-version=v0",
   "-C",
   # increase the stack size to prevent overflowing the
   # stack in debug when launching sub commands

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,6 @@ jobs:
       matrix:
         os: [ubuntu-22.04-arm, macos-15-intel, windows-11-arm]
     runs-on: ${{ matrix.os }}
-    env:
-      # Relate issue: https://github.com/denoland/rusty_v8/issues/1849
-      RUSTFLAGS: >-
-        -Dwarnings ${{ contains(matrix.os, 'windows') && '-Csymbol-mangling-version=v0' || '' }}
     steps:
       - uses: Swatinem/rust-cache@v2
       - uses: davidlattimore/wild-action@latest
@@ -105,10 +101,6 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-15, windows-2022]
     runs-on: ${{ matrix.os }}
-    env:
-      # Relate issue: https://github.com/denoland/rusty_v8/issues/1849
-      RUSTFLAGS: >-
-        -Dwarnings ${{ contains(matrix.os, 'windows') && '-Csymbol-mangling-version=v0' || '' }}
     steps:
       - uses: Swatinem/rust-cache@v2
       - uses: davidlattimore/wild-action@latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,9 +40,6 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     env:
-      # Relate issue: https://github.com/denoland/rusty_v8/issues/1849
-      RUSTFLAGS: >-
-        ${{ contains(matrix.os, 'windows') && '-Csymbol-mangling-version=v0 -Ctarget-feature=+crt-static ' || '' }}
       BIN_EXT: ${{ contains(matrix.os, 'windows') && '.exe' || '' }}
     needs: prepare
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,6 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     env:
-      # Relate issue: https://github.com/denoland/rusty_v8/issues/1849
-      RUSTFLAGS: >-
-        ${{ contains(matrix.os, 'windows') && '-Csymbol-mangling-version=v0 -Ctarget-feature=+crt-static ' || '' }}
       BIN_EXT: ${{ contains(matrix.os, 'windows') && '.exe' || '' }}
     needs: prepare
     strategy:

--- a/dev.py
+++ b/dev.py
@@ -72,8 +72,6 @@ def _linker():
 
 def rustflags():
     flags = ["-Dwarnings"]
-    if WINDOWS:
-        flags.append("-Csymbol-mangling-version=v0")
     linker_flags = _linker()
     if linker_flags is not None:
         flags.append(linker_flags)


### PR DESCRIPTION
Flag "-Csymbol-mangling-version=v0" is first introduced in #640 , it bumps rusty_v8 to v140.0.0, but that version contains a bug: https://github.com/denoland/rusty_v8/issues/1849. This flag fixes that issue.

This issue disappears in latest rusty_v8 v147.0.0, so we can remove this flag.