### PR TITLE
revert: "chore: move "std::path::Path" out from prelude"

### DIFF
--- a/rsvim_core/src/buf/undo_tests.rs
+++ b/rsvim_core/src/buf/undo_tests.rs
@@ -10,7 +10,6 @@ use compact_str::ToCompactString;
 use ropey::Rope;
 use ropey::RopeBuilder;
 use std::ops::Range;
-use std::path::Path;
 use std::time::Duration;
 
 const MAX_SIZE: usize = 100;

--- a/rsvim_core/src/js/binding/global_rsvim/buf_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/buf_tests.rs
@@ -7,7 +7,6 @@ use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
 use compact_str::ToCompactString;
 use regex::Regex;
-use std::path::Path;
 use std::time::Duration;
 
 #[cfg(test)]

--- a/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/cmd_tests.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
 use compact_str::ToCompactString;
-use std::path::Path;
 use std::time::Duration;
 
 #[tokio::test]

--- a/rsvim_core/src/js/binding/global_rsvim/fs.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/fs.rs
@@ -24,7 +24,6 @@ use crate::js::pending;
 use crate::prelude::*;
 use crate::wrap_cppgc_handle;
 use itertools::Itertools;
-use std::path::Path;
 
 /// `Rsvim.fs.open` API.
 pub fn open<'s>(

--- a/rsvim_core/src/js/binding/global_rsvim/fs/open.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/fs/open.rs
@@ -9,7 +9,6 @@ use crate::prelude::*;
 use crate::to_v8_prop;
 use crate::wrap_cppgc_handle;
 use compact_str::ToCompactString;
-use std::path::Path;
 
 // Attribute names.
 pub const APPEND: &str = "append";

--- a/rsvim_core/src/js/binding/global_rsvim/fs_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/fs_tests.rs
@@ -4,7 +4,6 @@ use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
 use assert_fs::prelude::FileTouch;
 use assert_fs::prelude::FileWriteStr;
-use std::path::Path;
 use std::time::Duration;
 
 #[tokio::test]

--- a/rsvim_core/src/js/binding/global_rsvim/opt_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/opt_tests.rs
@@ -4,7 +4,6 @@ use crate::prelude::*;
 use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
 use crate::ui::widget::window::opt::*;
-use std::path::Path;
 use std::time::Duration;
 
 #[cfg(test)]

--- a/rsvim_core/src/js/binding/global_rsvim/rt_tests.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/rt_tests.rs
@@ -2,7 +2,6 @@ use crate::cli::CliOptions;
 use crate::prelude::*;
 use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
-use std::path::Path;
 use std::time::Duration;
 
 #[tokio::test]

--- a/rsvim_core/src/js/binding/global_rsvim/syn.rs
+++ b/rsvim_core/src/js/binding/global_rsvim/syn.rs
@@ -12,7 +12,6 @@ use crate::syntax;
 use crate::syntax::SyntaxLoadGrammarRequest;
 pub use load::SynLoadTreeSitterGrammarFuture;
 pub use load::SynLoadTreeSitterGrammarOptions;
-use std::path::Path;
 
 /// Javascript `loadTreeSitterGrammarSync` API.
 pub fn load_treesitter_grammar_sync<'s>(

--- a/rsvim_core/src/js/binding/global_this/microtask_tests.rs
+++ b/rsvim_core/src/js/binding/global_this/microtask_tests.rs
@@ -2,7 +2,6 @@ use crate::cli::CliOptions;
 use crate::prelude::*;
 use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
-use std::path::Path;
 use std::time::Duration;
 
 #[tokio::test]

--- a/rsvim_core/src/js/binding/global_this/text_encoder_tests.rs
+++ b/rsvim_core/src/js/binding/global_this/text_encoder_tests.rs
@@ -2,7 +2,6 @@ use crate::cli::CliOptions;
 use crate::prelude::*;
 use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
-use std::path::Path;
 use std::time::Duration;
 
 #[tokio::test]

--- a/rsvim_core/src/js/binding/global_this/timeout_tests.rs
+++ b/rsvim_core/src/js/binding/global_this/timeout_tests.rs
@@ -3,7 +3,6 @@ use crate::prelude::*;
 use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
 use crate::ui::widget::window::opt::*;
-use std::path::Path;
 use std::time::Duration;
 
 #[tokio::test]

--- a/rsvim_core/src/js/command_tests.rs
+++ b/rsvim_core/src/js/command_tests.rs
@@ -8,7 +8,6 @@ use crate::tests::log::init as test_log_init;
 use assert_fs::prelude::FileTouch;
 use assert_fs::prelude::FileWriteStr;
 use compact_str::ToCompactString;
-use std::path::Path;
 use std::time::Duration;
 
 #[tokio::test]

