### PR TITLE
refactor(syn): use "parser-lib-path" option when building tree-sitter parsers

### DIFF
--- a/rsvim_core/Cargo.toml
+++ b/rsvim_core/Cargo.toml
@@ -116,12 +116,7 @@ tokio = { workspace = true, features = [
 tokio-util = { workspace = true, features = ["full"] }
 toml = { workspace = true, features = ["fast_hash"] }
 tree-sitter = { workspace = true }
-tree-sitter-c = { workspace = true }
-tree-sitter-html = { workspace = true }
 tree-sitter-loader = { workspace = true }
-tree-sitter-md = { workspace = true }
-tree-sitter-rust = { workspace = true }
-tree-sitter-toml-ng = { workspace = true }
 
 # NOTE: Javascript dependencies {
 
@@ -169,6 +164,11 @@ bitflags = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 fastrand = { workspace = true }
 regex = { workspace = true }
+tree-sitter-c = { workspace = true }
+tree-sitter-html = { workspace = true }
+tree-sitter-md = { workspace = true }
+tree-sitter-rust = { workspace = true }
+tree-sitter-toml-ng = { workspace = true }
 unicode-width = { workspace = true }
 
 [lints]

--- a/rsvim_core/src/buf/opt.rs
+++ b/rsvim_core/src/buf/opt.rs
@@ -1,4 +1,4 @@
-//! Vim buffer options.
+//! Buffer options.
 
 pub mod file_encoding;
 pub mod file_format;
@@ -23,7 +23,7 @@ pub const FILE_FORMAT: FileFormatOption = FileFormatOption::Unix;
 pub const FIX_END_OF_LINE: bool = true;
 
 #[derive(Debug, Copy, Clone, derive_builder::Builder)]
-/// Local buffer options.
+/// Buffer options.
 pub struct BufferOptions {
   #[builder(default = EXPAND_TAB)]
   expand_tab: bool,

--- a/rsvim_core/src/chan/jsrt.rs
+++ b/rsvim_core/src/chan/jsrt.rs
@@ -88,7 +88,7 @@ pub struct FsWriteResp {
 pub struct LoadTreeSitterGrammarResp {
   pub task_id: TaskId,
 
-  // type: `String`
+  // type: `Vec<String>`
   pub maybe_result: Option<TheResult<Vec<u8>>>,
 }
 

--- a/rsvim_core/src/err.rs
+++ b/rsvim_core/src/err.rs
@@ -38,11 +38,11 @@ pub enum TheErr {
   #[error("Failed to load syntax for language {0}: {1}.")]
   LoadSyntaxFailed(CompactString, LanguageError),
 
-  #[error("Failed to load tree-sitter grammar {0}: {1}.")]
-  LoadTreeSitterGrammarFailed(CompactString, LoaderError),
+  #[error("Failed to load tree-sitter parser {0}: {1}.")]
+  LoadTreeSitterParserFailed(CompactString, LoaderError),
 
-  #[error("Tree-sitter grammar not found: {0}.")]
-  TreeSitterGrammarNotFound(CompactString),
+  #[error("Tree-sitter parser not found: {0}.")]
+  TreeSitterParserNotFound(CompactString),
 
   #[error("Failed to load colorscheme: {0}.")]
   LoadColorSchemeFailed(CompactString),

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -953,12 +953,17 @@ impl EventLoop {
                     grammar_metainfo.injection_regex.map(|inj| inj.to_string()),
                   );
                 }
+                let grammar_names = metainfo
+                  .grammars
+                  .iter()
+                  .map(|gm| gm.name.to_string())
+                  .collect_vec();
                 jsrt_forwarder_tx
                   .send(JsMessage::LoadTreeSitterGrammarResp(
                     chan::LoadTreeSitterGrammarResp {
                       task_id: req.task_id,
                       maybe_result: Some(Ok(
-                        postcard::to_allocvec(&metainfo.to_string()).unwrap(),
+                        postcard::to_allocvec(&grammar_names).unwrap(),
                       )),
                     },
                   ))

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -41,6 +41,7 @@ use crate::ui::tree::*;
 use crate::ui::widget::WidgetContext;
 use crossterm::event::Event;
 use crossterm::event::EventStream;
+use fern::meta;
 use futures::StreamExt;
 use itertools::Itertools;
 use std::sync::Arc;
@@ -934,11 +935,23 @@ impl EventLoop {
             let load_result = syn_loader.async_load_grammar(load_req).await;
             match load_result {
               Ok((metainfo, grammar)) => {
-                lock!(syn_manager).insert_grammar(
-                  metainfo.clone(),
-                  grammar,
-                  None,
-                );
+                for grammar_metainfo in metainfo.grammars.iter() {
+                  let highlight_query = match grammar_metainfo.highlights {
+                    Some(highlights) => {
+                      tokio::fs::read_to_string(highlights).await.ok()
+                    }
+                    None => None,
+                  };
+                  let tags_query = match grammar_metainfo.tags {
+                    Some(tags) => tokio::fs::read_to_string(tags).await.ok(),
+                    None => None,
+                  };
+                  lock!(syn_manager).insert_grammar(
+                    grammar_metainfo.name.clone(),
+                    grammar,
+                    None,
+                  );
+                }
                 jsrt_forwarder_tx
                   .send(JsMessage::LoadTreeSitterGrammarResp(
                     chan::LoadTreeSitterGrammarResp {

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -924,38 +924,16 @@ impl EventLoop {
         MasterMessage::LoadTreeSitterGrammarReq(req) => {
           trace!("Recv LoadTreeSitterGrammarReq:{:?}", req.task_id);
           let syn_manager = self.syntax_manager.clone();
-          let syn_loader = lock!(syn_manager).loader();
           let jsrt_forwarder_tx = self.jsrt_forwarder_tx.clone();
 
           self.detached_tracker.spawn(async move {
             let load_req = SyntaxLoadGrammarRequest {
               grammar_path: req.grammar_path,
             };
-            let load_result = syn_loader.async_load_grammar(load_req).await;
+            let load_result =
+              syntax::async_load_syntax_grammar(syn_manager, load_req).await;
             match load_result {
-              Ok((metainfo, grammar)) => {
-                for grammar_metainfo in metainfo.grammars.iter() {
-                  let highlight_query = match &grammar_metainfo.highlights {
-                    Some(highlights) => {
-                      tokio::fs::read_to_string(highlights).await.ok()
-                    }
-                    None => None,
-                  };
-                  let tags_query = match &grammar_metainfo.tags {
-                    Some(tags) => tokio::fs::read_to_string(tags).await.ok(),
-                    None => None,
-                  };
-                  lock!(syn_manager).insert_grammar(
-                    grammar_metainfo.name.clone(),
-                    grammar.clone(),
-                    highlight_query,
-                    tags_query,
-                    grammar_metainfo
-                      .injection_regex
-                      .as_ref()
-                      .map(|inj| inj.to_string()),
-                  );
-                }
+              Ok(metainfo) => {
                 let grammar_names = metainfo
                   .grammars
                   .iter()

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -948,7 +948,9 @@ impl EventLoop {
                   lock!(syn_manager).insert_grammar(
                     grammar_metainfo.name.clone(),
                     grammar,
-                    None,
+                    highlight_query,
+                    tags_query,
+                    grammar_metainfo.injection_regex.map(|inj| inj.to_string()),
                   );
                 }
                 jsrt_forwarder_tx

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -935,19 +935,19 @@ impl EventLoop {
             match load_result {
               Ok((metainfo, grammar)) => {
                 for grammar_metainfo in metainfo.grammars.iter() {
-                  let highlight_query = match grammar_metainfo.highlights {
+                  let highlight_query = match &grammar_metainfo.highlights {
                     Some(highlights) => {
                       tokio::fs::read_to_string(highlights).await.ok()
                     }
                     None => None,
                   };
-                  let tags_query = match grammar_metainfo.tags {
+                  let tags_query = match &grammar_metainfo.tags {
                     Some(tags) => tokio::fs::read_to_string(tags).await.ok(),
                     None => None,
                   };
                   lock!(syn_manager).insert_grammar(
                     grammar_metainfo.name.clone(),
-                    grammar,
+                    grammar.clone(),
                     highlight_query,
                     tags_query,
                     grammar_metainfo.injection_regex.map(|inj| inj.to_string()),

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -924,19 +924,18 @@ impl EventLoop {
         MasterMessage::LoadTreeSitterGrammarReq(req) => {
           trace!("Recv LoadTreeSitterGrammarReq:{:?}", req.task_id);
           let syn_manager = self.syntax_manager.clone();
-          let syn_loader = lock!(syn_manager).loader();
+          let syn_loader = lock!(syn_manager).loader().clone();
           let jsrt_forwarder_tx = self.jsrt_forwarder_tx.clone();
 
           self.detached_tracker.spawn(async move {
             let load_req = SyntaxLoadGrammarRequest {
               grammar_path: req.grammar_path,
             };
-            let load_result =
-              lock!(syn_loader).async_load_grammar(load_req).await;
+            let load_result = syn_loader.async_load_grammar(load_req).await;
             match load_result {
-              Ok((grammar_id, grammar)) => {
+              Ok((metainfo, grammar)) => {
                 lock!(syn_manager).insert_grammar(
-                  grammar_id.clone(),
+                  metainfo.clone(),
                   grammar,
                   None,
                 );
@@ -945,7 +944,7 @@ impl EventLoop {
                     chan::LoadTreeSitterGrammarResp {
                       task_id: req.task_id,
                       maybe_result: Some(Ok(
-                        postcard::to_allocvec(&grammar_id.to_string()).unwrap(),
+                        postcard::to_allocvec(&metainfo.to_string()).unwrap(),
                       )),
                     },
                   ))

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -923,17 +923,23 @@ impl EventLoop {
         }
         MasterMessage::LoadTreeSitterGrammarReq(req) => {
           trace!("Recv LoadTreeSitterGrammarReq:{:?}", req.task_id);
-          let syn_loader = lock!(self.syntax_manager).loader();
+          let syn_manager = self.syntax_manager.clone();
+          let syn_loader = lock!(syn_manager).loader();
           let jsrt_forwarder_tx = self.jsrt_forwarder_tx.clone();
 
           self.detached_tracker.spawn(async move {
             let load_req = SyntaxLoadGrammarRequest {
               grammar_path: req.grammar_path,
             };
-            let loaded_grammar =
-              syntax::async_load_grammar(syn_loader, load_req).await;
-            match loaded_grammar {
-              Ok(grammar_id) => {
+            let load_result =
+              lock!(syn_loader).async_load_grammar(load_req).await;
+            match load_result {
+              Ok((grammar_id, grammar)) => {
+                lock!(syn_manager).insert_grammar(
+                  grammar_id.clone(),
+                  grammar,
+                  None,
+                );
                 jsrt_forwarder_tx
                   .send(JsMessage::LoadTreeSitterGrammarResp(
                     chan::LoadTreeSitterGrammarResp {

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -950,7 +950,10 @@ impl EventLoop {
                     grammar.clone(),
                     highlight_query,
                     tags_query,
-                    grammar_metainfo.injection_regex.map(|inj| inj.to_string()),
+                    grammar_metainfo
+                      .injection_regex
+                      .as_ref()
+                      .map(|inj| inj.to_string()),
                   );
                 }
                 let grammar_names = metainfo

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -924,7 +924,7 @@ impl EventLoop {
         MasterMessage::LoadTreeSitterGrammarReq(req) => {
           trace!("Recv LoadTreeSitterGrammarReq:{:?}", req.task_id);
           let syn_manager = self.syntax_manager.clone();
-          let syn_loader = lock!(syn_manager).loader().clone();
+          let syn_loader = lock!(syn_manager).loader();
           let jsrt_forwarder_tx = self.jsrt_forwarder_tx.clone();
 
           self.detached_tracker.spawn(async move {

--- a/rsvim_core/src/evloop.rs
+++ b/rsvim_core/src/evloop.rs
@@ -41,7 +41,6 @@ use crate::ui::tree::*;
 use crate::ui::widget::WidgetContext;
 use crossterm::event::Event;
 use crossterm::event::EventStream;
-use fern::meta;
 use futures::StreamExt;
 use itertools::Itertools;
 use std::sync::Arc;

--- a/rsvim_core/src/js/binding/global_rsvim/syn.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/syn.rs
@@ -9,7 +9,6 @@ use crate::js::converter::*;
 use crate::js::pending;
 use crate::prelude::*;
 use crate::syntax::SyntaxLoadGrammarRequest;
-use crate::syntax::load_grammar;
 pub use load::SynLoadTreeSitterGrammarFuture;
 pub use load::SynLoadTreeSitterGrammarOptions;
 
@@ -33,9 +32,17 @@ pub fn load_treesitter_grammar_sync<'s>(
     grammar_path: Path::new(&options.grammar_path).to_path_buf(),
   };
 
-  match load_grammar(syn_loader, req) {
-    Ok(grammar_id) => {
-      rv.set(v8::String::new(scope, &grammar_id).unwrap().into());
+  match syn_loader.load_grammar(req) {
+    Ok((metainfo, _grammar)) => {
+      let grammar_names = metainfo
+        .grammars
+        .iter()
+        .map(|gm| gm.name.to_string())
+        .collect::<Vec<String>>()
+        .to_v8(scope, |scope, grammar_name| {
+          grammar_name.to_v8(scope).into()
+        });
+      rv.set(grammar_names.into());
     }
     Err(e) => {
       binding::throw_exception(scope, &e);

--- a/rsvim_core/src/js/binding/global_rsvim/syn.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/syn.rs
@@ -8,6 +8,7 @@ use crate::js::binding;
 use crate::js::converter::*;
 use crate::js::pending;
 use crate::prelude::*;
+use crate::syntax;
 use crate::syntax::SyntaxLoadGrammarRequest;
 pub use load::SynLoadTreeSitterGrammarFuture;
 pub use load::SynLoadTreeSitterGrammarOptions;
@@ -27,13 +28,12 @@ pub fn load_treesitter_grammar_sync<'s>(
 
   let state_rc = JsRuntime::state(scope);
   let state = state_rc.borrow();
-  let syn_loader = lock!(state.syntax_manager).loader();
+
   let req = SyntaxLoadGrammarRequest {
     grammar_path: Path::new(&options.grammar_path).to_path_buf(),
   };
-
-  match syn_loader.load_grammar(req) {
-    Ok((metainfo, _grammar)) => {
+  match syntax::load_syntax_grammar(state.syntax_manager.clone(), req) {
+    Ok(metainfo) => {
       let grammar_names = metainfo
         .grammars
         .iter()

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -500,7 +500,7 @@ impl SyntaxLoader {
     let compile_cfg =
       CompileConfig::new(metainfo.src_path.as_path(), None, None);
     match lock!(self.loader).load_language_at_path(compile_cfg) {
-      Ok(grammar) => Ok((metainfo, Arc::new(grammar))),
+      Ok(grammar) => Ok((metainfo, grammar)),
       Err(e) => Err(TheErr::LoadTreeSitterParserFailed(
         req.grammar_path.to_string_lossy().to_compact_string(),
         e,

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -334,20 +334,6 @@ pub struct SyntaxLoadGrammarRequest {
   pub grammar_path: PathBuf,
 }
 
-impl SyntaxLoadGrammarRequest {
-  pub fn src_path(&self) -> PathBuf {
-    self.grammar_path.join("src")
-  }
-
-  pub fn queries_path(&self) -> PathBuf {
-    self.grammar_path.join("queries")
-  }
-
-  pub fn grammar_json_path(&self) -> PathBuf {
-    self.src_path().join("grammar.json")
-  }
-}
-
 impl SyntaxLoader {
   pub fn new() -> Self {
     let parser_lib_path =
@@ -400,11 +386,11 @@ struct SyntaxTreeSitterMetainfo {
 }
 
 impl SyntaxLoader {
-  pub fn grammar_metainfo(
+  pub fn parse_treesitter_metainfo(
     grammar_path: &Path,
   ) -> TheResult<SyntaxTreeSitterMetainfo> {
     let err = || {
-      TheErr::TreeSitterGrammarNotFound(
+      TheErr::TreeSitterParserNotFound(
         grammar_path.to_string_lossy().to_compact_string(),
       )
     };
@@ -494,7 +480,7 @@ impl SyntaxLoader {
     let grammar_json_path = req.grammar_json_path();
     let grammar_json_path = grammar_json_path.as_path();
     let err = || {
-      TheErr::TreeSitterGrammarNotFound(
+      TheErr::TreeSitterParserNotFound(
         grammar_json_path.to_string_lossy().to_compact_string(),
       )
     };
@@ -516,18 +502,16 @@ impl SyntaxLoader {
     &mut self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
-    /* grammar_id */ CompactString,
+    /* metainfo */ SyntaxTreeSitterMetainfo,
     /* grammar */ Language,
-    /* highlight_query */ Option<String>,
   )> {
-    let src_path = req.src_path();
-    let src_path = src_path.as_path();
-    let grammar_id = Self::get_grammar_name_from_src_path(&req)?;
-    let compile_cfg = CompileConfig::new(src_path, None, None);
+    let metainfo = Self::parse_treesitter_metainfo(req.grammar_path.as_path())?;
+    let compile_cfg =
+      CompileConfig::new(metainfo.src_path.as_path(), None, None);
     match lock!(self.loader).load_language_at_path(compile_cfg) {
-      Ok(grammar) => Ok((grammar_id, grammar, None)),
-      Err(e) => Err(TheErr::LoadTreeSitterGrammarFailed(
-        grammar_id.to_compact_string(),
+      Ok(grammar) => Ok((metainfo, grammar)),
+      Err(e) => Err(TheErr::LoadTreeSitterParserFailed(
+        req.grammar_path.to_string_lossy().to_compact_string(),
         e,
       )),
     }

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -316,11 +316,15 @@ impl Syntax {
   }
 }
 
-pub struct SyntaxLoader {
-  loader: Loader,
-}
+pub type TreeSitterLoaderArc = Arc<Mutex<Loader>>;
+pub type TreeSitterLoaderWk = Weak<Mutex<Loader>>;
+pub type TreeSitterLoaderMutexGuard<'a> = MutexGuard<'a, Loader>;
 
-arc_mutex_ptr!(SyntaxLoader);
+#[derive(Clone)]
+pub struct SyntaxLoader {
+  loader: TreeSitterLoaderArc,
+  parser_lib_path: PathBuf,
+}
 
 #[derive(Debug, Clone)]
 pub struct SyntaxLoadGrammarRequest {
@@ -342,23 +346,27 @@ impl SyntaxLoader {
     let parser_lib_path =
       PATH_CONFIG.config_home().join(".tree-sitter-parsers");
     Self {
-      loader: Loader::with_parser_lib_path(parser_lib_path),
+      loader: Arc::new(Mutex::new(Loader::with_parser_lib_path(
+        parser_lib_path.clone(),
+      ))),
+      parser_lib_path,
     }
   }
 
-  pub fn treesitter_parser_lib_path(&self) -> PathBuf {
-    self.loader.parser_lib_path.clone()
+  pub fn treesitter_parser_lib_path(&self) -> &PathBuf {
+    &self.parser_lib_path
   }
 
   pub fn set_treesitter_parser_lib_path(&mut self, parser_lib_path: PathBuf) {
-    self.loader.parser_lib_path = parser_lib_path;
+    lock!(self.loader).parser_lib_path = parser_lib_path.clone();
+    self.parser_lib_path = parser_lib_path;
   }
 }
 
 impl Debug for SyntaxLoader {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("SyntaxLoader")
-      .field("parser_lib_path", &self.loader.parser_lib_path)
+      .field("parser_lib_path", &self.parser_lib_path)
       .finish()
   }
 }

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -6,6 +6,9 @@ use crate::prelude::*;
 use crate::structural_id_impl;
 use compact_str::CompactString;
 use compact_str::ToCompactString;
+use itertools::Itertools;
+use itertools::process_results;
+use normpath::PathExt;
 use ropey::Rope;
 use std::cmp::Ordering;
 use std::fmt::Debug;
@@ -336,6 +339,10 @@ impl SyntaxLoadGrammarRequest {
     self.grammar_path.join("src")
   }
 
+  pub fn queries_path(&self) -> PathBuf {
+    self.grammar_path.join("queries")
+  }
+
   pub fn grammar_json_path(&self) -> PathBuf {
     self.src_path().join("grammar.json")
   }
@@ -371,7 +378,106 @@ impl Debug for SyntaxLoader {
   }
 }
 
+#[derive(Debug, Clone)]
+struct SyntaxTreeSitterGrammarMetainfo {
+  pub name: CompactString,
+  pub camelcase: CompactString,
+  pub scope: CompactString,
+  pub path: PathBuf,
+  pub file_types: Vec<CompactString>,
+  pub highlights: Option<PathBuf>,
+  pub tags: Option<PathBuf>,
+  pub injection_regex: Option<CompactString>,
+}
+
+#[derive(Debug, Clone)]
+struct SyntaxTreeSitterMetainfo {
+  pub grammar_path: PathBuf,
+
+  pub grammars: Vec<SyntaxTreeSitterGrammarMetainfo>,
+
+  pub metadata_version: CompactString,
+  pub metadata_repository: CompactString,
+
+  pub src_path: PathBuf,
+  pub tree_sitter_json_path: PathBuf,
+  pub grammar_json_path: PathBuf,
+}
+
 impl SyntaxLoader {
+  pub fn grammar_metainfo(
+    grammar_path: &Path,
+  ) -> TheResult<SyntaxTreeSitterMetainfo> {
+    let err = || {
+      TheErr::TreeSitterGrammarNotFound(
+        grammar_path.to_string_lossy().to_compact_string(),
+      )
+    };
+
+    let tree_sitter_json_path = grammar_path.join("tree-sitter.json");
+    let tree_sitter_json_text =
+      std::fs::read_to_string(tree_sitter_json_path).map_err(|_e| err())?;
+    let tree_sitter_json_data: serde_json::Value =
+      serde_json::from_str(&tree_sitter_json_text).map_err(|_e| err())?;
+
+    let tree_sitter_json_grammars = tree_sitter_json_data
+      .get("grammars")
+      .ok_or(err())?
+      .as_array()
+      .ok_or(err())?;
+
+    let mut grammars_metadata =
+      Vec::with_capacity(tree_sitter_json_grammars.len());
+    for grammar in tree_sitter_json_grammars {
+      let name = grammar.get("name").ok_or(err())?.as_str().ok_or(err())?;
+      let camelcase = grammar
+        .get("camelcase")
+        .ok_or(err())?
+        .as_str()
+        .ok_or(err())?;
+      let scope = grammar.get("scope").ok_or(err())?.as_str().ok_or(err())?;
+      let path = grammar.get("path").ok_or(err())?.as_str().ok_or(err())?;
+      let path = grammar_path.join(path).normalize().map_err(|_e| err())?;
+      let filetypes = grammar
+        .get("file-types")
+        .ok_or(err())?
+        .as_array()
+        .ok_or(err())?
+        .iter()
+        .map(|ft| ft.as_str().ok_or(err()));
+      let filetypes = process_results(filetypes, |ft| ft.collect_vec());
+      let highlights = grammar
+        .get("highlights")
+        .map(|hl| hl.as_str().ok_or(err()))
+        .transpose()?;
+      let highlights = highlights.map(|hl| Path::new(hl));
+      let tags = grammar
+        .get("tags")
+        .map(|tg| tg.as_str().ok_or(err()))
+        .transpose()?;
+      let tags = tags.map(|tg| Path::new(tg));
+      let injection_regex = grammar
+        .get("injection-regex")
+        .map(|tg| tg.as_str().ok_or(err()))
+        .transpose()?;
+      let grammar_metadata = SyntaxTreeSitterGrammarMetainfo {
+        name: name.to_compact_string(),
+        camelcase: camelcase.to_compact_string(),
+      };
+    }
+
+    let src_path = grammar_path.join("src");
+    let src_path = grammar_path.join("src");
+
+    pub fn queries_path(&self) -> PathBuf {
+      self.grammar_path.join("queries")
+    }
+
+    pub fn grammar_json_path(&self) -> PathBuf {
+      self.src_path().join("grammar.json")
+    }
+  }
+
   pub fn get_grammar_name_from_src_path(
     req: &SyntaxLoadGrammarRequest,
   ) -> TheResult<CompactString> {

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -320,11 +320,7 @@ pub type TreeSitterLoaderArc = Arc<Mutex<Loader>>;
 pub type TreeSitterLoaderWk = Weak<Mutex<Loader>>;
 pub type TreeSitterLoaderMutexGuard<'a> = MutexGuard<'a, Loader>;
 
-structural_id_impl!(usize, SyntaxLoaderId, 1);
-
 pub struct SyntaxLoader {
-  id: SyntaxLoaderId,
-
   loader: TreeSitterLoaderArc,
 
   // Loaded grammars/parsers
@@ -353,7 +349,6 @@ impl SyntaxLoader {
     let parser_lib_path =
       PATH_CONFIG.config_home().join(".tree-sitter-parsers");
     Self {
-      id: SyntaxLoaderId::next(),
       loader: Arc::new(Mutex::new(Loader::with_parser_lib_path(
         parser_lib_path,
       ))),
@@ -368,9 +363,7 @@ impl SyntaxLoader {
   /// NOTE: This will reset the tree-sitter loader and all loaded
   /// parsers/grammars.
   pub fn set_treesitter_parser_lib_path(&mut self, parser_lib_path: PathBuf) {
-    self.id = SyntaxLoaderId::next();
-    self.loader =
-      Arc::new(Mutex::new(Loader::with_parser_lib_path(parser_lib_path)));
+    lock!(self.loader).parser_lib_path = parser_lib_path;
     self.grammars.clear();
   }
 

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -493,7 +493,7 @@ impl SyntaxLoader {
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
     /* metainfo */ SyntaxTreeSitterGrammarMetainfo,
-    /* grammar */ TreeSitterLanguageArc,
+    /* grammar */ Language,
   )> {
     let metainfo =
       Self::parse_treesitter_grammar_metainfo(req.grammar_path.as_path())?;
@@ -513,20 +513,17 @@ impl SyntaxLoader {
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
     /* metainfo */ SyntaxTreeSitterGrammarMetainfo,
-    /* grammar */ TreeSitterLanguageArc,
+    /* grammar */ Language,
   )> {
     self.load_grammar(req)
   }
 }
 
-pub type TreeSitterLanguageArc = Arc<Language>;
-pub type TreeSitterLanguageWeak = Weak<Language>;
-
 pub struct SyntaxManager {
   loader: SyntaxLoader,
 
   // loaded_parsers: FoldMap<CompactString, SyntaxLoadedParser>,
-  grammars: FoldMap<CompactString, TreeSitterLanguageArc>,
+  grammars: FoldMap<CompactString, Language>,
   highlight_queries: FoldMap<CompactString, String>,
   tags_queries: FoldMap<CompactString, String>,
   injection_queries: FoldMap<CompactString, String>,
@@ -685,7 +682,7 @@ impl SyntaxManager {
   pub fn insert_grammar(
     &mut self,
     grammar_id: CompactString,
-    grammar: TreeSitterLanguageArc,
+    grammar: Language,
     highlight_query: Option<String>,
     tags_query: Option<String>,
     injection_query: Option<String>,

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -377,7 +377,7 @@ impl Debug for SyntaxLoader {
 }
 
 #[derive(Debug, Clone)]
-pub struct SyntaxTreeSitterGrammarMetainfoGrammar {
+pub struct SyntaxTreeSitterGrammarMetadataGrammar {
   pub name: CompactString,
   pub camelcase: CompactString,
   pub scope: CompactString,
@@ -389,17 +389,17 @@ pub struct SyntaxTreeSitterGrammarMetainfoGrammar {
 }
 
 #[derive(Debug, Clone)]
-pub struct SyntaxTreeSitterGrammarMetainfo {
-  pub grammars: Vec<SyntaxTreeSitterGrammarMetainfoGrammar>,
+pub struct SyntaxTreeSitterGrammarMetadata {
+  pub grammars: Vec<SyntaxTreeSitterGrammarMetadataGrammar>,
   pub grammar_path: PathBuf,
   pub src_path: PathBuf,
   pub grammar_json_path: PathBuf,
 }
 
 impl SyntaxLoader {
-  pub fn parse_treesitter_grammar_metainfo(
+  pub fn parse_treesitter_grammar_metadata(
     grammar_path: &Path,
-  ) -> TheResult<SyntaxTreeSitterGrammarMetainfo> {
+  ) -> TheResult<SyntaxTreeSitterGrammarMetadata> {
     let err = || {
       TheErr::TreeSitterParserNotFound(
         grammar_path.to_string_lossy().to_compact_string(),
@@ -474,7 +474,7 @@ impl SyntaxLoader {
         .map(|tg| tg.as_str().ok_or(err()))
         .transpose()?
         .map(|inj| inj.to_string());
-      let grammar_metainfo = SyntaxTreeSitterGrammarMetainfoGrammar {
+      let grammar_metainfo = SyntaxTreeSitterGrammarMetadataGrammar {
         name: name.to_compact_string(),
         camelcase: camelcase.to_compact_string(),
         scope: scope.to_compact_string(),
@@ -490,7 +490,7 @@ impl SyntaxLoader {
     let src_path = grammar_path.join("src");
     let grammar_json_path = src_path.join("grammar.json");
 
-    let metainfo = SyntaxTreeSitterGrammarMetainfo {
+    let metainfo = SyntaxTreeSitterGrammarMetadata {
       grammars: grammars_metainfo,
       grammar_path: grammar_path.to_path_buf(),
       src_path,
@@ -504,11 +504,11 @@ impl SyntaxLoader {
     &self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
-    /* metainfo */ SyntaxTreeSitterGrammarMetainfo,
+    /* metainfo */ SyntaxTreeSitterGrammarMetadata,
     /* grammar */ Language,
   )> {
     let metainfo =
-      Self::parse_treesitter_grammar_metainfo(req.grammar_path.as_path())?;
+      Self::parse_treesitter_grammar_metadata(req.grammar_path.as_path())?;
     let compile_cfg =
       CompileConfig::new(metainfo.src_path.as_path(), None, None);
     match lock!(self.loader).load_language_at_path(compile_cfg) {
@@ -524,7 +524,7 @@ impl SyntaxLoader {
     &self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
-    /* metainfo */ SyntaxTreeSitterGrammarMetainfo,
+    /* metainfo */ SyntaxTreeSitterGrammarMetadata,
     /* grammar */ Language,
   )> {
     self.load_grammar(req)
@@ -533,7 +533,7 @@ impl SyntaxLoader {
 
 fn save_loaded_grammars(
   syn_manager: &SyntaxManagerArc,
-  metainfo: &SyntaxTreeSitterGrammarMetainfo,
+  metainfo: &SyntaxTreeSitterGrammarMetadata,
   grammar: &Language,
 ) {
   for grammar_metainfo in metainfo.grammars.iter() {
@@ -560,7 +560,7 @@ fn save_loaded_grammars(
 
 async fn async_save_loaded_grammars(
   syn_manager: &SyntaxManagerArc,
-  metainfo: &SyntaxTreeSitterGrammarMetainfo,
+  metainfo: &SyntaxTreeSitterGrammarMetadata,
   grammar: &Language,
 ) {
   for grammar_metainfo in metainfo.grammars.iter() {
@@ -588,7 +588,7 @@ async fn async_save_loaded_grammars(
 pub fn load_syntax_grammar(
   syn_manager: SyntaxManagerArc,
   req: SyntaxLoadGrammarRequest,
-) -> TheResult<SyntaxTreeSitterGrammarMetainfo> {
+) -> TheResult<SyntaxTreeSitterGrammarMetadata> {
   let syn_loader = lock!(syn_manager).loader();
   let (metainfo, grammar) = syn_loader.load_grammar(req)?;
   save_loaded_grammars(&syn_manager, &metainfo, &grammar);
@@ -598,7 +598,7 @@ pub fn load_syntax_grammar(
 pub async fn async_load_syntax_grammar(
   syn_manager: SyntaxManagerArc,
   req: SyntaxLoadGrammarRequest,
-) -> TheResult<SyntaxTreeSitterGrammarMetainfo> {
+) -> TheResult<SyntaxTreeSitterGrammarMetadata> {
   let syn_loader = lock!(syn_manager).loader();
   let (metainfo, grammar) = syn_loader.async_load_grammar(req).await?;
   async_save_loaded_grammars(&syn_manager, &metainfo, &grammar).await;

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -377,7 +377,7 @@ impl Debug for SyntaxLoader {
 }
 
 #[derive(Debug, Clone)]
-pub struct SyntaxTreeSitterGrammarMetadataGrammar {
+pub struct SyntaxTreeSitterGrammarMetadata {
   pub name: CompactString,
   pub camelcase: CompactString,
   pub scope: CompactString,
@@ -389,8 +389,8 @@ pub struct SyntaxTreeSitterGrammarMetadataGrammar {
 }
 
 #[derive(Debug, Clone)]
-pub struct SyntaxTreeSitterGrammarMetadata {
-  pub grammars: Vec<SyntaxTreeSitterGrammarMetadataGrammar>,
+pub struct SyntaxTreeSitterGrammarRepository {
+  pub grammars: Vec<SyntaxTreeSitterGrammarMetadata>,
   pub grammar_path: PathBuf,
   pub src_path: PathBuf,
   pub grammar_json_path: PathBuf,
@@ -399,7 +399,7 @@ pub struct SyntaxTreeSitterGrammarMetadata {
 impl SyntaxLoader {
   pub fn parse_treesitter_grammar_metadata(
     grammar_path: &Path,
-  ) -> TheResult<SyntaxTreeSitterGrammarMetadata> {
+  ) -> TheResult<SyntaxTreeSitterGrammarRepository> {
     let err = || {
       TheErr::TreeSitterParserNotFound(
         grammar_path.to_string_lossy().to_compact_string(),
@@ -474,7 +474,7 @@ impl SyntaxLoader {
         .map(|tg| tg.as_str().ok_or(err()))
         .transpose()?
         .map(|inj| inj.to_string());
-      let grammar_metainfo = SyntaxTreeSitterGrammarMetadataGrammar {
+      let grammar_metainfo = SyntaxTreeSitterGrammarMetadata {
         name: name.to_compact_string(),
         camelcase: camelcase.to_compact_string(),
         scope: scope.to_compact_string(),
@@ -490,7 +490,7 @@ impl SyntaxLoader {
     let src_path = grammar_path.join("src");
     let grammar_json_path = src_path.join("grammar.json");
 
-    let metainfo = SyntaxTreeSitterGrammarMetadata {
+    let metainfo = SyntaxTreeSitterGrammarRepository {
       grammars: grammars_metainfo,
       grammar_path: grammar_path.to_path_buf(),
       src_path,
@@ -504,7 +504,7 @@ impl SyntaxLoader {
     &self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
-    /* metainfo */ SyntaxTreeSitterGrammarMetadata,
+    /* metainfo */ SyntaxTreeSitterGrammarRepository,
     /* grammar */ Language,
   )> {
     let metainfo =
@@ -524,7 +524,7 @@ impl SyntaxLoader {
     &self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
-    /* metainfo */ SyntaxTreeSitterGrammarMetadata,
+    /* metainfo */ SyntaxTreeSitterGrammarRepository,
     /* grammar */ Language,
   )> {
     self.load_grammar(req)
@@ -533,7 +533,7 @@ impl SyntaxLoader {
 
 fn save_loaded_grammars(
   syn_manager: &SyntaxManagerArc,
-  metainfo: &SyntaxTreeSitterGrammarMetadata,
+  metainfo: &SyntaxTreeSitterGrammarRepository,
   grammar: &Language,
 ) {
   for grammar_metainfo in metainfo.grammars.iter() {
@@ -560,7 +560,7 @@ fn save_loaded_grammars(
 
 async fn async_save_loaded_grammars(
   syn_manager: &SyntaxManagerArc,
-  metainfo: &SyntaxTreeSitterGrammarMetadata,
+  metainfo: &SyntaxTreeSitterGrammarRepository,
   grammar: &Language,
 ) {
   for grammar_metainfo in metainfo.grammars.iter() {
@@ -588,7 +588,7 @@ async fn async_save_loaded_grammars(
 pub fn load_syntax_grammar(
   syn_manager: SyntaxManagerArc,
   req: SyntaxLoadGrammarRequest,
-) -> TheResult<SyntaxTreeSitterGrammarMetadata> {
+) -> TheResult<SyntaxTreeSitterGrammarRepository> {
   let syn_loader = lock!(syn_manager).loader();
   let (metainfo, grammar) = syn_loader.load_grammar(req)?;
   save_loaded_grammars(&syn_manager, &metainfo, &grammar);
@@ -598,7 +598,7 @@ pub fn load_syntax_grammar(
 pub async fn async_load_syntax_grammar(
   syn_manager: SyntaxManagerArc,
   req: SyntaxLoadGrammarRequest,
-) -> TheResult<SyntaxTreeSitterGrammarMetadata> {
+) -> TheResult<SyntaxTreeSitterGrammarRepository> {
   let syn_loader = lock!(syn_manager).loader();
   let (metainfo, grammar) = syn_loader.async_load_grammar(req).await?;
   async_save_loaded_grammars(&syn_manager, &metainfo, &grammar).await;

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -693,7 +693,7 @@ impl SyntaxManager {
     ];
 
     for grammar_binding in grammar_bindings {
-      for file_ext in grammar_binding.3.iter() {
+      for file_ext in grammar_binding.5.iter() {
         it.insert_file_ext(
           grammar_binding.0.to_compact_string(),
           file_ext.to_compact_string(),

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -476,7 +476,7 @@ impl SyntaxLoader {
 
   /// Load the tree-sitter parser/grammar (`Language`) FFI dynamic library.
   pub fn load_grammar(
-    &mut self,
+    &self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
     /* metainfo */ SyntaxTreeSitterGrammarMetainfo,
@@ -496,7 +496,7 @@ impl SyntaxLoader {
   }
 
   pub async fn async_load_grammar(
-    &mut self,
+    &self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
     /* metainfo */ SyntaxTreeSitterGrammarMetainfo,

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -365,7 +365,7 @@ impl Debug for SyntaxLoader {
 }
 
 #[derive(Debug, Clone)]
-struct SyntaxTreeSitterGrammarMetainfoGrammar {
+pub struct SyntaxTreeSitterGrammarMetainfoGrammar {
   pub name: CompactString,
   pub camelcase: CompactString,
   pub scope: CompactString,
@@ -377,7 +377,7 @@ struct SyntaxTreeSitterGrammarMetainfoGrammar {
 }
 
 #[derive(Debug, Clone)]
-struct SyntaxTreeSitterGrammarMetainfo {
+pub struct SyntaxTreeSitterGrammarMetainfo {
   pub grammars: Vec<SyntaxTreeSitterGrammarMetainfoGrammar>,
   pub grammar_path: PathBuf,
   pub src_path: PathBuf,
@@ -519,6 +519,80 @@ impl SyntaxLoader {
   }
 }
 
+fn save_loaded_grammars(
+  syn_manager: &SyntaxManagerArc,
+  metainfo: &SyntaxTreeSitterGrammarMetainfo,
+  grammar: &Language,
+) {
+  for grammar_metainfo in metainfo.grammars.iter() {
+    let highlight_query = match &grammar_metainfo.highlights {
+      Some(highlights) => std::fs::read_to_string(highlights).ok(),
+      None => None,
+    };
+    let tags_query = match &grammar_metainfo.tags {
+      Some(tags) => std::fs::read_to_string(tags).ok(),
+      None => None,
+    };
+    lock!(syn_manager).insert_grammar(
+      grammar_metainfo.name.clone(),
+      grammar.clone(),
+      highlight_query,
+      tags_query,
+      grammar_metainfo
+        .injection_regex
+        .as_ref()
+        .map(|inj| inj.to_string()),
+    );
+  }
+}
+
+async fn async_save_loaded_grammars(
+  syn_manager: &SyntaxManagerArc,
+  metainfo: &SyntaxTreeSitterGrammarMetainfo,
+  grammar: &Language,
+) {
+  for grammar_metainfo in metainfo.grammars.iter() {
+    let highlight_query = match &grammar_metainfo.highlights {
+      Some(highlights) => tokio::fs::read_to_string(highlights).await.ok(),
+      None => None,
+    };
+    let tags_query = match &grammar_metainfo.tags {
+      Some(tags) => tokio::fs::read_to_string(tags).await.ok(),
+      None => None,
+    };
+    lock!(syn_manager).insert_grammar(
+      grammar_metainfo.name.clone(),
+      grammar.clone(),
+      highlight_query,
+      tags_query,
+      grammar_metainfo
+        .injection_regex
+        .as_ref()
+        .map(|inj| inj.to_string()),
+    );
+  }
+}
+
+pub fn load_syntax_grammar(
+  syn_manager: SyntaxManagerArc,
+  req: SyntaxLoadGrammarRequest,
+) -> TheResult<SyntaxTreeSitterGrammarMetainfo> {
+  let syn_loader = lock!(syn_manager).loader();
+  let (metainfo, grammar) = syn_loader.load_grammar(req)?;
+  save_loaded_grammars(&syn_manager, &metainfo, &grammar);
+  Ok(metainfo)
+}
+
+pub async fn async_load_syntax_grammar(
+  syn_manager: SyntaxManagerArc,
+  req: SyntaxLoadGrammarRequest,
+) -> TheResult<SyntaxTreeSitterGrammarMetainfo> {
+  let syn_loader = lock!(syn_manager).loader();
+  let (metainfo, grammar) = syn_loader.async_load_grammar(req).await?;
+  async_save_loaded_grammars(&syn_manager, &metainfo, &grammar).await;
+  Ok(metainfo)
+}
+
 pub struct SyntaxManager {
   loader: SyntaxLoader,
 
@@ -635,8 +709,8 @@ impl SyntaxManager {
     self.loader.set_treesitter_parser_lib_path(parser_lib_path);
   }
 
-  pub fn loader(&self) -> &SyntaxLoader {
-    &self.loader
+  pub fn loader(&self) -> SyntaxLoader {
+    self.loader.clone()
   }
 
   /// Associate a grammar ID with a file extension.

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -604,8 +604,8 @@ impl SyntaxManager {
     self.loader.set_treesitter_parser_lib_path(parser_lib_path);
   }
 
-  pub fn loader(&self) -> SyntaxLoader {
-    self.loader.clone()
+  pub fn loader(&self) -> &SyntaxLoader {
+    &self.loader
   }
 
   /// Associate a grammar ID with a file extension.

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -346,8 +346,8 @@ impl SyntaxLoader {
     }
   }
 
-  pub fn treesitter_parser_lib_path(&self) -> &PathBuf {
-    &self.parser_lib_path
+  pub fn treesitter_parser_lib_path(&self) -> &Path {
+    self.parser_lib_path.as_path()
   }
 
   pub fn set_treesitter_parser_lib_path(&mut self, parser_lib_path: PathBuf) {
@@ -594,17 +594,17 @@ impl SyntaxManager {
     it
   }
 
-  pub fn treesitter_parser_lib_path(&self) -> PathBuf {
-    lock!(self.loader).treesitter_parser_lib_path()
+  pub fn treesitter_parser_lib_path(&self) -> &Path {
+    self.loader.treesitter_parser_lib_path()
   }
 
   /// NOTE: This will reset the tree-sitter loader and all loaded
   /// parsers/grammars.
   pub fn set_treesitter_parser_lib_path(&mut self, parser_lib_path: PathBuf) {
-    lock!(self.loader).set_treesitter_parser_lib_path(parser_lib_path);
+    self.loader.set_treesitter_parser_lib_path(parser_lib_path);
   }
 
-  pub fn loader(&self) -> SyntaxLoaderArc {
+  pub fn loader(&self) -> SyntaxLoader {
     self.loader.clone()
   }
 

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -557,15 +557,15 @@ impl SyntaxManager {
 impl SyntaxManager {
   pub fn insert_grammar(
     &mut self,
-    id: CompactString,
+    grammar_id: CompactString,
     grammar: Language,
     highlight_query: Option<String>,
   ) {
-    self.grammars.insert(id.clone(), grammar);
+    self.grammars.insert(grammar_id.clone(), grammar);
     if let Some(hl_query) = highlight_query {
-      self.highlight_queries.insert(id.clone(), hl_query);
+      self.highlight_queries.insert(grammar_id.clone(), hl_query);
     }
-    self.gid2ext.entry(id.clone()).or_default();
+    self.gid2ext.entry(grammar_id.clone()).or_default();
   }
 
   pub fn get_grammar(&self, id: &str) -> Option<&Language> {

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -1,7 +1,6 @@
 //! Tree-sitter based syntax engine.
 
 use crate::buf::Buffer;
-use crate::cfg::path_cfg::PATH_CONFIG;
 use crate::prelude::*;
 use crate::structural_id_impl;
 use compact_str::CompactString;
@@ -335,7 +334,18 @@ pub struct SyntaxLoadGrammarRequest {
 }
 
 impl SyntaxLoader {
+  #[cfg(test)]
   pub fn new() -> Self {
+    Self {
+      loader: Arc::new(Mutex::new(Loader::new())),
+      parser_lib_path,
+    }
+  }
+
+  #[cfg(not(test))]
+  pub fn new() -> Self {
+    use crate::cfg::path_cfg::PATH_CONFIG;
+
     let parser_lib_path =
       PATH_CONFIG.config_home().join(".tree-sitter-parsers");
     Self {

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -1,6 +1,7 @@
 //! Tree-sitter based syntax engine.
 
 use crate::buf::Buffer;
+use crate::cfg::path_cfg::PATH_CONFIG;
 use crate::prelude::*;
 use crate::structural_id_impl;
 use compact_str::CompactString;
@@ -341,25 +342,16 @@ impl SyntaxLoadGrammarRequest {
   pub fn grammar_json_path(&self) -> PathBuf {
     self.src_path().join("grammar.json")
   }
-
-  // FIXME: tree-sitter-loader use `parser_lib_path` to configure where it
-  // caches all the compiled dynamic libraries (e.g. c.dll, rust.dylib, etc).
-  // For each parser/grammar, its `output_path` is built with `parser_lib_path`
-  // by default, so once we set a correct value for `parser_lib_path`, we no
-  // longer need to configure `output_path` for each parser/grammar.
-  //
-  // pub fn output_path(&self) -> TheResult<PathBuf> {
-  //   let grammar_id = get_grammar_name_from_src_path(self)?;
-  //   let mut out = self.grammar_path.join(grammar_id);
-  //   out.set_extension(std::env::consts::DLL_EXTENSION);
-  //   Ok(out)
-  // }
 }
 
 impl SyntaxLoader {
   pub fn new() -> Self {
+    let parser_lib_path =
+      PATH_CONFIG.config_home().join(".tree-sitter-parsers");
     Self {
-      loader: Arc::new(Mutex::new(Loader::new().unwrap())),
+      loader: Arc::new(Mutex::new(Loader::with_parser_lib_path(
+        parser_lib_path,
+      ))),
       grammars: FoldMap::new(),
     }
   }

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -399,13 +399,17 @@ impl SyntaxLoader {
   pub fn load_grammar(
     &mut self,
     req: SyntaxLoadGrammarRequest,
-  ) -> TheResult<(CompactString, Language)> {
+  ) -> TheResult<(
+    /* grammar_id */ CompactString,
+    /* grammar */ Language,
+    /* highlight_query */ Option<String>,
+  )> {
     let src_path = req.src_path();
     let src_path = src_path.as_path();
     let grammar_id = Self::get_grammar_name_from_src_path(&req)?;
     let compile_cfg = CompileConfig::new(src_path, None, None);
     match lock!(self.loader).load_language_at_path(compile_cfg) {
-      Ok(grammar) => Ok((grammar_id, grammar)),
+      Ok(grammar) => Ok((grammar_id, grammar, None)),
       Err(e) => Err(TheErr::LoadTreeSitterGrammarFailed(
         grammar_id.to_compact_string(),
         e,

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -507,7 +507,7 @@ impl SyntaxLoader {
 }
 
 pub struct SyntaxManager {
-  loader: SyntaxLoaderArc,
+  loader: SyntaxLoader,
 
   // loaded_parsers: FoldMap<CompactString, SyntaxLoadedParser>,
   grammars: FoldMap<CompactString, Language>,
@@ -524,7 +524,7 @@ arc_mutex_ptr!(SyntaxManager);
 impl Debug for SyntaxManager {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("SyntaxManager")
-      .field("loader", &lock!(self.loader))
+      .field("loader", &self.loader)
       .field("grammars", &self.grammars.keys())
       .field("highlight_queries", &self.highlight_queries)
       .field("grammarid2ext", &self.gid2ext)
@@ -537,7 +537,7 @@ impl Debug for SyntaxManager {
 impl SyntaxManager {
   pub fn new() -> Self {
     let mut it = Self {
-      loader: SyntaxLoader::to_arc(SyntaxLoader::new()),
+      loader: SyntaxLoader::new(),
       grammars: FoldMap::new(),
       highlight_queries: FoldMap::new(),
       gid2ext: FoldMap::new(),

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -379,7 +379,6 @@ struct SyntaxTreeSitterGrammarMetainfoGrammar {
 #[derive(Debug, Clone)]
 struct SyntaxTreeSitterGrammarMetainfo {
   pub grammars: Vec<SyntaxTreeSitterGrammarMetainfoGrammar>,
-
   pub grammar_path: PathBuf,
   pub src_path: PathBuf,
   pub grammar_json_path: PathBuf,

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -681,23 +681,25 @@ impl SyntaxManager {
 impl SyntaxManager {
   pub fn insert_grammar(
     &mut self,
-    grammar_id: CompactString,
+    grammar_name: CompactString,
     grammar: Language,
     highlight_query: Option<String>,
     tags_query: Option<String>,
     injection_query: Option<String>,
   ) {
-    self.grammars.insert(grammar_id.clone(), grammar);
+    self.grammars.insert(grammar_name.clone(), grammar);
     if let Some(hl) = highlight_query {
-      self.highlight_queries.insert(grammar_id.clone(), hl);
+      self.highlight_queries.insert(grammar_name.clone(), hl);
     }
     if let Some(tag) = tags_query {
-      self.tags_queries.insert(grammar_id.clone(), tag);
+      self.tags_queries.insert(grammar_name.clone(), tag);
     }
     if let Some(injection) = injection_query {
-      self.injection_queries.insert(grammar_id.clone(), injection);
+      self
+        .injection_queries
+        .insert(grammar_name.clone(), injection);
     }
-    self.gid2ext.entry(grammar_id.clone()).or_default();
+    self.gid2ext.entry(grammar_name.clone()).or_default();
   }
 
   pub fn get_grammar(&self, id: &str) -> Option<&Language> {

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -20,6 +20,7 @@ use std::sync::Weak;
 use tree_sitter::InputEdit;
 use tree_sitter::Language;
 use tree_sitter::LanguageError;
+use tree_sitter::LanguageFn;
 use tree_sitter::Parser;
 use tree_sitter::Point;
 use tree_sitter::Query;
@@ -636,6 +637,38 @@ impl Debug for SyntaxManager {
   }
 }
 
+#[cfg(test)]
+// WARNING: This is for testing only
+struct _BuiltinTreeSitterGrammar {
+  pub grammar_name: CompactString,
+  pub language: Language,
+  pub highlight_query: Option<String>,
+  pub tags_query: Option<String>,
+  pub injection_query: Option<String>,
+  pub file_types: Vec<CompactString>,
+}
+
+#[cfg(test)]
+impl _BuiltinTreeSitterGrammar {
+  pub fn new(
+    grammar_name: &str,
+    language: Language,
+    highlight_query: Option<String>,
+    tags_query: Option<String>,
+    injection_query: Option<String>,
+    file_types: Vec<CompactString>,
+  ) -> Self {
+    Self {
+      grammar_name: grammar_name.to_compact_string(),
+      language,
+      highlight_query,
+      tags_query,
+      injection_query,
+      file_types,
+    }
+  }
+}
+
 // Language ID and file extensions {
 impl SyntaxManager {
   #[cfg(not(test))]
@@ -664,61 +697,73 @@ impl SyntaxManager {
     };
 
     let grammar_bindings = [
-      (
+      _BuiltinTreeSitterGrammar::new(
         "c",
-        tree_sitter_c::LANGUAGE,
-        Some(tree_sitter_c::HIGHLIGHT_QUERY),
-        Some(tree_sitter_c::TAGS_QUERY),
+        tree_sitter_c::LANGUAGE.into(),
+        Some(tree_sitter_c::HIGHLIGHT_QUERY.to_string()),
+        Some(tree_sitter_c::TAGS_QUERY.to_string()),
         None,
-        vec!["c", "h"],
+        ["c", "h"]
+          .iter()
+          .map(|ft| ft.to_compact_string())
+          .collect_vec(),
       ),
-      (
+      _BuiltinTreeSitterGrammar::new(
         "rust",
-        tree_sitter_rust::LANGUAGE,
-        Some(tree_sitter_rust::HIGHLIGHTS_QUERY),
-        Some(tree_sitter_rust::TAGS_QUERY),
-        Some(tree_sitter_rust::INJECTIONS_QUERY),
-        vec!["rs"],
+        tree_sitter_rust::LANGUAGE.into(),
+        Some(tree_sitter_rust::HIGHLIGHTS_QUERY.to_string()),
+        Some(tree_sitter_rust::TAGS_QUERY.to_string()),
+        Some(tree_sitter_rust::INJECTIONS_QUERY.to_string()),
+        ["rs"].iter().map(|ft| ft.to_compact_string()).collect_vec(),
       ),
-      (
+      _BuiltinTreeSitterGrammar::new(
         "markdown",
-        tree_sitter_md::LANGUAGE,
-        Some(tree_sitter_md::HIGHLIGHT_QUERY_BLOCK),
+        tree_sitter_md::LANGUAGE.into(),
+        Some(tree_sitter_md::HIGHLIGHT_QUERY_BLOCK.to_string()),
         None,
-        Some(tree_sitter_md::INJECTION_QUERY_BLOCK),
-        vec!["md", "markdown"],
+        Some(tree_sitter_md::INJECTION_QUERY_BLOCK.to_string()),
+        ["md", "markdown"]
+          .iter()
+          .map(|ft| ft.to_compact_string())
+          .collect_vec(),
       ),
-      (
+      _BuiltinTreeSitterGrammar::new(
         "toml",
-        tree_sitter_toml_ng::LANGUAGE,
-        Some(tree_sitter_toml_ng::HIGHLIGHTS_QUERY),
+        tree_sitter_toml_ng::LANGUAGE.into(),
+        Some(tree_sitter_toml_ng::HIGHLIGHTS_QUERY.to_string()),
         None,
         None,
-        vec!["toml"],
+        ["toml"]
+          .iter()
+          .map(|ft| ft.to_compact_string())
+          .collect_vec(),
       ),
-      (
+      _BuiltinTreeSitterGrammar::new(
         "html",
-        tree_sitter_html::LANGUAGE,
-        Some(tree_sitter_html::HIGHLIGHTS_QUERY),
+        tree_sitter_html::LANGUAGE.into(),
+        Some(tree_sitter_html::HIGHLIGHTS_QUERY.to_string()),
         None,
-        Some(tree_sitter_html::INJECTIONS_QUERY),
-        vec!["html", "htm"],
+        Some(tree_sitter_html::INJECTIONS_QUERY.to_string()),
+        ["html", "htm"]
+          .iter()
+          .map(|ft| ft.to_compact_string())
+          .collect_vec(),
       ),
     ];
 
     for grammar_binding in grammar_bindings {
-      for file_ext in grammar_binding.5.iter() {
+      for file_ext in grammar_binding.file_types.iter() {
         it.insert_file_ext(
-          grammar_binding.0.to_compact_string(),
-          file_ext.to_compact_string(),
+          grammar_binding.grammar_name.clone(),
+          file_ext.clone(),
         );
       }
       it.insert_grammar(
-        grammar_binding.0.to_compact_string(),
-        grammar_binding.1.into(),
-        grammar_binding.2.map(|q| q.to_string()),
-        grammar_binding.3.map(|q| q.to_string()),
-        grammar_binding.4.map(|q| q.to_string()),
+        grammar_binding.grammar_name.clone(),
+        grammar_binding.language,
+        grammar_binding.highlight_query,
+        grammar_binding.tags_query,
+        grammar_binding.injection_query,
       );
     }
 

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -365,7 +365,7 @@ impl Debug for SyntaxLoader {
 }
 
 #[derive(Debug, Clone)]
-struct SyntaxTreeSitterGrammarMetainfo {
+struct SyntaxTreeSitterGrammarMetainfoGrammar {
   pub name: CompactString,
   pub camelcase: CompactString,
   pub scope: CompactString,
@@ -377,8 +377,8 @@ struct SyntaxTreeSitterGrammarMetainfo {
 }
 
 #[derive(Debug, Clone)]
-struct SyntaxTreeSitterMetainfo {
-  pub grammars: Vec<SyntaxTreeSitterGrammarMetainfo>,
+struct SyntaxTreeSitterGrammarMetainfo {
+  pub grammars: Vec<SyntaxTreeSitterGrammarMetainfoGrammar>,
 
   pub grammar_path: PathBuf,
   pub src_path: PathBuf,
@@ -386,9 +386,9 @@ struct SyntaxTreeSitterMetainfo {
 }
 
 impl SyntaxLoader {
-  pub fn parse_treesitter_metainfo(
+  pub fn parse_treesitter_grammar_metainfo(
     grammar_path: &Path,
-  ) -> TheResult<SyntaxTreeSitterMetainfo> {
+  ) -> TheResult<SyntaxTreeSitterGrammarMetainfo> {
     let err = || {
       TheErr::TreeSitterParserNotFound(
         grammar_path.to_string_lossy().to_compact_string(),
@@ -449,7 +449,7 @@ impl SyntaxLoader {
         .map(|tg| tg.as_str().ok_or(err()))
         .transpose()?
         .map(|ij| ij.to_compact_string());
-      let grammar_metainfo = SyntaxTreeSitterGrammarMetainfo {
+      let grammar_metainfo = SyntaxTreeSitterGrammarMetainfoGrammar {
         name: name.to_compact_string(),
         camelcase: camelcase.to_compact_string(),
         scope: scope.to_compact_string(),
@@ -465,7 +465,7 @@ impl SyntaxLoader {
     let src_path = grammar_path.join("src");
     let grammar_json_path = src_path.join("grammar.json");
 
-    let metainfo = SyntaxTreeSitterMetainfo {
+    let metainfo = SyntaxTreeSitterGrammarMetainfo {
       grammars: grammars_metainfo,
       grammar_path: grammar_path.to_path_buf(),
       src_path,
@@ -502,10 +502,11 @@ impl SyntaxLoader {
     &mut self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
-    /* metainfo */ SyntaxTreeSitterMetainfo,
+    /* metainfo */ SyntaxTreeSitterGrammarMetainfo,
     /* grammar */ Language,
   )> {
-    let metainfo = Self::parse_treesitter_metainfo(req.grammar_path.as_path())?;
+    let metainfo =
+      Self::parse_treesitter_grammar_metainfo(req.grammar_path.as_path())?;
     let compile_cfg =
       CompileConfig::new(metainfo.src_path.as_path(), None, None);
     match lock!(self.loader).load_language_at_path(compile_cfg) {
@@ -520,7 +521,10 @@ impl SyntaxLoader {
   pub async fn async_load_grammar(
     &mut self,
     req: SyntaxLoadGrammarRequest,
-  ) -> TheResult<(CompactString, Language)> {
+  ) -> TheResult<(
+    /* metainfo */ SyntaxTreeSitterGrammarMetainfo,
+    /* grammar */ Language,
+  )> {
     self.load_grammar(req)
   }
 }

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -320,7 +320,11 @@ pub type TreeSitterLoaderArc = Arc<Mutex<Loader>>;
 pub type TreeSitterLoaderWk = Weak<Mutex<Loader>>;
 pub type TreeSitterLoaderMutexGuard<'a> = MutexGuard<'a, Loader>;
 
+structural_id_impl!(usize, SyntaxLoaderId, 1);
+
 pub struct SyntaxLoader {
+  id: SyntaxLoaderId,
+
   loader: TreeSitterLoaderArc,
 
   // Loaded grammars/parsers
@@ -349,6 +353,7 @@ impl SyntaxLoader {
     let parser_lib_path =
       PATH_CONFIG.config_home().join(".tree-sitter-parsers");
     Self {
+      id: SyntaxLoaderId::next(),
       loader: Arc::new(Mutex::new(Loader::with_parser_lib_path(
         parser_lib_path,
       ))),
@@ -363,6 +368,7 @@ impl SyntaxLoader {
   /// NOTE: This will reset the tree-sitter loader and all loaded
   /// parsers/grammars.
   pub fn set_treesitter_parser_lib_path(&mut self, parser_lib_path: PathBuf) {
+    self.id = SyntaxLoaderId::next();
     self.loader =
       Arc::new(Mutex::new(Loader::with_parser_lib_path(parser_lib_path)));
     self.grammars.clear();

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -338,7 +338,7 @@ impl SyntaxLoader {
   pub fn new() -> Self {
     Self {
       loader: Arc::new(Mutex::new(Loader::new().unwrap())),
-      parser_lib_path,
+      parser_lib_path: Path::new(".").to_path_buf(),
     }
   }
 

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -474,29 +474,6 @@ impl SyntaxLoader {
     Ok(metainfo)
   }
 
-  pub fn get_grammar_name_from_src_path(
-    req: &SyntaxLoadGrammarRequest,
-  ) -> TheResult<CompactString> {
-    let grammar_json_path = req.grammar_json_path();
-    let grammar_json_path = grammar_json_path.as_path();
-    let err = || {
-      TheErr::TreeSitterParserNotFound(
-        grammar_json_path.to_string_lossy().to_compact_string(),
-      )
-    };
-    let grammar_json_text =
-      std::fs::read_to_string(grammar_json_path).map_err(|_e| err())?;
-    let grammar_json_data: serde_json::Value =
-      serde_json::from_str(&grammar_json_text).map_err(|_e| err())?;
-    match grammar_json_data.get("name") {
-      Some(name_value) => match name_value.as_str() {
-        Some(name) => Ok(name.to_compact_string()),
-        None => Err(err()),
-      },
-      None => Err(err()),
-    }
-  }
-
   /// Load the tree-sitter parser/grammar (`Language`) FFI dynamic library.
   pub fn load_grammar(
     &mut self,

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -392,15 +392,10 @@ struct SyntaxTreeSitterGrammarMetainfo {
 
 #[derive(Debug, Clone)]
 struct SyntaxTreeSitterMetainfo {
-  pub grammar_path: PathBuf,
-
   pub grammars: Vec<SyntaxTreeSitterGrammarMetainfo>,
 
-  pub metadata_version: CompactString,
-  pub metadata_repository: CompactString,
-
+  pub grammar_path: PathBuf,
   pub src_path: PathBuf,
-  pub tree_sitter_json_path: PathBuf,
   pub grammar_json_path: PathBuf,
 }
 
@@ -426,7 +421,7 @@ impl SyntaxLoader {
       .as_array()
       .ok_or(err())?;
 
-    let mut grammars_metadata =
+    let mut grammars_metainfo =
       Vec::with_capacity(tree_sitter_json_grammars.len());
     for grammar in tree_sitter_json_grammars {
       let name = grammar.get("name").ok_or(err())?.as_str().ok_or(err())?;
@@ -468,7 +463,7 @@ impl SyntaxLoader {
         .map(|tg| tg.as_str().ok_or(err()))
         .transpose()?
         .map(|ij| ij.to_compact_string());
-      let grammar_metadata = SyntaxTreeSitterGrammarMetainfo {
+      let grammar_metainfo = SyntaxTreeSitterGrammarMetainfo {
         name: name.to_compact_string(),
         camelcase: camelcase.to_compact_string(),
         scope: scope.to_compact_string(),
@@ -478,18 +473,19 @@ impl SyntaxLoader {
         tags,
         injection_regex,
       };
+      grammars_metainfo.push(grammar_metainfo);
     }
 
     let src_path = grammar_path.join("src");
-    let src_path = grammar_path.join("src");
+    let grammar_json_path = src_path.join("grammar.json");
 
-    pub fn queries_path(&self) -> PathBuf {
-      self.grammar_path.join("queries")
-    }
-
-    pub fn grammar_json_path(&self) -> PathBuf {
-      self.src_path().join("grammar.json")
-    }
+    let metainfo = SyntaxTreeSitterMetainfo {
+      grammars: grammars_metainfo,
+      grammar_path: grammar_path.to_path_buf(),
+      src_path,
+      grammar_json_path,
+    };
+    Ok(metainfo)
   }
 
   pub fn get_grammar_name_from_src_path(

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -438,12 +438,26 @@ impl SyntaxLoader {
         .get("highlights")
         .map(|hl| hl.as_str().ok_or(err()))
         .transpose()?
-        .map(|hl| Path::new(hl).to_path_buf());
+        .map(|hl| {
+          grammar_path
+            .join(hl)
+            .normalize()
+            .map(|hl| hl.into_path_buf())
+            .map_err(|_e| err())
+        })
+        .transpose()?;
       let tags = grammar
         .get("tags")
         .map(|tg| tg.as_str().ok_or(err()))
         .transpose()?
-        .map(|tg| Path::new(tg).to_path_buf());
+        .map(|tg| {
+          grammar_path
+            .join(tg)
+            .normalize()
+            .map(|tg| tg.into_path_buf())
+            .map_err(|_e| err())
+        })
+        .transpose()?;
       let injection_regex = grammar
         .get("injection-regex")
         .map(|tg| tg.as_str().ok_or(err()))

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -390,72 +390,70 @@ impl Debug for SyntaxLoader {
   }
 }
 
-pub fn get_grammar_name_from_src_path(
-  req: &SyntaxLoadGrammarRequest,
-) -> TheResult<CompactString> {
-  let grammar_json_path = req.grammar_json_path();
-  let grammar_json_path = grammar_json_path.as_path();
-  let err = || {
-    TheErr::TreeSitterGrammarNotFound(
-      grammar_json_path.to_string_lossy().to_compact_string(),
-    )
-  };
-  let grammar_json_text =
-    std::fs::read_to_string(grammar_json_path).map_err(|_e| err())?;
-  let grammar_json_data: serde_json::Value =
-    serde_json::from_str(&grammar_json_text).map_err(|_e| err())?;
-  match grammar_json_data.get("name") {
-    Some(name_value) => match name_value.as_str() {
-      Some(name) => Ok(name.to_compact_string()),
+impl SyntaxLoader {
+  pub fn get_grammar_name_from_src_path(
+    req: &SyntaxLoadGrammarRequest,
+  ) -> TheResult<CompactString> {
+    let grammar_json_path = req.grammar_json_path();
+    let grammar_json_path = grammar_json_path.as_path();
+    let err = || {
+      TheErr::TreeSitterGrammarNotFound(
+        grammar_json_path.to_string_lossy().to_compact_string(),
+      )
+    };
+    let grammar_json_text =
+      std::fs::read_to_string(grammar_json_path).map_err(|_e| err())?;
+    let grammar_json_data: serde_json::Value =
+      serde_json::from_str(&grammar_json_text).map_err(|_e| err())?;
+    match grammar_json_data.get("name") {
+      Some(name_value) => match name_value.as_str() {
+        Some(name) => Ok(name.to_compact_string()),
+        None => Err(err()),
+      },
       None => Err(err()),
-    },
-    None => Err(err()),
-  }
-}
-
-/// Load the tree-sitter parser (`Language`) FFI dynamic library.
-///
-/// NOTE: Make this method public only for testing purpose.
-pub fn _load_treesitter_grammar(
-  loader: TreeSitterLoaderArc,
-  req: SyntaxLoadGrammarRequest,
-) -> TheResult<(CompactString, Language)> {
-  let src_path = req.src_path();
-  let src_path = src_path.as_path();
-  let grammar_id = get_grammar_name_from_src_path(&req)?;
-  let compile_cfg = CompileConfig::new(src_path, None, None);
-  match lock!(loader).load_language_at_path(compile_cfg) {
-    Ok(grammar) => Ok((grammar_id, grammar)),
-    Err(e) => Err(TheErr::LoadTreeSitterGrammarFailed(
-      grammar_id.to_compact_string(),
-      e,
-    )),
-  }
-}
-
-pub fn load_grammar(
-  syn_loader: SyntaxLoaderArc,
-  req: SyntaxLoadGrammarRequest,
-) -> TheResult<CompactString> {
-  let loader = lock!(syn_loader).treesitter_loader();
-  let load_result = _load_treesitter_grammar(loader, req);
-  let mut syn_loader = lock!(syn_loader);
-  match load_result {
-    Ok((grammar_id, grammar)) => {
-      syn_loader
-        .cached_grammars_mut()
-        .insert(grammar_id.clone(), grammar);
-      Ok(grammar_id)
     }
-    Err(e) => Err(e),
   }
-}
 
-pub async fn async_load_grammar(
-  syn_loader: SyntaxLoaderArc,
-  req: SyntaxLoadGrammarRequest,
-) -> TheResult<CompactString> {
-  load_grammar(syn_loader, req)
+  /// Load the tree-sitter parser (`Language`) FFI dynamic library.
+  ///
+  /// NOTE: Make this method public only for testing purpose.
+  pub fn _load_treesitter_grammar(
+    &self,
+    req: SyntaxLoadGrammarRequest,
+  ) -> TheResult<(CompactString, Language)> {
+    let src_path = req.src_path();
+    let src_path = src_path.as_path();
+    let grammar_id = Self::get_grammar_name_from_src_path(&req)?;
+    let compile_cfg = CompileConfig::new(src_path, None, None);
+    match lock!(self.loader).load_language_at_path(compile_cfg) {
+      Ok(grammar) => Ok((grammar_id, grammar)),
+      Err(e) => Err(TheErr::LoadTreeSitterGrammarFailed(
+        grammar_id.to_compact_string(),
+        e,
+      )),
+    }
+  }
+
+  pub fn load_grammar(
+    &mut self,
+    req: SyntaxLoadGrammarRequest,
+  ) -> TheResult<CompactString> {
+    let load_result = self._load_treesitter_grammar(req);
+    match load_result {
+      Ok((grammar_id, grammar)) => {
+        self.grammars.insert(grammar_id.clone(), grammar);
+        Ok(grammar_id)
+      }
+      Err(e) => Err(e),
+    }
+  }
+
+  pub async fn async_load_grammar(
+    &mut self,
+    req: SyntaxLoadGrammarRequest,
+  ) -> TheResult<CompactString> {
+    self.load_grammar(req)
+  }
 }
 
 pub struct SyntaxManager {

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -638,6 +638,20 @@ impl Debug for SyntaxManager {
 
 // Language ID and file extensions {
 impl SyntaxManager {
+  #[cfg(not(test))]
+  pub fn new() -> Self {
+    Self {
+      loader: SyntaxLoader::new(),
+      grammars: FoldMap::new(),
+      highlight_queries: FoldMap::new(),
+      tags_queries: FoldMap::new(),
+      injection_queries: FoldMap::new(),
+      gid2ext: FoldMap::new(),
+      ext2gid: FoldMap::new(),
+    }
+  }
+
+  #[cfg(test)]
   pub fn new() -> Self {
     let mut it = Self {
       loader: SyntaxLoader::new(),

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -387,11 +387,9 @@ impl SyntaxLoader {
     }
   }
 
-  /// Load the tree-sitter parser (`Language`) FFI dynamic library.
-  ///
-  /// NOTE: Make this method public only for testing purpose.
-  pub fn _load_treesitter_grammar(
-    &self,
+  /// Load the tree-sitter parser/grammar (`Language`) FFI dynamic library.
+  pub fn load_grammar(
+    &mut self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(CompactString, Language)> {
     let src_path = req.src_path();
@@ -407,18 +405,10 @@ impl SyntaxLoader {
     }
   }
 
-  pub fn load_grammar(
-    &mut self,
-    req: SyntaxLoadGrammarRequest,
-  ) -> TheResult<CompactString> {
-    let (grammar_id, _grammar) = self._load_treesitter_grammar(req)?;
-    Ok(grammar_id)
-  }
-
   pub async fn async_load_grammar(
     &mut self,
     req: SyntaxLoadGrammarRequest,
-  ) -> TheResult<CompactString> {
+  ) -> TheResult<(CompactString, Language)> {
     self.load_grammar(req)
   }
 }

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -337,7 +337,7 @@ impl SyntaxLoader {
   #[cfg(test)]
   pub fn new() -> Self {
     Self {
-      loader: Arc::new(Mutex::new(Loader::new())),
+      loader: Arc::new(Mutex::new(Loader::new().unwrap())),
       parser_lib_path,
     }
   }

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -20,7 +20,6 @@ use std::sync::Weak;
 use tree_sitter::InputEdit;
 use tree_sitter::Language;
 use tree_sitter::LanguageError;
-use tree_sitter::LanguageFn;
 use tree_sitter::Parser;
 use tree_sitter::Point;
 use tree_sitter::Query;

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -356,6 +356,18 @@ impl SyntaxLoader {
     }
   }
 
+  pub fn treesitter_parser_lib_path(&self) -> PathBuf {
+    lock!(self.loader).parser_lib_path.clone()
+  }
+
+  /// NOTE: This will reset the tree-sitter loader and all loaded
+  /// parsers/grammars.
+  pub fn set_treesitter_parser_lib_path(&mut self, parser_lib_path: PathBuf) {
+    self.loader =
+      Arc::new(Mutex::new(Loader::with_parser_lib_path(parser_lib_path)));
+    self.grammars.clear();
+  }
+
   pub fn treesitter_loader(&self) -> TreeSitterLoaderArc {
     self.loader.clone()
   }
@@ -533,6 +545,16 @@ impl SyntaxManager {
     }
 
     it
+  }
+
+  pub fn treesitter_parser_lib_path(&self) -> PathBuf {
+    lock!(self.loader).treesitter_parser_lib_path()
+  }
+
+  /// NOTE: This will reset the tree-sitter loader and all loaded
+  /// parsers/grammars.
+  pub fn set_treesitter_parser_lib_path(&mut self, parser_lib_path: PathBuf) {
+    lock!(self.loader).set_treesitter_parser_lib_path(parser_lib_path);
   }
 
   pub fn loader(&self) -> SyntaxLoaderArc {

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -526,7 +526,7 @@ pub struct SyntaxManager {
   grammars: FoldMap<CompactString, Language>,
   highlight_queries: FoldMap<CompactString, String>,
   tags_queries: FoldMap<CompactString, String>,
-  injection_regex_queries: FoldMap<CompactString, String>,
+  injection_queries: FoldMap<CompactString, String>,
 
   // Maps grammar ID to file extensions
   gid2ext: FoldMap<CompactString, FoldSet<CompactString>>,
@@ -543,7 +543,7 @@ impl Debug for SyntaxManager {
       .field("grammars", &self.grammars.keys())
       .field("highlight_queries", &self.highlight_queries)
       .field("tags_queries", &self.tags_queries)
-      .field("injection_regex_queries", &self.injection_regex_queries)
+      .field("injection_queries", &self.injection_queries)
       .field("grammarid2ext", &self.gid2ext)
       .field("ext2grammarid", &self.ext2gid)
       .finish()
@@ -558,7 +558,7 @@ impl SyntaxManager {
       grammars: FoldMap::new(),
       highlight_queries: FoldMap::new(),
       tags_queries: FoldMap::new(),
-      injection_regex_queries: FoldMap::new(),
+      injection_queries: FoldMap::new(),
       gid2ext: FoldMap::new(),
       ext2gid: FoldMap::new(),
     };
@@ -568,30 +568,40 @@ impl SyntaxManager {
         "c",
         tree_sitter_c::LANGUAGE,
         Some(tree_sitter_c::HIGHLIGHT_QUERY),
+        Some(tree_sitter_c::TAGS_QUERY),
+        None,
         vec!["c", "h"],
       ),
       (
         "rust",
         tree_sitter_rust::LANGUAGE,
         Some(tree_sitter_rust::HIGHLIGHTS_QUERY),
+        Some(tree_sitter_rust::TAGS_QUERY),
+        Some(tree_sitter_rust::INJECTIONS_QUERY),
         vec!["rs"],
       ),
       (
         "markdown",
         tree_sitter_md::LANGUAGE,
         Some(tree_sitter_md::HIGHLIGHT_QUERY_BLOCK),
+        None,
+        Some(tree_sitter_md::INJECTION_QUERY_BLOCK),
         vec!["md", "markdown"],
       ),
       (
         "toml",
         tree_sitter_toml_ng::LANGUAGE,
         Some(tree_sitter_toml_ng::HIGHLIGHTS_QUERY),
+        None,
+        None,
         vec!["toml"],
       ),
       (
         "html",
         tree_sitter_html::LANGUAGE,
         Some(tree_sitter_html::HIGHLIGHTS_QUERY),
+        None,
+        Some(tree_sitter_html::INJECTIONS_QUERY),
         vec!["html", "htm"],
       ),
     ];
@@ -607,6 +617,8 @@ impl SyntaxManager {
         grammar_binding.0.to_compact_string(),
         grammar_binding.1.into(),
         grammar_binding.2.map(|q| q.to_string()),
+        grammar_binding.3.map(|q| q.to_string()),
+        grammar_binding.4.map(|q| q.to_string()),
       );
     }
 
@@ -673,11 +685,17 @@ impl SyntaxManager {
     grammar: Language,
     highlight_query: Option<String>,
     tags_query: Option<String>,
-    injection_regex: Option<String>,
+    injection_query: Option<String>,
   ) {
     self.grammars.insert(grammar_id.clone(), grammar);
-    if let Some(hl_query) = highlight_query {
-      self.highlight_queries.insert(grammar_id.clone(), hl_query);
+    if let Some(hl) = highlight_query {
+      self.highlight_queries.insert(grammar_id.clone(), hl);
+    }
+    if let Some(tag) = tags_query {
+      self.tags_queries.insert(grammar_id.clone(), tag);
+    }
+    if let Some(injection) = injection_query {
+      self.injection_queries.insert(grammar_id.clone(), injection);
     }
     self.gid2ext.entry(grammar_id.clone()).or_default();
   }

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -404,7 +404,7 @@ impl SyntaxLoader {
     let src_path = src_path.as_path();
     let grammar_id = Self::get_grammar_name_from_src_path(&req)?;
     let compile_cfg = CompileConfig::new(src_path, None, None);
-    match self.loader.load_language_at_path(compile_cfg) {
+    match lock!(self.loader).load_language_at_path(compile_cfg) {
       Ok(grammar) => Ok((grammar_id, grammar)),
       Err(e) => Err(TheErr::LoadTreeSitterGrammarFailed(
         grammar_id.to_compact_string(),

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -373,7 +373,7 @@ struct SyntaxTreeSitterGrammarMetainfoGrammar {
   pub file_types: Vec<CompactString>,
   pub highlights: Option<PathBuf>,
   pub tags: Option<PathBuf>,
-  pub injection_regex: Option<CompactString>,
+  pub injection_regex: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -461,7 +461,7 @@ impl SyntaxLoader {
         .get("injection-regex")
         .map(|tg| tg.as_str().ok_or(err()))
         .transpose()?
-        .map(|ij| ij.to_compact_string());
+        .map(|inj| inj.to_string());
       let grammar_metainfo = SyntaxTreeSitterGrammarMetainfoGrammar {
         name: name.to_compact_string(),
         camelcase: camelcase.to_compact_string(),

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -493,14 +493,14 @@ impl SyntaxLoader {
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
     /* metainfo */ SyntaxTreeSitterGrammarMetainfo,
-    /* grammar */ Language,
+    /* grammar */ TreeSitterLanguageArc,
   )> {
     let metainfo =
       Self::parse_treesitter_grammar_metainfo(req.grammar_path.as_path())?;
     let compile_cfg =
       CompileConfig::new(metainfo.src_path.as_path(), None, None);
     match lock!(self.loader).load_language_at_path(compile_cfg) {
-      Ok(grammar) => Ok((metainfo, grammar)),
+      Ok(grammar) => Ok((metainfo, Arc::new(grammar))),
       Err(e) => Err(TheErr::LoadTreeSitterParserFailed(
         req.grammar_path.to_string_lossy().to_compact_string(),
         e,
@@ -513,17 +513,20 @@ impl SyntaxLoader {
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<(
     /* metainfo */ SyntaxTreeSitterGrammarMetainfo,
-    /* grammar */ Language,
+    /* grammar */ TreeSitterLanguageArc,
   )> {
     self.load_grammar(req)
   }
 }
 
+pub type TreeSitterLanguageArc = Arc<Language>;
+pub type TreeSitterLanguageWeak = Weak<Language>;
+
 pub struct SyntaxManager {
   loader: SyntaxLoader,
 
   // loaded_parsers: FoldMap<CompactString, SyntaxLoadedParser>,
-  grammars: FoldMap<CompactString, Language>,
+  grammars: FoldMap<CompactString, TreeSitterLanguageArc>,
   highlight_queries: FoldMap<CompactString, String>,
   tags_queries: FoldMap<CompactString, String>,
   injection_queries: FoldMap<CompactString, String>,
@@ -682,7 +685,7 @@ impl SyntaxManager {
   pub fn insert_grammar(
     &mut self,
     grammar_id: CompactString,
-    grammar: Language,
+    grammar: TreeSitterLanguageArc,
     highlight_query: Option<String>,
     tags_query: Option<String>,
     injection_query: Option<String>,

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -456,13 +456,13 @@ impl SyntaxLoader {
       let highlights = grammar
         .get("highlights")
         .map(|hl| hl.as_str().ok_or(err()))
-        .transpose()?;
-      let highlights = highlights.map(|hl| Path::new(hl).to_path_buf());
+        .transpose()?
+        .map(|hl| Path::new(hl).to_path_buf());
       let tags = grammar
         .get("tags")
         .map(|tg| tg.as_str().ok_or(err()))
-        .transpose()?;
-      let tags = tags.map(|tg| Path::new(tg).to_path_buf());
+        .transpose()?
+        .map(|tg| Path::new(tg).to_path_buf());
       let injection_regex = grammar
         .get("injection-regex")
         .map(|tg| tg.as_str().ok_or(err()))

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -442,7 +442,7 @@ impl Debug for SyntaxManager {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("SyntaxManager")
       .field("loader", &lock!(self.loader))
-      .field("grammars", &self.grammars)
+      .field("grammars", &self.grammars.keys())
       .field("highlight_queries", &self.highlight_queries)
       .field("grammarid2ext", &self.gid2ext)
       .field("ext2grammarid", &self.ext2gid)

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -316,15 +316,8 @@ impl Syntax {
   }
 }
 
-pub type TreeSitterLoaderArc = Arc<Mutex<Loader>>;
-pub type TreeSitterLoaderWk = Weak<Mutex<Loader>>;
-pub type TreeSitterLoaderMutexGuard<'a> = MutexGuard<'a, Loader>;
-
 pub struct SyntaxLoader {
-  loader: TreeSitterLoaderArc,
-
-  // Loaded grammars/parsers
-  grammars: FoldMap<CompactString, Language>,
+  loader: Loader,
 }
 
 arc_mutex_ptr!(SyntaxLoader);
@@ -349,43 +342,23 @@ impl SyntaxLoader {
     let parser_lib_path =
       PATH_CONFIG.config_home().join(".tree-sitter-parsers");
     Self {
-      loader: Arc::new(Mutex::new(Loader::with_parser_lib_path(
-        parser_lib_path,
-      ))),
-      grammars: FoldMap::new(),
+      loader: Loader::with_parser_lib_path(parser_lib_path),
     }
   }
 
   pub fn treesitter_parser_lib_path(&self) -> PathBuf {
-    lock!(self.loader).parser_lib_path.clone()
+    self.loader.parser_lib_path.clone()
   }
 
-  /// NOTE: This will reset the tree-sitter loader and all loaded
-  /// parsers/grammars.
   pub fn set_treesitter_parser_lib_path(&mut self, parser_lib_path: PathBuf) {
-    lock!(self.loader).parser_lib_path = parser_lib_path;
-    self.grammars.clear();
-  }
-
-  pub fn treesitter_loader(&self) -> TreeSitterLoaderArc {
-    self.loader.clone()
-  }
-
-  pub fn cached_grammars(&self) -> &FoldMap<CompactString, Language> {
-    &self.grammars
-  }
-
-  pub fn cached_grammars_mut(
-    &mut self,
-  ) -> &mut FoldMap<CompactString, Language> {
-    &mut self.grammars
+    self.loader.parser_lib_path = parser_lib_path;
   }
 }
 
 impl Debug for SyntaxLoader {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("SyntaxGrammarLoader")
-      .field("grammars", &self.grammars)
+    f.debug_struct("SyntaxLoader")
+      .field("parser_lib_path", &self.loader.parser_lib_path)
       .finish()
   }
 }
@@ -425,7 +398,7 @@ impl SyntaxLoader {
     let src_path = src_path.as_path();
     let grammar_id = Self::get_grammar_name_from_src_path(&req)?;
     let compile_cfg = CompileConfig::new(src_path, None, None);
-    match lock!(self.loader).load_language_at_path(compile_cfg) {
+    match self.loader.load_language_at_path(compile_cfg) {
       Ok(grammar) => Ok((grammar_id, grammar)),
       Err(e) => Err(TheErr::LoadTreeSitterGrammarFailed(
         grammar_id.to_compact_string(),
@@ -438,14 +411,8 @@ impl SyntaxLoader {
     &mut self,
     req: SyntaxLoadGrammarRequest,
   ) -> TheResult<CompactString> {
-    let load_result = self._load_treesitter_grammar(req);
-    match load_result {
-      Ok((grammar_id, grammar)) => {
-        self.grammars.insert(grammar_id.clone(), grammar);
-        Ok(grammar_id)
-      }
-      Err(e) => Err(e),
-    }
+    let (grammar_id, _grammar) = self._load_treesitter_grammar(req)?;
+    Ok(grammar_id)
   }
 
   pub async fn async_load_grammar(

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -336,9 +336,11 @@ pub struct SyntaxLoadGrammarRequest {
 impl SyntaxLoader {
   #[cfg(test)]
   pub fn new() -> Self {
+    let loader = Loader::new().unwrap();
+    let parser_lib_path = loader.parser_lib_path.clone();
     Self {
-      loader: Arc::new(Mutex::new(Loader::new().unwrap())),
-      parser_lib_path: Path::new(".").to_path_buf(),
+      loader: Arc::new(Mutex::new(loader)),
+      parser_lib_path,
     }
   }
 

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -437,32 +437,46 @@ impl SyntaxLoader {
         .ok_or(err())?;
       let scope = grammar.get("scope").ok_or(err())?.as_str().ok_or(err())?;
       let path = grammar.get("path").ok_or(err())?.as_str().ok_or(err())?;
-      let path = grammar_path.join(path).normalize().map_err(|_e| err())?;
-      let filetypes = grammar
+      let path = grammar_path
+        .join(path)
+        .normalize()
+        .map_err(|_e| err())?
+        .into_path_buf();
+      let file_types = grammar
         .get("file-types")
         .ok_or(err())?
         .as_array()
         .ok_or(err())?
         .iter()
         .map(|ft| ft.as_str().ok_or(err()));
-      let filetypes = process_results(filetypes, |ft| ft.collect_vec());
+      let file_types = process_results(file_types, |ft| ft.collect_vec())?
+        .iter()
+        .map(|ft| ft.to_compact_string())
+        .collect_vec();
       let highlights = grammar
         .get("highlights")
         .map(|hl| hl.as_str().ok_or(err()))
         .transpose()?;
-      let highlights = highlights.map(|hl| Path::new(hl));
+      let highlights = highlights.map(|hl| Path::new(hl).to_path_buf());
       let tags = grammar
         .get("tags")
         .map(|tg| tg.as_str().ok_or(err()))
         .transpose()?;
-      let tags = tags.map(|tg| Path::new(tg));
+      let tags = tags.map(|tg| Path::new(tg).to_path_buf());
       let injection_regex = grammar
         .get("injection-regex")
         .map(|tg| tg.as_str().ok_or(err()))
-        .transpose()?;
+        .transpose()?
+        .map(|ij| ij.to_compact_string());
       let grammar_metadata = SyntaxTreeSitterGrammarMetainfo {
         name: name.to_compact_string(),
         camelcase: camelcase.to_compact_string(),
+        scope: scope.to_compact_string(),
+        path,
+        file_types,
+        highlights,
+        tags,
+        injection_regex,
       };
     }
 

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -526,6 +526,8 @@ pub struct SyntaxManager {
   // loaded_parsers: FoldMap<CompactString, SyntaxLoadedParser>,
   grammars: FoldMap<CompactString, Language>,
   highlight_queries: FoldMap<CompactString, String>,
+  tags_queries: FoldMap<CompactString, String>,
+  injection_regex_queries: FoldMap<CompactString, String>,
 
   // Maps grammar ID to file extensions
   gid2ext: FoldMap<CompactString, FoldSet<CompactString>>,
@@ -541,6 +543,8 @@ impl Debug for SyntaxManager {
       .field("loader", &self.loader)
       .field("grammars", &self.grammars.keys())
       .field("highlight_queries", &self.highlight_queries)
+      .field("tags_queries", &self.tags_queries)
+      .field("injection_regex_queries", &self.injection_regex_queries)
       .field("grammarid2ext", &self.gid2ext)
       .field("ext2grammarid", &self.ext2gid)
       .finish()
@@ -554,6 +558,8 @@ impl SyntaxManager {
       loader: SyntaxLoader::new(),
       grammars: FoldMap::new(),
       highlight_queries: FoldMap::new(),
+      tags_queries: FoldMap::new(),
+      injection_regex_queries: FoldMap::new(),
       gid2ext: FoldMap::new(),
       ext2gid: FoldMap::new(),
     };
@@ -667,6 +673,8 @@ impl SyntaxManager {
     grammar_id: CompactString,
     grammar: Language,
     highlight_query: Option<String>,
+    tags_query: Option<String>,
+    injection_regex: Option<String>,
   ) {
     self.grammars.insert(grammar_id.clone(), grammar);
     if let Some(hl_query) = highlight_query {

--- a/rsvim_core/src/syntax_tests.rs
+++ b/rsvim_core/src/syntax_tests.rs
@@ -1173,13 +1173,11 @@ mod tests_grammar_loader {
     let opts = SyntaxLoadGrammarRequest {
       grammar_path: grammar_path.to_path_buf(),
     };
-    let grammar =
-      _load_treesitter_grammar(syn_loader.treesitter_loader(), opts.clone());
+    let grammar = syn_loader.load_grammar(opts.clone());
     info!("{}:{:?}", hint, grammar);
     assert!(grammar.is_ok());
 
-    let grammar =
-      _load_treesitter_grammar(syn_loader.treesitter_loader(), opts.clone());
+    let grammar = syn_loader.load_grammar(opts.clone());
     info!("{}:{:?}", hint, grammar);
     assert!(grammar.is_ok());
   }

--- a/rsvim_core/src/syntax_tests.rs
+++ b/rsvim_core/src/syntax_tests.rs
@@ -1234,15 +1234,13 @@ mod tests_grammar_loader {
     let opts = SyntaxLoadGrammarRequest {
       grammar_path: grammar_path.to_path_buf(),
     };
-    let grammar =
-      _load_treesitter_grammar(syn_loader.treesitter_loader(), opts.clone());
+    let grammar = syn_loader.load_grammar(opts.clone());
     assert!(grammar.is_err());
     if let Err(e) = grammar {
       info!("failed1:{:?}", e)
     }
 
-    let grammar =
-      _load_treesitter_grammar(syn_loader.treesitter_loader(), opts);
+    let grammar = syn_loader.load_grammar(opts.clone());
     assert!(grammar.is_err());
     if let Err(e) = grammar {
       info!("failed1:{:?}", e)
@@ -1267,15 +1265,13 @@ mod tests_grammar_loader {
     let opts = SyntaxLoadGrammarRequest {
       grammar_path: grammar_path.to_path_buf(),
     };
-    let grammar =
-      _load_treesitter_grammar(syn_loader.treesitter_loader(), opts.clone());
+    let grammar = syn_loader.load_grammar(opts.clone());
     assert!(grammar.is_err());
     if let Err(e) = grammar {
       info!("failed2:{:?}", e)
     }
 
-    let grammar =
-      _load_treesitter_grammar(syn_loader.treesitter_loader(), opts);
+    let grammar = syn_loader.load_grammar(opts.clone());
     assert!(grammar.is_err());
     if let Err(e) = grammar {
       info!("failed2:{:?}", e)

--- a/rsvim_core/src/syntax_tests.rs
+++ b/rsvim_core/src/syntax_tests.rs
@@ -1169,20 +1169,20 @@ mod tests_grammar_loader {
 
   fn _run_loader(grammar_path: &str, hint: &str) {
     let grammar_path = Path::new(grammar_path);
-    let syn_loader = SyntaxLoader::new();
-    let opts = SyntaxLoadGrammarRequest {
+    let syn_manager = SyntaxManager::to_arc(SyntaxManager::new());
+    let req = SyntaxLoadGrammarRequest {
       grammar_path: grammar_path.to_path_buf(),
     };
-    let grammar = syn_loader.load_grammar(opts.clone());
+    let grammar = load_syntax_grammar(syn_manager.clone(), req.clone());
     info!("{}:{:?}", hint, grammar);
     assert!(grammar.is_ok());
-    let (metainfo, _) = grammar.unwrap();
+    let metainfo = grammar.unwrap();
     info!("{}:{:?}", hint, metainfo);
 
-    let grammar = syn_loader.load_grammar(opts.clone());
+    let grammar = load_syntax_grammar(syn_manager.clone(), req.clone());
     info!("{}:{:?}", hint, grammar);
     assert!(grammar.is_ok());
-    let (metainfo, _) = grammar.unwrap();
+    let metainfo = grammar.unwrap();
     info!("{}:{:?}", hint, metainfo);
   }
 

--- a/rsvim_core/src/syntax_tests.rs
+++ b/rsvim_core/src/syntax_tests.rs
@@ -1176,10 +1176,14 @@ mod tests_grammar_loader {
     let grammar = syn_loader.load_grammar(opts.clone());
     info!("{}:{:?}", hint, grammar);
     assert!(grammar.is_ok());
+    let (metainfo, _) = grammar.unwrap();
+    info!("{}:{:?}", hint, metainfo);
 
     let grammar = syn_loader.load_grammar(opts.clone());
     info!("{}:{:?}", hint, grammar);
     assert!(grammar.is_ok());
+    let (metainfo, _) = grammar.unwrap();
+    info!("{}:{:?}", hint, metainfo);
   }
 
   // This test case always fail.


### PR DESCRIPTION
1. Use "parser-lib-path" option when building tree-sitter parsers, i.e. the programming language dynamic library.
2. Use two mutex on tree-sitter loader and syntax manager, thus we have a smaller locking time and they can work better in async runtime.
3. Remove bundled tree-sitter parsers (rust, c, python, html, etc) introduced in previous work #975 