--- a/rsvim_core/src/js/hook.rs
+++ b/rsvim_core/src/js/hook.rs
@@ -13,7 +13,6 @@ use crate::prelude::*;
 use crate::util::paths;
 use normpath::PathExt;
 use std::cell::RefCell;
-use std::path::Path;
 use std::rc::Rc;
 
 /// Called during `Module::instantiate_module`, see:

--- a/rsvim_core/src/js/loader/fs_loader.rs
+++ b/rsvim_core/src/js/loader/fs_loader.rs
@@ -13,8 +13,6 @@ use crate::prelude::*;
 use async_trait::async_trait;
 use oxc_resolver::ResolveOptions;
 use oxc_resolver::Resolver;
-use std::path::Path;
-use std::path::PathBuf;
 
 /// Checks if path is a JSON file.
 fn is_json_import(path: &Path) -> bool {

--- a/rsvim_core/src/js/loader/fs_loader_tests.rs
+++ b/rsvim_core/src/js/loader/fs_loader_tests.rs
@@ -6,7 +6,6 @@ use crate::prelude::*;
 use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
 use normpath::PathExt;
-use std::path::Path;
 
 #[tokio::test]
 #[cfg_attr(miri, ignore)]

--- a/rsvim_core/src/js/module/module_map.rs
+++ b/rsvim_core/src/js/module/module_map.rs
@@ -44,9 +44,6 @@ use crate::prelude::*;
 use std::collections::hash_map::Entry;
 use std::fmt::Debug;
 
-#[cfg(test)]
-use std::path::Path;
-
 #[derive(Clone)]
 /// Import kind.
 pub enum ImportKind {

--- a/rsvim_core/src/js/module_tests.rs
+++ b/rsvim_core/src/js/module_tests.rs
@@ -5,7 +5,6 @@ use crate::tests::evloop::*;
 use crate::tests::js::make_js_runtime;
 use crate::tests::log::init as test_log_init;
 use std::io::Write;
-use std::path::Path;
 
 #[test]
 #[cfg_attr(miri, ignore)]

--- a/rsvim_core/src/js/pending.rs
+++ b/rsvim_core/src/js/pending.rs
@@ -7,7 +7,6 @@ use crate::js::TaskId;
 use crate::js::TimerId;
 use crate::js::binding::global_rsvim::fs::open::FsOpenOptions;
 use crate::prelude::*;
-use std::path::Path;
 use tokio::time::Instant;
 
 pub type TimerCallback = Box<dyn FnMut() + 'static>;

--- a/rsvim_core/src/js_tests.rs
+++ b/rsvim_core/src/js_tests.rs
@@ -8,7 +8,6 @@ use crate::tests::evloop::*;
 use crate::tests::log::init as test_log_init;
 use assert_fs::prelude::PathChild;
 use compact_str::ToCompactString;
-use std::path::Path;
 use std::time::Duration;
 
 #[test]

--- a/rsvim_core/src/prelude.rs
+++ b/rsvim_core/src/prelude.rs
@@ -29,3 +29,5 @@ pub use log::trace;
 pub use log::warn;
 pub use std::collections::BTreeMap;
 pub use std::collections::BTreeSet;
+pub use std::path::Path;
+pub use std::path::PathBuf;

--- a/rsvim_core/src/syntax.rs
+++ b/rsvim_core/src/syntax.rs
@@ -12,7 +12,6 @@ use ropey::Rope;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::ops::Range;
-use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;

--- a/rsvim_core/src/syntax_tests.rs
+++ b/rsvim_core/src/syntax_tests.rs
@@ -14,7 +14,6 @@ use assert_fs::prelude::PathChild;
 use compact_str::ToCompactString;
 use crossterm::style::Color;
 use itertools::Itertools;
-use std::path::Path;
 use std::time::Duration;
 
 #[cfg(test)]

--- a/rsvim_core/src/tests/evloop.rs
+++ b/rsvim_core/src/tests/evloop.rs
@@ -11,7 +11,6 @@ use crossterm::event::KeyEventKind;
 use crossterm::event::KeyModifiers;
 use std::cell::RefCell;
 use std::path::Path;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::mpsc::Receiver;

--- a/rsvim_core/src/util/paths.rs
+++ b/rsvim_core/src/util/paths.rs
@@ -1,7 +1,7 @@
 //! File path utils.
 
+use crate::prelude::*;
 use std::ffi::OsStr;
-use std::path::Path;
 
 /// Map path to its parent, or remain unchanged if it has no parent.
 pub fn maybe_parent<S: AsRef<OsStr> + ?Sized>(s: &S) -> &Path {


### PR DESCRIPTION
Reverts rsvim/rsvim#1047